### PR TITLE
add skills for TypeScript, Go, .NET, Java

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,10 @@
 {
   "name": "qdrant",
-  "description": "Skills for the Qdrant vector search platform: Python SDK, search, filtering, hybrid search, and multi-tenancy",
+  "description": "Skills for the Qdrant vector search platform: Python, TypeScript, Rust, Go, .NET, and Java SDKs. Covers search, filtering, hybrid search, and multi-tenancy.",
   "version": "1.0.0",
+  "license": "Apache-2.0",
+  "homepage": "https://qdrant.tech",
+  "repository": "https://github.com/qdrant/skills",
   "author": {
     "name": "Qdrant"
   }

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.PHONY: test test-structure test-scenarios validate lint
+
+SKILLS := $(wildcard skills/*)
+
+test: test-structure test-scenarios
+
+test-structure:
+	@bash scripts/test-skills.sh
+
+test-scenarios:
+	@python3 tests/run-scenarios.py
+
+validate:
+	@echo "validating skill definitions..."
+	@command -v skills-ref > /dev/null 2>&1 || { echo "error: skills-ref not installed. run: npm install -g skills-ref"; exit 1; }
+	@for s in $(SKILLS); do \
+		echo "  $$s"; \
+		skills-ref validate "$$s"; \
+	done
+	@echo "all skills valid"
+
+lint:
+	@echo "checking skill files..."
+	@for f in skills/*/SKILL.md; do \
+		echo "  $$f"; \
+		head -1 "$$f" | grep -q '^---$$' || { echo "error: $$f missing frontmatter"; exit 1; }; \
+	done
+	@echo "lint passed"

--- a/README.md
+++ b/README.md
@@ -47,10 +47,46 @@ Commands are user-invocable slash commands that you explicitly call.
 
 ## Skills
 
-| Skill | Useful for |
-|-------|------------|
-| qdrant-python | Python SDK best practices: search, filtering, hybrid search, multi-tenancy, gotchas |
-| qdrant-rust | Rust client best practices: gRPC setup, builders, query, upsert, gotchas |
+| Skill | Language | Transport | Useful for |
+|-------|----------|-----------|------------|
+| qdrant-python | Python | REST (6333) | `qdrant-client` SDK: query_points, filtering, hybrid search, multi-tenancy, gotchas |
+| qdrant-typescript | TypeScript/JS | REST (6333) | `@qdrant/js-client-rest`: query, plain-object filters, hybrid search, named vectors |
+| qdrant-rust | Rust | gRPC (6334) | `qdrant-client` crate: builders, query, upsert, async patterns, gotchas |
+| qdrant-go | Go | gRPC (6334) | `go-client`: protobuf types, constructor helpers, PtrOf patterns, gotchas |
+| qdrant-dotnet | C# / .NET | gRPC (6334) | `Qdrant.Client` NuGet: operator overload filters, async, implicit conversions |
+| qdrant-java | Java | gRPC (6334) | `io.qdrant:client`: factory classes, ListenableFuture, builder pattern, gotchas |
+
+## References
+
+Each skill includes a `references/` directory with detailed supplemental docs that agents can load on demand:
+
+| Skill | Reference | Contents |
+|-------|-----------|----------|
+| qdrant-python | `references/filtering.md` | All filter condition types, nested filters, geo, datetime |
+| qdrant-python | `references/migration-guide.md` | Old-to-new API migration table |
+| qdrant-rust | `references/builders.md` | Comprehensive builder API reference for all operations |
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `scripts/start-qdrant.sh` | Pull and run a local Qdrant Docker container |
+
+Usage:
+
+```bash
+bash scripts/start-qdrant.sh          # latest version
+bash scripts/start-qdrant.sh v1.13.0  # specific version
+```
+
+## Validation
+
+Run the Makefile targets to check skill definitions:
+
+```bash
+make validate  # run skills-ref validator (requires npm install -g skills-ref)
+make lint      # basic frontmatter checks
+```
 
 ## Resources
 

--- a/commands/add-multitenancy.md
+++ b/commands/add-multitenancy.md
@@ -16,34 +16,99 @@ The user invoked this command with: $ARGUMENTS
 
 When this command is invoked:
 
-1. Read the relevant skill file (`qdrant-python/SKILL.md` or `qdrant-rust/SKILL.md`) based on the project language
-2. Find the existing collection setup in the codebase
-3. Determine the tenant field name (default: `tenant_id`, or use what the user provides)
-4. Generate:
-   - A payload index with `is_tenant=True` on the tenant field
+1. Determine the project language from its dependency files (pyproject.toml, package.json, Cargo.toml, go.mod, .csproj, pom.xml). If unclear, ask the user.
+2. Read the matching skill file (`skills/qdrant-{language}/SKILL.md`)
+3. Find the existing collection setup in the codebase
+4. Determine the tenant field name (default: `tenant_id`, or use what the user provides)
+5. Generate:
+   - A payload index with tenant flag on the tenant field
    - A filter wrapper that adds the tenant condition to every query
    - Updated upsert code that includes the tenant field in every point's payload
-5. Warn: NEVER create one collection per user/tenant. Always use a single collection with tenant filtering.
+6. Warn: NEVER create one collection per user/tenant. Always use a single collection with tenant filtering.
 
-## Key Pattern (Python)
+## Key Patterns
+
+### Python
 
 ```python
-# Create tenant index (do this once, before bulk upload)
-client.create_payload_index(
-    "collection",
-    "tenant_id",
-    field_schema=PayloadSchemaType.KEYWORD,
-    is_tenant=True,
-)
+client.create_payload_index("collection", "tenant_id",
+    field_schema=PayloadSchemaType.KEYWORD, is_tenant=True)
 
-# Every query must include the tenant filter
-client.query_points("collection",
-    query=embedding,
+client.query_points("collection", query=embedding,
     query_filter=Filter(must=[
         FieldCondition(key="tenant_id", match=MatchValue(value=current_tenant)),
-    ]),
-    limit=10,
-)
+    ]), limit=10)
+```
+
+### TypeScript
+
+```typescript
+client.createPayloadIndex('collection', {
+    field_name: 'tenant_id',
+    field_schema: { type: 'keyword', is_tenant: true },
+});
+
+client.query('collection', {
+    query: embedding,
+    filter: { must: [{ key: 'tenant_id', match: { value: currentTenant } }] },
+    limit: 10,
+});
+```
+
+### Rust
+
+```rust
+client.create_field_index(
+    CreateFieldIndexCollectionBuilder::new("collection", "tenant_id", FieldType::Keyword)
+        .is_tenant(true)
+).await?;
+
+client.query(QueryPointsBuilder::new("collection")
+    .query(vec![...])
+    .filter(Filter::must([Condition::matches("tenant_id", current_tenant.to_string())]))
+    .limit(10u64)
+).await?;
+```
+
+### Go
+
+```go
+client.CreateFieldIndex(ctx, &qdrant.CreateFieldIndexCollection{
+    CollectionName: "collection", FieldName: "tenant_id",
+    FieldType: qdrant.FieldType_FieldTypeKeyword.Enum(),
+    IsTenant: qdrant.PtrOf(true),
+})
+
+client.Query(ctx, &qdrant.QueryPoints{
+    CollectionName: "collection", Query: qdrant.NewQuery(embedding...),
+    Filter: &qdrant.Filter{Must: []*qdrant.Condition{qdrant.NewMatch("tenant_id", currentTenant)}},
+    Limit: qdrant.PtrOf(uint64(10)),
+})
+```
+
+### .NET/C#
+
+```csharp
+await client.CreatePayloadIndexAsync("collection", "tenant_id",
+    PayloadSchemaType.Keyword, isTenant: true);
+
+await client.QueryAsync("collection", query: embedding,
+    filter: MatchKeyword("tenant_id", currentTenant), limit: 10);
+```
+
+### Java
+
+```java
+client.createPayloadIndexAsync("collection", "tenant_id",
+    PayloadSchemaType.Keyword, null, null, null, true).get();
+
+client.queryAsync(QueryPoints.newBuilder()
+    .setCollectionName("collection")
+    .setQuery(nearest(embedding))
+    .setFilter(Filter.newBuilder()
+        .addMust(matchKeyword("tenant_id", currentTenant)).build())
+    .setLimit(10).build()
+).get();
 ```
 
 ## Example Usage

--- a/commands/connect.md
+++ b/commands/connect.md
@@ -16,16 +16,20 @@ The user invoked this command with: $ARGUMENTS
 
 When this command is invoked:
 
-1. Detect the project language (Python or Rust)
+1. Determine the project language from its dependency files (pyproject.toml, package.json, Cargo.toml, go.mod, .csproj, pom.xml). If unclear, ask the user.
 2. Determine connection target:
-   - **local**: `localhost:6333` (Python REST) or `localhost:6334` (Rust gRPC)
+   - **local**: `localhost:6333` (Python/TypeScript REST) or `localhost:6334` (Rust/Go/.NET/Java gRPC)
    - **cloud**: Qdrant Cloud URL with API key from environment variable
    - If not specified, ask the user
-3. Generate connection code:
+3. Generate connection code using the language's client:
    - API key read from environment variable (`QDRANT_API_KEY`), never hardcoded
    - Add `.env` entry if a `.env` file exists in the project
-   - For Python: use `QdrantClient`
-   - For Rust: use `Qdrant::from_url().api_key().build()`
+   - For Python: `QdrantClient(url=..., api_key=...)`
+   - For TypeScript: `new QdrantClient({ url: ..., apiKey: ... })`
+   - For Rust: `Qdrant::from_url(...).api_key(...).build()?`
+   - For Go: `qdrant.NewClient(&qdrant.Config{Host: ..., Port: 6334, APIKey: ...})`
+   - For .NET: `new QdrantClient(host, port: 6334, https: true, apiKey: ...)`
+   - For Java: `new QdrantClient(QdrantGrpcClient.newBuilder(host, 6334, true).withApiKey(...).build())`
 4. Verify the connection works by listing collections
 
 ## Python
@@ -44,6 +48,21 @@ client = QdrantClient(
 )
 ```
 
+## TypeScript
+
+```typescript
+import { QdrantClient } from '@qdrant/js-client-rest';
+
+// Local
+const client = new QdrantClient({ url: 'http://127.0.0.1:6333' });
+
+// Cloud
+const client = new QdrantClient({
+    url: 'https://xyz.cloud.qdrant.io',
+    apiKey: process.env.QDRANT_API_KEY,
+});
+```
+
 ## Rust
 
 ```rust
@@ -56,6 +75,60 @@ let client = Qdrant::from_url("http://localhost:6334").build()?;
 let client = Qdrant::from_url("https://xyz.cloud.qdrant.io:6334")
     .api_key(std::env::var("QDRANT_API_KEY"))
     .build()?;
+```
+
+## Go
+
+```go
+import "github.com/qdrant/go-client/qdrant"
+
+// Local
+client, err := qdrant.NewClient(&qdrant.Config{
+    Host: "localhost",
+    Port: 6334,
+})
+defer client.Close()
+
+// Cloud
+client, err := qdrant.NewClient(&qdrant.Config{
+    Host:   "xyz.cloud.qdrant.io",
+    Port:   6334,
+    APIKey: os.Getenv("QDRANT_API_KEY"),
+    UseTLS: true,
+})
+```
+
+## .NET/C#
+
+```csharp
+using Qdrant.Client;
+
+// Local
+var client = new QdrantClient("localhost");
+
+// Cloud
+var client = new QdrantClient(
+    "xyz.cloud.qdrant.io",
+    port: 6334,
+    https: true,
+    apiKey: Environment.GetEnvironmentVariable("QDRANT_API_KEY"));
+```
+
+## Java
+
+```java
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+
+// Local
+QdrantClient client = new QdrantClient(
+    QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+// Cloud
+QdrantClient client = new QdrantClient(
+    QdrantGrpcClient.newBuilder("xyz.cloud.qdrant.io", 6334, true)
+        .withApiKey(System.getenv("QDRANT_API_KEY"))
+        .build());
 ```
 
 ## Example Usage

--- a/commands/hybrid-search.md
+++ b/commands/hybrid-search.md
@@ -16,16 +16,19 @@ The user invoked this command with: $ARGUMENTS
 
 When this command is invoked:
 
-1. Read the relevant skill file (`qdrant-python/SKILL.md` or `qdrant-rust/SKILL.md`) based on the project language
-2. Check if the target collection already exists in the codebase and what vector names are configured
-3. Generate a hybrid search using:
+1. Determine the project language from its dependency files (pyproject.toml, package.json, Cargo.toml, go.mod, .csproj, pom.xml). If unclear, ask the user.
+2. Read the matching skill file (`skills/qdrant-{language}/SKILL.md`)
+3. Check if the target collection already exists in the codebase and what vector names are configured
+4. Generate a hybrid search using the language's idiom for:
    - `prefetch` with both dense and sparse queries
-   - `FusionQuery(fusion=Fusion.RRF)` for result fusion
+   - RRF fusion for result merging
    - Prefetch limits higher than the final limit (prefetch is the candidate pool)
-4. If sparse vectors aren't set up yet, include the collection config with both dense and sparse vector params
-5. Remind: BM25 requires `Modifier.IDF` - without it, sparse search quality is poor
+5. If sparse vectors aren't set up yet, include the collection config with both dense and sparse vector params
+6. Remind: BM25 requires IDF modifier. Without it, sparse search quality is poor
 
-## Key Pattern (Python)
+## Key Patterns
+
+### Python
 
 ```python
 client.query_points("collection",
@@ -36,6 +39,77 @@ client.query_points("collection",
     query=FusionQuery(fusion=Fusion.RRF),
     limit=10,
 )
+```
+
+### TypeScript
+
+```typescript
+client.query('collection', {
+    prefetch: [
+        { query: denseEmbedding, using: 'dense', limit: 20 },
+        { query: { values: sparseValues, indices: sparseIndices }, using: 'sparse', limit: 20 },
+    ],
+    query: { fusion: 'rrf' },
+    limit: 10,
+});
+```
+
+### Rust
+
+```rust
+client.query(
+    QueryPointsBuilder::new("collection")
+        .add_prefetch(PrefetchQueryBuilder::default()
+            .query(Query::new_nearest(dense_vec))
+            .using("dense")
+            .limit(20u64))
+        .add_prefetch(PrefetchQueryBuilder::default()
+            .query(Query::new_nearest(sparse_vec))
+            .using("sparse")
+            .limit(20u64))
+        .query(Query::new_fusion(Fusion::Rrf))
+        .limit(10u64)
+).await?;
+```
+
+### Go
+
+```go
+client.Query(ctx, &qdrant.QueryPoints{
+    CollectionName: "collection",
+    Prefetch: []*qdrant.PrefetchQuery{
+        {Query: qdrant.NewQueryDense(denseVec), Using: qdrant.PtrOf("dense"), Limit: qdrant.PtrOf(uint64(20))},
+        {Query: qdrant.NewQuerySparse(sparseIndices, sparseValues), Using: qdrant.PtrOf("sparse"), Limit: qdrant.PtrOf(uint64(20))},
+    },
+    Query: qdrant.NewQueryFusion(qdrant.Fusion_RRF),
+})
+```
+
+### .NET/C#
+
+```csharp
+await client.QueryAsync("collection",
+    query: Fusion.Rrf,
+    prefetch: new List<PrefetchQuery>
+    {
+        new() { Query = denseVec, Using = "dense", Limit = 20 },
+        new() { Query = sparseVec, Using = "sparse", Limit = 20 },
+    },
+    limit: 10);
+```
+
+### Java
+
+```java
+client.queryAsync(QueryPoints.newBuilder()
+    .setCollectionName("collection")
+    .addPrefetch(PrefetchQuery.newBuilder()
+        .setQuery(nearest(denseVec)).setUsing("dense").setLimit(20).build())
+    .addPrefetch(PrefetchQuery.newBuilder()
+        .setQuery(nearest(sparseValues, sparseIndices)).setUsing("sparse").setLimit(20).build())
+    .setQuery(fusion(Fusion.RRF))
+    .setLimit(10).build()
+).get();
 ```
 
 ## Example Usage

--- a/commands/migrate-search.md
+++ b/commands/migrate-search.md
@@ -16,19 +16,17 @@ The user invoked this command with: $ARGUMENTS
 
 When this command is invoked:
 
-1. Search the codebase for deprecated search methods:
-   - `client.search(` (Python)
-   - `client.search_points(` (Python/Rust)
-   - `client.search_batch(` (Python)
-   - `SearchRequest` (Python)
-2. For each occurrence, rewrite to use `query_points` / `QueryPointsBuilder`:
-   - `client.search("col", query_vector=vec)` becomes `client.query_points("col", query=vec)`
-   - `search_params` stays as-is
-   - `query_filter` stays as-is
-   - `with_payload` stays as-is
-   - `limit` stays as-is
-3. Show a diff of each change before applying
-4. After migration, verify no deprecated methods remain
+1. Determine the project language from its dependency files (pyproject.toml, package.json, Cargo.toml, go.mod, .csproj, pom.xml). If unclear, ask the user.
+2. Search the codebase for deprecated search methods based on the language:
+   - **Python**: `client.search(`, `client.search_points(`, `client.search_batch(`, `SearchRequest`
+   - **TypeScript**: `client.search(` (still works but `client.query(` is preferred)
+   - **Rust**: `client.search_points(`, `SearchPointsBuilder`
+   - **Go**: No legacy methods (Go client launched with the unified query API)
+   - **.NET**: `client.SearchAsync(` (still works but `client.QueryAsync(` is preferred)
+   - **Java**: `client.searchAsync(`, `SearchPoints.newBuilder`, `addAllVector(`
+3. For each occurrence, rewrite to the modern query API
+4. Show a diff of each change before applying
+5. After migration, verify no deprecated methods remain
 
 ## Migration Map (Python)
 
@@ -37,6 +35,32 @@ When this command is invoked:
 | `client.search(collection, query_vector=v)` | `client.query_points(collection, query=v)` |
 | `client.search_batch(collection, requests)` | `client.query_batch_points(collection, requests)` |
 | `SearchRequest(vector=v, ...)` | `QueryRequest(query=v, ...)` |
+
+## Migration Map (TypeScript)
+
+| Old | New |
+|-----|-----|
+| `client.search('col', { vector: v })` | `client.query('col', { query: v })` |
+
+## Migration Map (Rust)
+
+| Old | New |
+|-----|-----|
+| `SearchPointsBuilder::new("col")` | `QueryPointsBuilder::new("col")` |
+| `client.search_points(req)` | `client.query(req)` |
+
+## Migration Map (.NET)
+
+| Old | New |
+|-----|-----|
+| `client.SearchAsync("col", vec)` | `client.QueryAsync("col", query: vec)` |
+
+## Migration Map (Java)
+
+| Old | New |
+|-----|-----|
+| `client.searchAsync(SearchPoints.newBuilder()...)` | `client.queryAsync(QueryPoints.newBuilder()...)` |
+| `addAllVector(List.of(...))` | `setQuery(nearest(...))` |
 
 ## Example Usage
 

--- a/commands/setup-collection.md
+++ b/commands/setup-collection.md
@@ -16,18 +16,19 @@ The user invoked this command with: $ARGUMENTS
 
 When this command is invoked:
 
-1. Read the relevant skill file (`qdrant-python/SKILL.md` or `qdrant-rust/SKILL.md`) based on the project language
-2. Ask the user:
+1. Determine the project language from its dependency files (pyproject.toml, package.json, Cargo.toml, go.mod, .csproj, pom.xml). If unclear, ask the user.
+2. Read the matching skill file (`skills/qdrant-{language}/SKILL.md`)
+3. Ask the user:
    - Collection name
    - What they're storing (to determine vector dimensions and distance metric)
    - Whether they need multi-tenancy
    - Whether they need hybrid search (dense + sparse)
-3. Generate the collection creation code with:
-   - `VectorParams` with correct size and distance
+4. Generate the collection creation code with:
+   - Vector config with correct size and distance (using the language's idiom)
    - Sparse vector config if hybrid search is needed
    - Payload indexes created BEFORE any data upload
-   - Tenant payload index with `is_tenant=True` if multi-tenant
-4. Remind the user: create payload indexes before bulk upload, not after
+   - Tenant payload index if multi-tenant
+5. Remind the user: create payload indexes before bulk upload, not after
 
 ## Common Configurations
 

--- a/scripts/start-qdrant.sh
+++ b/scripts/start-qdrant.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start a local Qdrant instance using Docker.
+# Usage: bash scripts/start-qdrant.sh [version]
+# Default version: latest
+
+VERSION="${1:-latest}"
+CONTAINER_NAME="qdrant-dev"
+REST_PORT=6333
+GRPC_PORT=6334
+STORAGE_DIR="${QDRANT_STORAGE:-$(pwd)/qdrant_storage}"
+
+if ! command -v docker &> /dev/null; then
+    echo "error: docker is not installed"
+    exit 1
+fi
+
+# Stop existing container if running
+if docker ps -q --filter "name=${CONTAINER_NAME}" | grep -q .; then
+    echo "stopping existing ${CONTAINER_NAME} container..."
+    docker stop "${CONTAINER_NAME}" > /dev/null
+    docker rm "${CONTAINER_NAME}" > /dev/null
+fi
+
+# Remove stopped container with same name
+if docker ps -aq --filter "name=${CONTAINER_NAME}" | grep -q .; then
+    docker rm "${CONTAINER_NAME}" > /dev/null
+fi
+
+echo "starting qdrant ${VERSION}..."
+echo "  REST: http://localhost:${REST_PORT}"
+echo "  gRPC: localhost:${GRPC_PORT}"
+echo "  storage: ${STORAGE_DIR}"
+
+mkdir -p "${STORAGE_DIR}"
+
+docker run -d \
+    --name "${CONTAINER_NAME}" \
+    -p "${REST_PORT}:6333" \
+    -p "${GRPC_PORT}:6334" \
+    -v "${STORAGE_DIR}:/qdrant/storage:z" \
+    "qdrant/qdrant:${VERSION}"
+
+echo "qdrant is running (container: ${CONTAINER_NAME})"

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate all skill definitions for structural correctness.
+# Usage: bash scripts/test-skills.sh
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILLS_DIR="$REPO_ROOT/skills"
+ERRORS=0
+TESTS=0
+PASSED=0
+
+pass() {
+    TESTS=$((TESTS + 1))
+    PASSED=$((PASSED + 1))
+    echo "  pass: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    ERRORS=$((ERRORS + 1))
+    echo "  FAIL: $1"
+}
+
+echo "=== skill structure tests ==="
+echo ""
+
+for skill_dir in "$SKILLS_DIR"/*/; do
+    skill_name="$(basename "$skill_dir")"
+    echo "[$skill_name]"
+
+    # 1. SKILL.md exists
+    if [ -f "$skill_dir/SKILL.md" ]; then
+        pass "SKILL.md exists"
+    else
+        fail "SKILL.md missing"
+        continue
+    fi
+
+    # 2. SKILL.md starts with frontmatter delimiter
+    if head -1 "$skill_dir/SKILL.md" | grep -q '^---$'; then
+        pass "SKILL.md has frontmatter opening"
+    else
+        fail "SKILL.md missing frontmatter opening ---"
+    fi
+
+    # 3. SKILL.md has closing frontmatter delimiter
+    if awk 'NR>1' "$skill_dir/SKILL.md" | grep -q '^---$'; then
+        pass "SKILL.md has frontmatter closing"
+    else
+        fail "SKILL.md missing frontmatter closing ---"
+    fi
+
+    # 4. Frontmatter has required 'name' field
+    if grep -q '^name:' "$skill_dir/SKILL.md"; then
+        pass "SKILL.md has name field"
+    else
+        fail "SKILL.md missing name field"
+    fi
+
+    # 5. Frontmatter 'name' matches directory name
+    fm_name=$(grep '^name:' "$skill_dir/SKILL.md" | head -1 | sed 's/^name: *//')
+    if [ "$fm_name" = "$skill_name" ]; then
+        pass "SKILL.md name matches directory ($fm_name)"
+    else
+        fail "SKILL.md name '$fm_name' does not match directory '$skill_name'"
+    fi
+
+    # 6. Frontmatter has required 'description' field
+    if grep -q '^description:' "$skill_dir/SKILL.md"; then
+        pass "SKILL.md has description field"
+    else
+        fail "SKILL.md missing description field"
+    fi
+
+    # 7. allowed-tools is space-delimited string (not YAML list)
+    if grep -q '^allowed-tools:' "$skill_dir/SKILL.md"; then
+        at_line=$(grep '^allowed-tools:' "$skill_dir/SKILL.md")
+        if echo "$at_line" | grep -q '^allowed-tools: [A-Za-z]'; then
+            pass "allowed-tools is space-delimited string"
+        else
+            fail "allowed-tools appears to be YAML list instead of space-delimited string"
+        fi
+    else
+        fail "SKILL.md missing allowed-tools field"
+    fi
+
+    # 8. Has license field
+    if grep -q '^license:' "$skill_dir/SKILL.md"; then
+        pass "SKILL.md has license field"
+    else
+        fail "SKILL.md missing license field"
+    fi
+
+    # 9. Has metadata section
+    if grep -q '^metadata:' "$skill_dir/SKILL.md"; then
+        pass "SKILL.md has metadata field"
+    else
+        fail "SKILL.md missing metadata field"
+    fi
+
+    # 10. AGENTS.md exists
+    if [ -f "$skill_dir/AGENTS.md" ]; then
+        pass "AGENTS.md exists"
+    else
+        fail "AGENTS.md missing"
+    fi
+
+    # 11. AGENTS.md does NOT have frontmatter (it should be plain markdown)
+    if [ -f "$skill_dir/AGENTS.md" ]; then
+        if head -1 "$skill_dir/AGENTS.md" | grep -q '^---$'; then
+            fail "AGENTS.md should not have frontmatter (that belongs in SKILL.md)"
+        else
+            pass "AGENTS.md has no frontmatter"
+        fi
+    fi
+
+    # 12. AGENTS.md is not identical to SKILL.md
+    if [ -f "$skill_dir/AGENTS.md" ]; then
+        if diff -q "$skill_dir/SKILL.md" "$skill_dir/AGENTS.md" > /dev/null 2>&1; then
+            fail "AGENTS.md is identical to SKILL.md (should be compressed version)"
+        else
+            pass "AGENTS.md differs from SKILL.md"
+        fi
+    fi
+
+    # 13. AGENTS.md is smaller than SKILL.md (compressed)
+    if [ -f "$skill_dir/AGENTS.md" ]; then
+        skill_size=$(wc -c < "$skill_dir/SKILL.md")
+        agents_size=$(wc -c < "$skill_dir/AGENTS.md")
+        if [ "$agents_size" -lt "$skill_size" ]; then
+            pass "AGENTS.md ($agents_size bytes) < SKILL.md ($skill_size bytes)"
+        else
+            fail "AGENTS.md ($agents_size bytes) should be smaller than SKILL.md ($skill_size bytes)"
+        fi
+    fi
+
+    # 14. SKILL.md contains a Gotchas section
+    if grep -q '## Gotchas' "$skill_dir/SKILL.md"; then
+        pass "SKILL.md has Gotchas section"
+    else
+        fail "SKILL.md missing Gotchas section"
+    fi
+
+    # 15. AGENTS.md contains a Gotchas section
+    if [ -f "$skill_dir/AGENTS.md" ]; then
+        if grep -q '## Gotchas' "$skill_dir/AGENTS.md" || grep -q 'Gotchas' "$skill_dir/AGENTS.md"; then
+            pass "AGENTS.md has Gotchas section"
+        else
+            fail "AGENTS.md missing Gotchas section"
+        fi
+    fi
+
+    # 16. No em-dashes in any file
+    for f in "$skill_dir"/*.md; do
+        fname="$(basename "$f")"
+        if grep -Pq '\x{2014}' "$f" 2>/dev/null || grep -q '—' "$f"; then
+            fail "$fname contains em-dash"
+        else
+            pass "$fname has no em-dashes"
+        fi
+    done
+
+    echo ""
+done
+
+echo "=== repo structure tests ==="
+echo ""
+
+# Plugin manifest exists
+if [ -f "$REPO_ROOT/.claude-plugin/plugin.json" ]; then
+    pass "plugin.json exists"
+else
+    fail "plugin.json missing"
+fi
+
+# Plugin manifest is valid JSON
+if python3 -c "import json; json.load(open('$REPO_ROOT/.claude-plugin/plugin.json'))" 2>/dev/null; then
+    pass "plugin.json is valid JSON"
+else
+    fail "plugin.json is not valid JSON"
+fi
+
+# README exists
+if [ -f "$REPO_ROOT/README.md" ]; then
+    pass "README.md exists"
+else
+    fail "README.md missing"
+fi
+
+# README lists all skills
+for skill_dir in "$SKILLS_DIR"/*/; do
+    skill_name="$(basename "$skill_dir")"
+    if grep -q "$skill_name" "$REPO_ROOT/README.md"; then
+        pass "README mentions $skill_name"
+    else
+        fail "README does not mention $skill_name"
+    fi
+done
+
+# start-qdrant.sh exists and is executable
+if [ -x "$REPO_ROOT/scripts/start-qdrant.sh" ]; then
+    pass "scripts/start-qdrant.sh exists and is executable"
+else
+    fail "scripts/start-qdrant.sh missing or not executable"
+fi
+
+# Makefile exists
+if [ -f "$REPO_ROOT/Makefile" ]; then
+    pass "Makefile exists"
+else
+    fail "Makefile missing"
+fi
+
+# No AGENTS.md files that are identical to SKILL.md (repo-wide check already done per skill)
+
+echo ""
+echo "=== results ==="
+echo "$PASSED/$TESTS passed, $ERRORS failed"
+
+if [ "$ERRORS" -gt 0 ]; then
+    exit 1
+fi

--- a/skills/qdrant-dotnet/AGENTS.md
+++ b/skills/qdrant-dotnet/AGENTS.md
@@ -1,0 +1,50 @@
+# Qdrant .NET/C# Client
+
+Uses gRPC (port 6334) via `Qdrant.Client` NuGet. All methods are async (`*Async`). Filtering uses `&`/`|`/`!` operator overloads on conditions.
+
+## Setup
+
+```csharp
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+using static Qdrant.Client.Grpc.Conditions;
+var client = new QdrantClient("localhost");
+// cloud: new QdrantClient("xyz.cloud.qdrant.io", port: 6334, https: true, apiKey: "...")
+```
+
+## Quick Reference
+
+| Operation | Code |
+|-----------|------|
+| Create collection | `client.CreateCollectionAsync("col", new VectorParams { Size = 768, Distance = Distance.Cosine })` |
+| Upsert | `client.UpsertAsync("col", points)` (IReadOnlyList\<PointStruct\>) |
+| Query | `client.QueryAsync("col", query: new float[] { ... }, limit: 10)` |
+| Filter query | `filter: MatchKeyword("field", "value")` (single Condition converts to Filter) |
+| Hybrid (RRF) | `query: Fusion.Rrf, prefetch: new List<PrefetchQuery> { ... }` |
+| Scroll | `client.ScrollAsync("col", limit: 100)` returns `ScrollResponse` (.Result, .NextPageOffset) |
+| Delete | `client.DeleteAsync("col", ids)` or `client.DeleteAsync("col", filter)` |
+| Payload index | `client.CreatePayloadIndexAsync("col", "field", PayloadSchemaType.Keyword)` |
+| Multi-tenant | keyword index + filter per query |
+| Recommend | `query: new RecommendInput { Positive = { id.ToVectorInput() }, Negative = { ... } }` |
+| Set payload | `client.SetPayloadAsync("col", payload, ids)` |
+| Delete payload keys | `client.DeletePayloadAsync("col", keys, ids)` |
+| Snapshot | `client.CreateSnapshotAsync("col")`, `client.ListSnapshotsAsync("col")` |
+| Alias | `client.CreateAliasAsync("alias", "col")`, `client.DeleteAliasAsync("alias")` |
+| Update collection | `client.UpdateCollectionAsync("col", optimizersConfig: new OptimizersConfigDiff { ... })` |
+
+## Gotchas
+
+- gRPC only (port 6334). Not REST.
+- `IDisposable`. Always `using var client = ...`.
+- Implicit operators everywhere. `float[]` becomes `Vectors`/`Query`. `string` becomes `Value`. `ulong` becomes `PointId`.
+- Use `&`/`|`/`!` for filter logic, NOT `&&`/`||` (C# limitation).
+- `ulong` IDs need `ul` suffix. `42` is `int`, use `42ul`.
+- Payload values are `Value` protobuf objects. Implicit from `string`/`long`/`bool`/`double` on write. Read via `.StringValue`, `.IntegerValue`, etc.
+- `UpsertAsync` defaults `wait: true`. Writes block.
+- `SearchAsync` and `QueryAsync` both exist. `QueryAsync` is the modern unified API.
+- Scroll needs `.Result` for points and `.NextPageOffset` for cursor.
+- All methods end with `Async`. Don't forget `await`.
+- Errors throw `RpcException`. Collection not found is `StatusCode.NotFound`.
+- Never one collection per user. Use tenant payload index.
+- Vector dims must match collection config on every upsert and query.
+- Distance is immutable. Delete and recreate collection to change.

--- a/skills/qdrant-dotnet/SKILL.md
+++ b/skills/qdrant-dotnet/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: qdrant-dotnet
+description: "Best practices for the Qdrant .NET/C# client (Qdrant.Client NuGet). Use when writing C# code that uses Qdrant. Covers client setup, query, filtering with operator overloads, and common gotchas."
+allowed-tools: Read Grep Glob
+license: Apache-2.0
+metadata:
+  author: qdrant
+  version: "1.0"
+---
+
+# Qdrant .NET/C# Client
+
+You interact with Qdrant over gRPC (port 6334) using the `Qdrant.Client` NuGet package. All methods are async and end with `Async`.
+
+## Setup
+
+```bash
+dotnet add package Qdrant.Client
+```
+
+```csharp
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+using static Qdrant.Client.Grpc.Conditions;
+
+// Local
+var client = new QdrantClient("localhost");
+
+// Cloud
+var client = new QdrantClient("xyz.cloud.qdrant.io", port: 6334, https: true, apiKey: "<api-key>");
+```
+
+## Decision Table
+
+| Want to... | Do |
+|-----------|-----|
+| Create collection (single vector) | `client.CreateCollectionAsync("col", new VectorParams { Size = 768, Distance = Distance.Cosine })` |
+| Create collection (named vectors) | `client.CreateCollectionAsync("col", new VectorParamsMap { Map = { ["dense"] = new VectorParams { ... } } })` |
+| Upsert | `client.UpsertAsync("col", points)` where points is `IReadOnlyList<PointStruct>` |
+| Query (modern) | `client.QueryAsync("col", query: vector, limit: 10)` |
+| Query with filter | `client.QueryAsync("col", query: vec, filter: MatchKeyword("field", "value"))` |
+| Hybrid (RRF) | `client.QueryAsync("col", query: Fusion.Rrf, prefetch: [...])` |
+| Scroll | `client.ScrollAsync("col", limit: 100)` returns `ScrollResponse` with `.Result` and `.NextPageOffset` |
+| Delete by IDs | `client.DeleteAsync("col", ids)` |
+| Delete by filter | `client.DeleteAsync("col", filter)` |
+| Payload index | `client.CreatePayloadIndexAsync("col", "field", PayloadSchemaType.Keyword)` |
+| Count | `client.CountAsync("col")` or `client.CountAsync("col", filter)` |
+| Recommend | `client.QueryAsync("col", query: new RecommendInput { Positive = { 1ul.ToVectorInput() }, Negative = { 3ul.ToVectorInput() } })` |
+| Discover | `client.QueryAsync("col", query: new DiscoverInput { Target = 1ul.ToVectorInput(), Context = { ... } })` |
+| Set payload | `client.SetPayloadAsync("col", payload, ids)` |
+| Overwrite payload | `client.OverwritePayloadAsync("col", payload, ids)` |
+| Delete payload keys | `client.DeletePayloadAsync("col", keys, ids)` |
+| Clear payload | `client.ClearPayloadAsync("col", ids)` |
+| Create snapshot | `client.CreateSnapshotAsync("col")` |
+| List snapshots | `client.ListSnapshotsAsync("col")` |
+| Create alias | `client.CreateAliasAsync("alias", "col")` |
+| Delete alias | `client.DeleteAliasAsync("alias")` |
+| Update collection | `client.UpdateCollectionAsync("col", optimizersConfig: new OptimizersConfigDiff { IndexingThreshold = 20000 })` |
+
+## Query with Filter
+
+```csharp
+var results = await client.QueryAsync(
+    "products",
+    query: new float[] { 0.2f, 0.1f, 0.9f, 0.7f },
+    filter: MatchKeyword("category", "electronics"),
+    payloadSelector: true,
+    limit: 10);
+```
+
+## Upsert with Payload
+
+```csharp
+var points = new List<PointStruct>
+{
+    new PointStruct
+    {
+        Id = 1ul,
+        Vectors = new float[] { 0.1f, 0.2f, 0.3f },
+        Payload =
+        {
+            ["city"] = "London",
+            ["population"] = 9_000_000L,
+            ["active"] = true,
+        }
+    }
+};
+
+await client.UpsertAsync("col", points);
+```
+
+## Hybrid Search (RRF Fusion)
+
+```csharp
+var results = await client.QueryAsync(
+    "col",
+    query: Fusion.Rrf,
+    prefetch: new List<PrefetchQuery>
+    {
+        new() { Query = new float[] { 0.01f, 0.45f, 0.67f } },
+        new() { Query = new float[] { 0.5f, 0.3f, 0.1f } },
+    },
+    limit: 10);
+```
+
+## Filtering (Operator Overloads)
+
+The .NET client uses `&` (AND), `|` (OR), `!` (NOT) operators on conditions.
+
+```csharp
+using static Qdrant.Client.Grpc.Conditions;
+
+// Simple conditions
+MatchKeyword("city", "Berlin")
+Match("active", true)
+Match("count", 42L)
+Range("price", new Range { Gte = 10.0, Lte = 100.0 })
+DatetimeRange("date", gte: new DateTime(2024, 1, 1))
+GeoRadius("location", 52.52, 13.40, 1000.0f)
+IsNull("email")
+IsEmpty("tags")
+HasId(1ul)
+
+// Match any / except
+Match("color", new[] { "red", "blue" }.ToList())
+MatchExcept("status", new[] { "deleted" }.ToList())
+
+// Nested
+Nested("reviews", Range("score", new Range { Gte = 4.0 }))
+
+// Combine with operators
+var filter = MatchKeyword("type", "doc") & !Match("archived", true);
+var filter = HasId(1ul) | HasId(2ul);
+```
+
+A single `Condition` implicitly converts to a `Filter`, so you can pass conditions directly where a filter is expected.
+
+## Named Vectors
+
+```csharp
+// Create
+await client.CreateCollectionAsync("col",
+    vectorsConfig: new VectorParamsMap
+    {
+        Map = {
+            ["dense"] = new VectorParams { Size = 128, Distance = Distance.Cosine },
+            ["image"] = new VectorParams { Size = 512, Distance = Distance.Euclid }
+        }
+    });
+
+// Upsert
+var point = new PointStruct
+{
+    Id = 1ul,
+    Vectors = new Dictionary<string, float[]>
+    {
+        ["dense"] = new[] { 0.1f, 0.2f },
+        ["image"] = new[] { 0.3f, 0.4f }
+    }
+};
+
+// Sparse vectors
+point.Vectors = ("sparse-name", new Vector(new[] { (3.5f, 0u), (4.5f, 1u) }));
+```
+
+## Payload and Vector Selectors
+
+```csharp
+// Payload
+payloadSelector: true                       // all payload
+payloadSelector: new[] { "field1", "field2" }  // include specific fields
+
+// Vectors
+vectorsSelector: true                       // all vectors
+vectorsSelector: new[] { "dense", "image" }   // specific named vectors
+```
+
+## Recommend (Find Similar)
+
+```csharp
+var results = await client.QueryAsync("products",
+    query: new RecommendInput
+    {
+        Positive = { 1ul.ToVectorInput(), 2ul.ToVectorInput() },
+        Negative = { 3ul.ToVectorInput() },
+    },
+    limit: 10);
+```
+
+## Payload Mutation
+
+```csharp
+// Set (merge keys)
+await client.SetPayloadAsync("col",
+    new Dictionary<string, Value> { ["status"] = "reviewed" },
+    ids: new ulong[] { 1, 2, 3 });
+
+// Delete specific keys
+await client.DeletePayloadAsync("col",
+    new[] { "temp_field" },
+    ids: new ulong[] { 1, 2 });
+
+// Clear all payload
+await client.ClearPayloadAsync("col", ids: new ulong[] { 1 });
+```
+
+## Collection Aliases
+
+```csharp
+// Zero-downtime swap
+await client.DeleteAliasAsync("production");
+await client.CreateAliasAsync("production", "products_v2");
+```
+
+## Gotchas
+
+- **gRPC only, port 6334**: Not REST. The Python client defaults to REST on 6333.
+- **`IDisposable`**: Always `using var client = new QdrantClient(...)` or call `.Dispose()`.
+- **Implicit operators everywhere**: `float[]` converts to `Vectors`, `Vector`, `VectorInput`, or `Query`. `string` becomes `Value`. `ulong` becomes `PointId`.
+- **Use `&` / `|` / `!`, not `&&` / `||`**: C# cannot overload `&&`/`||`. The bitwise-style operators are intentional.
+- **`ulong` IDs need suffix**: Use `42ul` not `42`. Integer literals are `int`, not `ulong`.
+- **Payload values are `Value` objects**: Implicit conversions from `string`, `long`, `bool`, `double` work on assignment. Reading back needs `.StringValue`, `.IntegerValue`, etc.
+- **`UpsertAsync` `wait` defaults to `true`**: Unlike the REST API default. Writes block until committed.
+- **`RecreateCollectionAsync` exists**: Convenience method that deletes then creates. Not in all clients.
+- **Scroll returns `ScrollResponse`**: Access `.Result` for points and `.NextPageOffset` for cursor.
+- **All methods end with `Async`**: `QueryAsync`, `UpsertAsync`, `ScrollAsync`, etc.
+- **`SearchAsync` takes `ReadOnlyMemory<float>`**: But `float[]` converts implicitly.
+- **Errors throw `RpcException` (gRPC)**: Collection not found gives `StatusCode.NotFound`.
+- **Never one collection per user**: Use tenant payload index.
+- **Vector size must match**: Every upsert and query must match collection dims.
+- **Distance is immutable**: Delete and recreate collection to change it.
+
+## Read More
+
+- [NuGet: Qdrant.Client](https://www.nuget.org/packages/Qdrant.Client/)
+- [GitHub: qdrant/qdrant-dotnet](https://github.com/qdrant/qdrant-dotnet)
+- [Qdrant Documentation](https://qdrant.tech/documentation/)

--- a/skills/qdrant-dotnet/references/advanced-indexing.md
+++ b/skills/qdrant-dotnet/references/advanced-indexing.md
@@ -1,0 +1,130 @@
+# Advanced Indexing and Quantization
+
+HNSW, quantization, and multi-vector configuration in .NET/C#.
+
+## HNSW Parameters
+
+```csharp
+// At creation
+await client.CreateCollectionAsync("col",
+    new VectorParams { Size = 768, Distance = Distance.Cosine },
+    hnswConfig: new HnswConfigDiff { M = 16, EfConstruct = 100 });
+
+// Tune after creation
+await client.UpdateCollectionAsync("col",
+    hnswConfig: new HnswConfigDiff { M = 32, EfConstruct = 200 });
+```
+
+### Search-Time ef
+
+```csharp
+await client.QueryAsync("col",
+    query: vector,
+    searchParams: new SearchParams { HnswEf = 128 },
+    limit: 10);
+```
+
+## Scalar Quantization
+
+```csharp
+await client.CreateCollectionAsync("col",
+    new VectorParams { Size = 768, Distance = Distance.Cosine },
+    quantizationConfig: new ScalarQuantization
+    {
+        Scalar = new ScalarQuantizationConfig
+        {
+            Type = QuantizationType.Int8,
+            Quantile = 0.99f,
+            AlwaysRam = true,
+        }
+    });
+```
+
+## Product Quantization
+
+```csharp
+await client.CreateCollectionAsync("col",
+    new VectorParams { Size = 768, Distance = Distance.Cosine },
+    quantizationConfig: new ProductQuantization
+    {
+        Product = new ProductQuantizationConfig
+        {
+            Compression = CompressionRatio.X16,
+            AlwaysRam = true,
+        }
+    });
+```
+
+## Binary Quantization
+
+```csharp
+await client.CreateCollectionAsync("col",
+    new VectorParams { Size = 768, Distance = Distance.Cosine },
+    quantizationConfig: new BinaryQuantization
+    {
+        Binary = new BinaryQuantizationConfig { AlwaysRam = true }
+    });
+```
+
+## Quantization Search Params
+
+```csharp
+await client.QueryAsync("col",
+    query: vector,
+    searchParams: new SearchParams
+    {
+        Quantization = new QuantizationSearchParams
+        {
+            Rescore = true,
+            Oversampling = 2.0,
+        }
+    },
+    limit: 10);
+```
+
+## Multi-Vector (ColBERT)
+
+```csharp
+// Single multi-vector collection
+await client.CreateCollectionAsync("col",
+    new VectorParams
+    {
+        Size = 128,
+        Distance = Distance.Cosine,
+        MultivectorConfig = new MultiVectorConfig
+        {
+            Comparator = MultiVectorComparator.MaxSim,
+        }
+    });
+
+// Two-stage: dense + ColBERT reranking
+await client.CreateCollectionAsync("col",
+    vectorsConfig: new VectorParamsMap
+    {
+        Map = {
+            ["dense"] = new VectorParams { Size = 768, Distance = Distance.Cosine },
+            ["colbert"] = new VectorParams
+            {
+                Size = 128,
+                Distance = Distance.Cosine,
+                MultivectorConfig = new MultiVectorConfig
+                {
+                    Comparator = MultiVectorComparator.MaxSim,
+                },
+                HnswConfig = new HnswConfigDiff { M = 0 },  // disable HNSW
+            }
+        }
+    });
+```
+
+## What's Mutable at Runtime
+
+| Parameter | Mutable | Method |
+|-----------|---------|--------|
+| Distance | No | Recreate collection |
+| Vector size | No | Recreate collection |
+| HNSW `m`, `ef_construct` | Yes | `UpdateCollectionAsync` |
+| Quantization | Yes | `UpdateCollectionAsync` |
+| Optimizer settings | Yes | `UpdateCollectionAsync` |
+| On-disk flag | No | Set at creation |
+| Multi-vector comparator | No | Recreate collection |

--- a/skills/qdrant-dotnet/references/operators.md
+++ b/skills/qdrant-dotnet/references/operators.md
@@ -1,0 +1,249 @@
+# Operator Overloads and Conditions Reference
+
+Complete reference for Qdrant .NET client filter conditions and operator composition.
+
+## Static Import
+
+All condition helpers require this import:
+
+```csharp
+using static Qdrant.Client.Grpc.Conditions;
+```
+
+## Condition Helpers
+
+### Keyword Match
+
+```csharp
+MatchKeyword("city", "Berlin")
+```
+
+### Boolean Match
+
+```csharp
+Match("active", true)
+```
+
+### Integer Match
+
+```csharp
+Match("count", 42L)    // note: long, not int
+```
+
+### Match Any (IN)
+
+```csharp
+Match("color", new[] { "red", "blue" }.ToList())
+```
+
+### Match Except (NOT IN)
+
+```csharp
+MatchExcept("status", new[] { "deleted", "archived" }.ToList())
+```
+
+### Range
+
+```csharp
+Range("price", new Range { Gte = 10.0, Lte = 100.0 })
+Range("count", new Range { Gt = 0 })
+```
+
+### Datetime Range
+
+```csharp
+DatetimeRange("created_at", gte: new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+DatetimeRange("created_at", gte: new DateTime(2024, 1, 1), lt: new DateTime(2025, 1, 1))
+```
+
+### Full-Text Match
+
+```csharp
+MatchText("description", "vector database")
+```
+
+Requires a `text` payload index on the field.
+
+### Geo Radius
+
+```csharp
+GeoRadius("location", 52.52, 13.40, 1000.0f)    // lat, lon, radius in meters
+```
+
+### Geo Bounding Box
+
+```csharp
+GeoBoundingBox("location",
+    topLeftLat: 52.52, topLeftLon: 13.35,
+    bottomRightLat: 52.50, bottomRightLon: 13.45)
+```
+
+### Null and Empty
+
+```csharp
+IsNull("email")       // field is null / missing
+IsEmpty("tags")       // field is empty array
+```
+
+### Has ID
+
+```csharp
+HasId(1ul)
+HasId(1ul, 2ul, 3ul)
+HasId("uuid-string")
+```
+
+### Nested
+
+```csharp
+Nested("reviews", Range("reviews[].score", new Range { Gte = 4.0 }))
+Nested("reviews",
+    MatchKeyword("reviews[].verdict", "positive")
+    & Match("reviews[].verified", true))
+```
+
+## Operator Composition
+
+The .NET client overloads `&`, `|`, and `!` on `Condition` and `Filter` types.
+
+### AND (&)
+
+```csharp
+var filter = MatchKeyword("type", "doc") & MatchKeyword("status", "active");
+```
+
+Equivalent to `Filter { Must = [condition1, condition2] }`.
+
+### OR (|)
+
+```csharp
+var filter = MatchKeyword("color", "red") | MatchKeyword("color", "blue");
+```
+
+Equivalent to `Filter { Should = [condition1, condition2] }`.
+
+### NOT (!)
+
+```csharp
+var filter = !Match("archived", true);
+```
+
+Equivalent to `Filter { MustNot = [condition] }`.
+
+### Combined
+
+```csharp
+var filter = MatchKeyword("type", "doc")
+    & (MatchKeyword("color", "red") | MatchKeyword("color", "blue"))
+    & !Match("archived", true);
+```
+
+### Important: Use & | ! not && || !=
+
+C# cannot overload short-circuit operators `&&` and `||`. The bitwise-style `&` and `|` operators are intentional. Using `&&` or `||` will cause a compile error.
+
+## Implicit Conversions
+
+A single `Condition` implicitly converts to a `Filter`. You can pass a condition directly where a filter is expected:
+
+```csharp
+// These are equivalent:
+await client.QueryAsync("col", query: vec, filter: MatchKeyword("city", "Berlin"));
+await client.QueryAsync("col", query: vec,
+    filter: new Filter { Must = { MatchKeyword("city", "Berlin") } });
+```
+
+Other implicit conversions:
+- `float[]` converts to `Vectors`, `Vector`, `VectorInput`, or `Query`
+- `string` converts to `Value`
+- `ulong` converts to `PointId`
+- `ReadOnlyMemory<float>` converts to vector types
+
+## Building Filters Manually
+
+When operator composition is not enough:
+
+```csharp
+var filter = new Filter
+{
+    Must =
+    {
+        MatchKeyword("category", "electronics"),
+        Range("price", new Range { Lte = 100.0 }),
+    },
+    Should =
+    {
+        MatchKeyword("brand", "Apple"),
+        MatchKeyword("brand", "Samsung"),
+    },
+    MustNot =
+    {
+        Match("discontinued", true),
+    },
+};
+```
+
+## Payload Selectors
+
+```csharp
+// All payload
+payloadSelector: true
+
+// Specific fields
+payloadSelector: new[] { "field1", "field2" }
+
+// Exclude fields
+payloadSelector: new WithPayloadSelector
+{
+    Exclude = new PayloadExcludeSelector { Fields = { "secret" } }
+}
+```
+
+## Vector Selectors
+
+```csharp
+// All vectors
+vectorsSelector: true
+
+// Specific named vectors
+vectorsSelector: new[] { "dense", "image" }
+```
+
+## Point IDs
+
+```csharp
+// Numeric (must use ulong suffix)
+PointId id = 42ul;          // correct
+// PointId id = 42;         // compile error: int, not ulong
+
+// String UUID
+PointId id = Guid.NewGuid();
+```
+
+## Payload Values
+
+Implicit conversions on assignment:
+
+```csharp
+var point = new PointStruct
+{
+    Id = 1ul,
+    Vectors = new float[] { 0.1f, 0.2f },
+    Payload =
+    {
+        ["city"] = "London",           // string -> Value
+        ["population"] = 9_000_000L,   // long -> Value
+        ["active"] = true,             // bool -> Value
+        ["score"] = 0.95,              // double -> Value
+    }
+};
+```
+
+Reading payload values back requires explicit access:
+
+```csharp
+string city = point.Payload["city"].StringValue;
+long pop = point.Payload["population"].IntegerValue;
+bool active = point.Payload["active"].BoolValue;
+double score = point.Payload["score"].DoubleValue;
+```

--- a/skills/qdrant-go/AGENTS.md
+++ b/skills/qdrant-go/AGENTS.md
@@ -1,0 +1,47 @@
+# Qdrant Go Client
+
+Uses gRPC only (port 6334) via `github.com/qdrant/go-client/qdrant`. All types are protobuf structs. Pointer-heavy API, use `qdrant.PtrOf(value)` everywhere.
+
+## Setup
+
+```go
+import "github.com/qdrant/go-client/qdrant"
+client, err := qdrant.NewClient(&qdrant.Config{Host: "localhost", Port: 6334})
+// cloud: add APIKey, UseTLS: true
+```
+
+## Quick Reference
+
+| Operation | Code |
+|-----------|------|
+| Create collection | `client.CreateCollection(ctx, &qdrant.CreateCollection{CollectionName: "col", VectorsConfig: qdrant.NewVectorsConfig(&qdrant.VectorParams{Size: 768, Distance: qdrant.Distance_Cosine})})` |
+| Upsert | `client.Upsert(ctx, &qdrant.UpsertPoints{CollectionName: "col", Points: points, Wait: qdrant.PtrOf(true)})` |
+| Query | `client.Query(ctx, &qdrant.QueryPoints{CollectionName: "col", Query: qdrant.NewQuery(0.2, 0.1, 0.9)})` |
+| Filter | `Filter: &qdrant.Filter{Must: []*qdrant.Condition{qdrant.NewMatch("field", "value")}}` |
+| Hybrid (RRF) | `Prefetch` with dense+sparse, `Query: qdrant.NewQueryFusion(qdrant.Fusion_RRF)` |
+| Scroll | `client.Scroll(ctx, req)` or `client.ScrollAndOffset(ctx, req)` for pagination |
+| Delete | `client.Delete(ctx, &qdrant.DeletePoints{CollectionName: "col", Points: qdrant.NewPointsSelector(ids...)})` |
+| Payload index | `client.CreateFieldIndex(ctx, &qdrant.CreateFieldIndexCollection{...FieldType: qdrant.FieldType_FieldTypeKeyword.Enum()})` |
+| Multi-tenant | keyword index with `IsTenant: qdrant.PtrOf(true)` + filter per query |
+| Recommend | `Query: qdrant.NewQueryRecommend(&qdrant.RecommendInput{Positive: [...], Negative: [...]})` |
+| Set payload | `client.SetPayload(ctx, &qdrant.SetPayloadPoints{Payload: qdrant.NewValueMap(m), PointsSelector: ...})` |
+| Delete payload keys | `client.DeletePayload(ctx, &qdrant.DeletePayloadPoints{Keys: []string{"k"}, PointsSelector: ...})` |
+| Snapshot | `client.CreateSnapshot(ctx, "col")`, `client.ListSnapshots(ctx, "col")` |
+| Alias | `client.CreateAlias(ctx, "alias", "col")`, `client.DeleteAlias(ctx, "alias")` |
+| Update collection | `client.UpdateCollection(ctx, &qdrant.UpdateCollection{CollectionName: "col", OptimizersConfig: ...})` |
+
+## Gotchas
+
+- gRPC only (port 6334). Port 6333 won't work.
+- Pointer-heavy. `qdrant.PtrOf(value)` for all optional fields. Watch types: scroll Limit is `*uint32`, query Limit is `*uint64`.
+- `NewValueMap` panics on bad types. Use `TryValueMap` for error handling.
+- No `Search` method. Only `Query`/`QueryBatch`/`QueryGroups`.
+- `Scroll` discards offset. Use `ScrollAndOffset` for cursor-based pagination.
+- Enum syntax: `qdrant.Distance_Cosine`. Field types need `.Enum()` call.
+- `Using` is `*string`: `qdrant.PtrOf("image")` for named vector queries.
+- Datetime ranges need `timestamppb.New(time.Date(...))`, not `time.Time`.
+- Connection pool default is 3 connections with round-robin.
+- `CollectionName` required in each inner query of batch operations.
+- Never one collection per user. Use `IsTenant: true` payload index.
+- Vector dims must match collection config on every upsert and query.
+- Distance is immutable. Delete and recreate collection to change.

--- a/skills/qdrant-go/SKILL.md
+++ b/skills/qdrant-go/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: qdrant-go
+description: "Best practices for the Qdrant Go client (github.com/qdrant/go-client). Use when writing Go code that uses qdrant. Covers client setup, query, filtering, hybrid search, and common gotchas."
+allowed-tools: Read Grep Glob
+license: Apache-2.0
+metadata:
+  author: qdrant
+  version: "1.0"
+---
+
+# Qdrant Go Client
+
+You interact with Qdrant over gRPC using `github.com/qdrant/go-client/qdrant`. All types are protobuf-generated structs. The client is gRPC-only (port 6334).
+
+## Setup
+
+```bash
+go get -u github.com/qdrant/go-client
+```
+
+```go
+import "github.com/qdrant/go-client/qdrant"
+
+// Local
+client, err := qdrant.NewClient(&qdrant.Config{
+    Host: "localhost",
+    Port: 6334,
+})
+defer client.Close()
+
+// Cloud
+client, err := qdrant.NewClient(&qdrant.Config{
+    Host:   "xyz.cloud.qdrant.io",
+    Port:   6334,
+    APIKey: os.Getenv("QDRANT_API_KEY"),
+    UseTLS: true,
+})
+```
+
+## Decision Table
+
+| Want to... | Do |
+|-----------|-----|
+| Create collection | `client.CreateCollection(ctx, &qdrant.CreateCollection{CollectionName: "col", VectorsConfig: qdrant.NewVectorsConfig(&qdrant.VectorParams{Size: 768, Distance: qdrant.Distance_Cosine})})` |
+| Upsert | `client.Upsert(ctx, &qdrant.UpsertPoints{CollectionName: "col", Points: points})` |
+| Query | `client.Query(ctx, &qdrant.QueryPoints{CollectionName: "col", Query: qdrant.NewQuery(0.2, 0.1, 0.9)})` |
+| Filter | `Filter: &qdrant.Filter{Must: []*qdrant.Condition{qdrant.NewMatch("field", "value")}}` |
+| Hybrid (RRF) | Use `Prefetch` with dense + sparse, `Query: qdrant.NewQueryFusion(qdrant.Fusion_RRF)` |
+| Scroll | `client.Scroll(ctx, &qdrant.ScrollPoints{CollectionName: "col", Limit: qdrant.PtrOf(uint32(100))})` |
+| Scroll with offset | `client.ScrollAndOffset(ctx, req)` returns `(points, *PointId, error)` |
+| Delete by IDs | `client.Delete(ctx, &qdrant.DeletePoints{CollectionName: "col", Points: qdrant.NewPointsSelector(ids...)})` |
+| Delete by filter | `client.Delete(ctx, &qdrant.DeletePoints{CollectionName: "col", Points: qdrant.NewPointsSelectorFilter(filter)})` |
+| Payload index | `client.CreateFieldIndex(ctx, &qdrant.CreateFieldIndexCollection{CollectionName: "col", FieldName: "f", FieldType: qdrant.FieldType_FieldTypeKeyword.Enum()})` |
+| Multi-tenant | Keyword index with `IsTenant: qdrant.PtrOf(true)` + filter per query |
+| Recommend | `Query: qdrant.NewQueryRecommend(&qdrant.RecommendInput{Positive: [...], Negative: [...]})` |
+| Discover | `Query: qdrant.NewQueryDiscover(&qdrant.DiscoverInput{Target: ..., Context: ...})` |
+| Set payload | `client.SetPayload(ctx, &qdrant.SetPayloadPoints{CollectionName: "col", Payload: map, PointsSelector: ...})` |
+| Delete payload keys | `client.DeletePayload(ctx, &qdrant.DeletePayloadPoints{CollectionName: "col", Keys: []string{"k"}, PointsSelector: ...})` |
+| Clear payload | `client.ClearPayload(ctx, &qdrant.ClearPayloadPoints{CollectionName: "col", Points: ...})` |
+| Create snapshot | `client.CreateSnapshot(ctx, "col")` |
+| List snapshots | `client.ListSnapshots(ctx, "col")` |
+| Create alias | `client.CreateAlias(ctx, "alias", "col")` |
+| Delete alias | `client.DeleteAlias(ctx, "alias")` |
+| Update collection | `client.UpdateCollection(ctx, &qdrant.UpdateCollection{CollectionName: "col", OptimizersConfig: ...})` |
+
+## Query with Filter
+
+```go
+results, err := client.Query(ctx, &qdrant.QueryPoints{
+    CollectionName: "products",
+    Query:          qdrant.NewQuery(0.2, 0.1, 0.9, 0.7),
+    Filter: &qdrant.Filter{
+        Must: []*qdrant.Condition{
+            qdrant.NewMatch("category", "electronics"),
+        },
+    },
+    WithPayload: qdrant.NewWithPayload(true),
+    Limit:       qdrant.PtrOf(uint64(10)),
+})
+```
+
+## Upsert with Payload
+
+```go
+wait := true
+_, err := client.Upsert(ctx, &qdrant.UpsertPoints{
+    CollectionName: "col",
+    Wait:           &wait,
+    Points: []*qdrant.PointStruct{
+        {
+            Id:      qdrant.NewIDNum(1),
+            Vectors: qdrant.NewVectors(0.05, 0.61, 0.76, 0.74),
+            Payload: qdrant.NewValueMap(map[string]any{
+                "city": "Berlin", "population": 3_500_000,
+            }),
+        },
+    },
+})
+```
+
+## Hybrid Search (Dense + Sparse with RRF)
+
+```go
+results, err := client.Query(ctx, &qdrant.QueryPoints{
+    CollectionName: "col",
+    Prefetch: []*qdrant.PrefetchQuery{
+        {
+            Query: qdrant.NewQuerySparse([]uint32{1, 42}, []float32{0.22, 0.8}),
+            Using: qdrant.PtrOf("sparse"),
+            Limit: qdrant.PtrOf(uint64(20)),
+        },
+        {
+            Query: qdrant.NewQueryDense([]float32{0.01, 0.45, 0.67}),
+            Using: qdrant.PtrOf("dense"),
+            Limit: qdrant.PtrOf(uint64(20)),
+        },
+    },
+    Query: qdrant.NewQueryFusion(qdrant.Fusion_RRF),
+})
+```
+
+## Named Vectors
+
+```go
+// Create
+client.CreateCollection(ctx, &qdrant.CreateCollection{
+    CollectionName: "col",
+    VectorsConfig: qdrant.NewVectorsConfigMap(map[string]*qdrant.VectorParams{
+        "image": {Size: 4, Distance: qdrant.Distance_Dot},
+        "text":  {Size: 8, Distance: qdrant.Distance_Cosine},
+    }),
+})
+
+// Upsert
+client.Upsert(ctx, &qdrant.UpsertPoints{
+    CollectionName: "col",
+    Points: []*qdrant.PointStruct{{
+        Id: qdrant.NewIDNum(1),
+        Vectors: qdrant.NewVectorsMap(map[string]*qdrant.Vector{
+            "image": qdrant.NewVector(0.9, 0.1, 0.1, 0.2),
+            "text":  qdrant.NewVector(0.4, 0.7, 0.1, 0.8),
+        }),
+    }},
+})
+
+// Query specific vector
+client.Query(ctx, &qdrant.QueryPoints{
+    CollectionName: "col",
+    Query:          qdrant.NewQuery(0.9, 0.1, 0.1, 0.2),
+    Using:          qdrant.PtrOf("image"),
+})
+```
+
+## Key Constructor Helpers
+
+| Helper | Creates |
+|--------|---------|
+| `qdrant.NewIDNum(42)` / `qdrant.NewID("uuid")` | Point IDs |
+| `qdrant.NewVectors(0.1, 0.2)` / `qdrant.NewVectorsDense(slice)` | Dense vectors |
+| `qdrant.NewVectorsSparse(indices, values)` | Sparse vector |
+| `qdrant.NewVectorsMap(map)` | Named vectors |
+| `qdrant.NewQuery(0.1, 0.2)` / `qdrant.NewQueryDense(slice)` | Query nearest |
+| `qdrant.NewQueryFusion(qdrant.Fusion_RRF)` | Fusion query |
+| `qdrant.NewQueryRecommend(input)` | Recommend query |
+| `qdrant.NewMatch("field", "value")` | Match condition |
+| `qdrant.NewRange("field", range)` | Range condition |
+| `qdrant.NewValueMap(map[string]any{...})` | Payload (panics on bad types) |
+| `qdrant.PtrOf(value)` | Pointer to any value |
+| `qdrant.NewWithPayload(true)` | Payload selector |
+| `qdrant.NewPointsSelector(ids...)` | Points selector by IDs |
+
+## Filtering
+
+```go
+// Match
+qdrant.NewMatch("city", "Berlin")            // keyword
+qdrant.NewMatchInt("count", 42)              // integer
+qdrant.NewMatchBool("active", true)          // boolean
+qdrant.NewMatchKeywords("color", "r", "g")   // any-of
+qdrant.NewMatchExceptKeywords("x", "a", "b") // none-of
+
+// Range
+qdrant.NewRange("price", &qdrant.Range{Gte: qdrant.PtrOf(10.0), Lte: qdrant.PtrOf(100.0)})
+
+// Datetime (uses timestamppb)
+qdrant.NewDatetimeRange("date", &qdrant.DatetimeRange{
+    Gte: timestamppb.New(startTime),
+    Lt:  timestamppb.New(endTime),
+})
+
+// Geo
+qdrant.NewGeoRadius("location", 52.52, 13.40, 1000.0)
+
+// Existence
+qdrant.NewIsNull("field")
+qdrant.NewIsEmpty("tags")
+qdrant.NewHasID(qdrant.NewIDNum(1), qdrant.NewIDNum(2))
+
+// Nested
+qdrant.NewNestedFilter("reviews", &qdrant.Filter{
+    Must: []*qdrant.Condition{qdrant.NewRange("reviews[].score", ...)},
+})
+```
+
+## Recommend (Find Similar)
+
+```go
+results, err := client.Query(ctx, &qdrant.QueryPoints{
+    CollectionName: "products",
+    Query: qdrant.NewQueryRecommend(&qdrant.RecommendInput{
+        Positive: []*qdrant.VectorInput{
+            {Variant: &qdrant.VectorInput_Id{Id: qdrant.NewIDNum(1)}},
+            {Variant: &qdrant.VectorInput_Id{Id: qdrant.NewIDNum(2)}},
+        },
+        Negative: []*qdrant.VectorInput{
+            {Variant: &qdrant.VectorInput_Id{Id: qdrant.NewIDNum(3)}},
+        },
+    }),
+    Limit: qdrant.PtrOf(uint64(10)),
+})
+```
+
+## Payload Mutation
+
+```go
+// Set payload (merge)
+client.SetPayload(ctx, &qdrant.SetPayloadPoints{
+    CollectionName: "col",
+    Payload:        qdrant.NewValueMap(map[string]any{"status": "reviewed"}),
+    PointsSelector: qdrant.NewPointsSelector(qdrant.NewIDNum(1)),
+    Wait:           qdrant.PtrOf(true),
+})
+
+// Delete specific keys
+client.DeletePayload(ctx, &qdrant.DeletePayloadPoints{
+    CollectionName: "col",
+    Keys:           []string{"temp_field"},
+    PointsSelector: qdrant.NewPointsSelector(qdrant.NewIDNum(1)),
+})
+```
+
+## Collection Aliases
+
+```go
+// Zero-downtime swap
+client.DeleteAlias(ctx, "production")
+client.CreateAlias(ctx, "production", "products_v2")
+```
+
+## Gotchas
+
+- **gRPC only, port 6334**: No REST fallback. Port 6333 does not work with this client.
+- **Pointer-heavy API**: Optional fields are pointers. Use `qdrant.PtrOf(value)` constantly. Watch types: `Limit` on scroll is `*uint32`, on query is `*uint64`.
+- **`NewValueMap` panics on bad types**: Use `TryValueMap` for error-returning version if input is untrusted.
+- **No `Search` method**: Only `Query`/`QueryBatch`/`QueryGroups`. Everything goes through the unified query API.
+- **`Scroll` vs `ScrollAndOffset`**: `Scroll` discards the next offset. Use `ScrollAndOffset` for pagination.
+- **Enum syntax**: `qdrant.Distance_Cosine`, not `qdrant.Cosine`. Field types need `.Enum()`: `qdrant.FieldType_FieldTypeKeyword.Enum()`.
+- **`Using` is `*string`**: Named vector queries need `Using: qdrant.PtrOf("image")`, not a bare string.
+- **Datetime uses protobuf Timestamp**: `timestamppb.New(time.Date(...))`, not `time.Time` directly.
+- **Connection pool default is 3**: Not 1. Round-robin across connections.
+- **`CollectionName` required in batch inner queries**: Each `QueryPoints` in `QueryBatchPoints` must set its own `CollectionName`.
+- **Never one collection per user**: Use payload index with `IsTenant: true`.
+- **Vector size must match**: Every upsert and query must match collection dims.
+- **Distance is immutable**: Delete and recreate collection to change it.
+
+## Read More
+
+- [GitHub: qdrant/go-client](https://github.com/qdrant/go-client)
+- [Qdrant Documentation](https://qdrant.tech/documentation/)

--- a/skills/qdrant-go/references/advanced-indexing.md
+++ b/skills/qdrant-go/references/advanced-indexing.md
@@ -1,0 +1,128 @@
+# Advanced Indexing and Quantization
+
+HNSW, quantization, and multi-vector configuration in Go.
+
+## HNSW Parameters
+
+```go
+client.CreateCollection(ctx, &qdrant.CreateCollection{
+    CollectionName: "col",
+    VectorsConfig: qdrant.NewVectorsConfig(&qdrant.VectorParams{
+        Size: 768, Distance: qdrant.Distance_Cosine,
+    }),
+    HnswConfig: &qdrant.HnswConfigDiff{
+        M:                  qdrant.PtrOf(uint64(16)),
+        EfConstruct:        qdrant.PtrOf(uint64(100)),
+        FullScanThreshold:  qdrant.PtrOf(uint64(10000)),
+    },
+})
+
+// Tune after creation
+client.UpdateCollection(ctx, &qdrant.UpdateCollection{
+    CollectionName: "col",
+    HnswConfig: &qdrant.HnswConfigDiff{
+        M:           qdrant.PtrOf(uint64(32)),
+        EfConstruct: qdrant.PtrOf(uint64(200)),
+    },
+})
+```
+
+### Search-Time ef
+
+```go
+client.Query(ctx, &qdrant.QueryPoints{
+    CollectionName: "col",
+    Query:          qdrant.NewQuery(0.2, 0.1, 0.9),
+    Params: &qdrant.SearchParams{
+        HnswEf: qdrant.PtrOf(uint64(128)),
+    },
+    Limit: qdrant.PtrOf(uint64(10)),
+})
+```
+
+## Scalar Quantization
+
+```go
+client.CreateCollection(ctx, &qdrant.CreateCollection{
+    CollectionName: "col",
+    VectorsConfig: qdrant.NewVectorsConfig(&qdrant.VectorParams{
+        Size: 768, Distance: qdrant.Distance_Cosine,
+    }),
+    QuantizationConfig: &qdrant.QuantizationConfig{
+        Quantization: &qdrant.QuantizationConfig_Scalar{
+            Scalar: &qdrant.ScalarQuantization{
+                Type:      qdrant.QuantizationType_Int8,
+                Quantile:  qdrant.PtrOf(float32(0.99)),
+                AlwaysRam: qdrant.PtrOf(true),
+            },
+        },
+    },
+})
+```
+
+## Product Quantization
+
+```go
+QuantizationConfig: &qdrant.QuantizationConfig{
+    Quantization: &qdrant.QuantizationConfig_Product{
+        Product: &qdrant.ProductQuantization{
+            Compression: qdrant.CompressionRatio_x16,
+            AlwaysRam:   qdrant.PtrOf(true),
+        },
+    },
+}
+```
+
+## Binary Quantization
+
+```go
+QuantizationConfig: &qdrant.QuantizationConfig{
+    Quantization: &qdrant.QuantizationConfig_Binary{
+        Binary: &qdrant.BinaryQuantization{
+            AlwaysRam: qdrant.PtrOf(true),
+        },
+    },
+}
+```
+
+## Quantization Search Params
+
+```go
+client.Query(ctx, &qdrant.QueryPoints{
+    CollectionName: "col",
+    Query:          qdrant.NewQuery(0.2, 0.1, 0.9),
+    Params: &qdrant.SearchParams{
+        Quantization: &qdrant.QuantizationSearchParams{
+            Rescore:      qdrant.PtrOf(true),
+            Oversampling: qdrant.PtrOf(2.0),
+        },
+    },
+})
+```
+
+## Multi-Vector (ColBERT)
+
+```go
+client.CreateCollection(ctx, &qdrant.CreateCollection{
+    CollectionName: "col",
+    VectorsConfig: qdrant.NewVectorsConfig(&qdrant.VectorParams{
+        Size:     128,
+        Distance: qdrant.Distance_Cosine,
+        MultivectorConfig: &qdrant.MultiVectorConfig{
+            Comparator: qdrant.MultiVectorComparator_MaxSim,
+        },
+    }),
+})
+```
+
+## What's Mutable at Runtime
+
+| Parameter | Mutable | Method |
+|-----------|---------|--------|
+| Distance | No | Recreate collection |
+| Vector size | No | Recreate collection |
+| HNSW `m`, `ef_construct` | Yes | `UpdateCollection` |
+| Quantization | Yes | `UpdateCollection` |
+| Optimizer settings | Yes | `UpdateCollection` |
+| On-disk flag | No | Set at creation |
+| Multi-vector comparator | No | Recreate collection |

--- a/skills/qdrant-go/references/helpers.md
+++ b/skills/qdrant-go/references/helpers.md
@@ -1,0 +1,223 @@
+# Constructor Helpers Reference
+
+Complete reference for the Go client's constructor helpers and protobuf type patterns.
+
+## Point ID Constructors
+
+```go
+qdrant.NewIDNum(42)           // uint64 ID
+qdrant.NewID("abc-uuid")      // string ID
+```
+
+## Vector Constructors
+
+```go
+// Dense vectors (variadic floats)
+qdrant.NewVectors(0.1, 0.2, 0.3)
+
+// Dense vectors (from slice)
+qdrant.NewVectorsDense([]float32{0.1, 0.2, 0.3})
+
+// Sparse vector
+qdrant.NewVectorsSparse([]uint32{1, 42}, []float32{0.22, 0.8})
+
+// Named vectors (map of name -> vector)
+qdrant.NewVectorsMap(map[string]*qdrant.Vector{
+    "image": qdrant.NewVector(0.9, 0.1, 0.1, 0.2),
+    "text":  qdrant.NewVector(0.4, 0.7, 0.1, 0.8),
+})
+
+// Single vector (for named vector maps)
+qdrant.NewVector(0.1, 0.2, 0.3)
+qdrant.NewVectorDense([]float32{0.1, 0.2, 0.3})
+```
+
+## Query Constructors
+
+```go
+// Nearest (variadic floats)
+qdrant.NewQuery(0.2, 0.1, 0.9)
+
+// Nearest (from slice)
+qdrant.NewQueryDense([]float32{0.2, 0.1, 0.9})
+
+// Sparse query
+qdrant.NewQuerySparse([]uint32{1, 42}, []float32{0.22, 0.8})
+
+// Fusion
+qdrant.NewQueryFusion(qdrant.Fusion_RRF)
+
+// Recommend (by point IDs)
+qdrant.NewQueryRecommend(&qdrant.RecommendInput{
+    Positive: []*qdrant.VectorInput{
+        {Variant: &qdrant.VectorInput_Id{Id: qdrant.NewIDNum(1)}},
+    },
+})
+
+// Discover
+qdrant.NewQueryDiscover(&qdrant.DiscoverInput{
+    Target: &qdrant.VectorInput{Variant: &qdrant.VectorInput_Id{Id: qdrant.NewIDNum(1)}},
+    Context: &qdrant.ContextInput{
+        Pairs: []*qdrant.ContextInputPair{{
+            Positive: &qdrant.VectorInput{Variant: &qdrant.VectorInput_Id{Id: qdrant.NewIDNum(2)}},
+            Negative: &qdrant.VectorInput{Variant: &qdrant.VectorInput_Id{Id: qdrant.NewIDNum(3)}},
+        }},
+    },
+})
+
+// Order by payload field (no vector similarity)
+qdrant.NewQueryOrderBy(&qdrant.OrderBy{Key: "timestamp"})
+```
+
+## Condition Constructors
+
+```go
+// Keyword match
+qdrant.NewMatch("city", "Berlin")
+
+// Integer match
+qdrant.NewMatchInt("count", 42)
+
+// Boolean match
+qdrant.NewMatchBool("active", true)
+
+// Any-of (keyword list)
+qdrant.NewMatchKeywords("color", "red", "green", "blue")
+
+// None-of (keyword exclude)
+qdrant.NewMatchExceptKeywords("status", "deleted", "archived")
+
+// Any-of (integer list)
+qdrant.NewMatchIntegers("code", 200, 201, 204)
+
+// None-of (integer exclude)
+qdrant.NewMatchExceptIntegers("code", 500, 502, 503)
+
+// Range
+qdrant.NewRange("price", &qdrant.Range{
+    Gte: qdrant.PtrOf(10.0),
+    Lte: qdrant.PtrOf(100.0),
+})
+
+// Datetime range (uses timestamppb)
+import "google.golang.org/protobuf/types/known/timestamppb"
+
+qdrant.NewDatetimeRange("created_at", &qdrant.DatetimeRange{
+    Gte: timestamppb.New(startTime),
+    Lt:  timestamppb.New(endTime),
+})
+
+// Geo radius
+qdrant.NewGeoRadius("location", 52.52, 13.40, 1000.0)
+
+// Geo bounding box
+qdrant.NewGeoBoundingBox("location",
+    52.52, 13.35,   // top-left lat, lon
+    52.50, 13.45,   // bottom-right lat, lon
+)
+
+// Null / Empty checks
+qdrant.NewIsNull("email")
+qdrant.NewIsEmpty("tags")
+
+// Has ID
+qdrant.NewHasID(qdrant.NewIDNum(1), qdrant.NewIDNum(2))
+
+// Full-text match (requires text index)
+qdrant.NewMatchText("description", "vector database")
+
+// Nested
+qdrant.NewNestedFilter("reviews", &qdrant.Filter{
+    Must: []*qdrant.Condition{
+        qdrant.NewRange("reviews[].score", &qdrant.Range{Gte: qdrant.PtrOf(4.0)}),
+    },
+})
+```
+
+## Payload Constructors
+
+```go
+// From map (panics on unsupported types)
+qdrant.NewValueMap(map[string]any{
+    "city":       "Berlin",
+    "population": 3_500_000,
+    "active":     true,
+    "tags":       []any{"fast", "reliable"},
+})
+
+// Error-returning version (safe for untrusted input)
+payload, err := qdrant.TryValueMap(map[string]any{...})
+```
+
+Supported types in value maps: `string`, `int`, `int64`, `float64`, `bool`, `[]any`, `map[string]any`.
+
+## Selector Constructors
+
+```go
+// Payload selector
+qdrant.NewWithPayload(true)                    // all payload
+qdrant.NewWithPayloadInclude("field1", "field2") // specific fields
+qdrant.NewWithPayloadExclude("secret")          // exclude fields
+
+// Vectors selector
+qdrant.NewWithVectors(true)                    // all vectors
+qdrant.NewWithVectorsInclude("dense")           // specific vectors
+
+// Points selector (for delete)
+qdrant.NewPointsSelector(qdrant.NewIDNum(1), qdrant.NewIDNum(2))
+qdrant.NewPointsSelectorFilter(&qdrant.Filter{...})
+```
+
+## Pointer Helper
+
+All optional fields in protobuf structs are pointers. Use `PtrOf` for conversion:
+
+```go
+qdrant.PtrOf(uint64(10))    // *uint64
+qdrant.PtrOf(uint32(100))   // *uint32
+qdrant.PtrOf("image")       // *string
+qdrant.PtrOf(true)          // *bool
+qdrant.PtrOf(0.5)           // *float64
+```
+
+Watch types carefully. `Limit` on `QueryPoints` is `*uint64`, but `Limit` on `ScrollPoints` is `*uint32`.
+
+## Enum Values
+
+```go
+// Distance
+qdrant.Distance_Cosine
+qdrant.Distance_Euclid
+qdrant.Distance_Dot
+qdrant.Distance_Manhattan
+
+// Fusion
+qdrant.Fusion_RRF
+qdrant.Fusion_DBSF
+
+// Field types (need .Enum() for pointer)
+qdrant.FieldType_FieldTypeKeyword.Enum()
+qdrant.FieldType_FieldTypeInteger.Enum()
+qdrant.FieldType_FieldTypeFloat.Enum()
+qdrant.FieldType_FieldTypeGeo.Enum()
+qdrant.FieldType_FieldTypeDatetime.Enum()
+qdrant.FieldType_FieldTypeText.Enum()
+qdrant.FieldType_FieldTypeBool.Enum()
+qdrant.FieldType_FieldTypeUuid.Enum()
+```
+
+## Collection Config Constructors
+
+```go
+// Single unnamed vector
+qdrant.NewVectorsConfig(&qdrant.VectorParams{
+    Size:     768,
+    Distance: qdrant.Distance_Cosine,
+})
+
+// Named vectors
+qdrant.NewVectorsConfigMap(map[string]*qdrant.VectorParams{
+    "dense": {Size: 768, Distance: qdrant.Distance_Cosine},
+    "image": {Size: 512, Distance: qdrant.Distance_Euclid},
+})
+```

--- a/skills/qdrant-java/AGENTS.md
+++ b/skills/qdrant-java/AGENTS.md
@@ -1,0 +1,54 @@
+# Qdrant Java Client
+
+Uses gRPC (port 6334) via `io.qdrant:client`. All methods return `ListenableFuture<T>` (call `.get()` to block). Protobuf types with builder pattern. Static import factory classes for usable code.
+
+## Setup
+
+```java
+import static io.qdrant.client.PointIdFactory.id;
+import static io.qdrant.client.ValueFactory.value;
+import static io.qdrant.client.VectorsFactory.vectors;
+import static io.qdrant.client.QueryFactory.nearest;
+import static io.qdrant.client.ConditionFactory.*;
+
+QdrantClient client = new QdrantClient(
+    QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+```
+
+## Quick Reference
+
+| Operation | Code |
+|-----------|------|
+| Create collection | `client.createCollectionAsync("col", VectorParams.newBuilder().setSize(768).setDistance(Distance.Cosine).build())` |
+| Upsert | `client.upsertAsync("col", List.of(PointStruct.newBuilder().setId(id(1)).setVectors(vectors(...)).putAllPayload(Map.of("k", value("v"))).build()))` |
+| Query | `client.queryAsync(QueryPoints.newBuilder().setCollectionName("col").setQuery(nearest(...)).setLimit(10).build())` |
+| Filter | `.setFilter(Filter.newBuilder().addMust(matchKeyword("field", "value")).build())` |
+| Hybrid (RRF) | `.addPrefetch(...)` with `.setQuery(fusion(Fusion.RRF))` |
+| Named vector | `.setUsing("image")` on QueryPoints |
+| Scroll | `client.scrollAsync(ScrollPoints.newBuilder()...build())` with `.getNextPageOffset()` |
+| Delete | `client.deleteAsync("col", List.of(id(0), id(1)))` or pass Filter |
+| Payload index | `client.createPayloadIndexAsync("col", "field", PayloadSchemaType.Keyword, null, null, null, null)` |
+| Multi-tenant | keyword index with `setIsTenant(true)` + filter per query |
+| Recommend | `setQuery(recommend(List.of(vectorInput(id(1))), List.of(vectorInput(id(3)))))` |
+| Set payload | `client.setPayloadAsync("col", Map.of("k", value("v")), List.of(id(1)), null, null)` |
+| Delete payload keys | `client.deletePayloadAsync("col", List.of("key"), List.of(id(1)), null, null)` |
+| Snapshot | `client.createSnapshotAsync("col")`, `client.listSnapshotAsync("col")` |
+| Alias | `client.createAliasAsync("alias", "col")`, `client.deleteAliasAsync("alias")` |
+| Update collection | `client.updateCollectionAsync(UpdateCollection.newBuilder().setCollectionName("col").setOptimizersConfig(...).build())` |
+
+## Gotchas
+
+- gRPC only (port 6334). Not REST.
+- Everything returns `ListenableFuture<T>`. Call `.get()` to block.
+- Builder pattern everywhere. `Type.newBuilder()...build()`.
+- Factory classes required. Without `import static` for `id()`, `value()`, `vectors()`, `nearest()`, `matchKeyword()`, code is unreadable.
+- `vectors()` (plural) for PointStruct. `vector()` (singular) for named vector maps.
+- Payload values need `value()` wrapper: `value("str")`, `value(42L)`, `value(true)`.
+- `nearest()` overloads: `float...`, `List<Float>`, `long` (ID), `UUID`, `float[][]` (multi), `List<Float>, List<Integer>` (sparse).
+- Sparse vector upsert is verbose: build Vectors > NamedVectors > Map manually.
+- `searchAsync` is legacy. Use `queryAsync` with `nearest()`.
+- Protobuf types use getters: `.getId()`, `.getScore()`, `.getPayloadMap()`.
+- Channel lifecycle: pass `true` as second arg to auto-shutdown on client close.
+- Never one collection per user. Use `setIsTenant(true)` payload index.
+- Vector dims must match collection config on every upsert and query.
+- Distance is immutable. Delete and recreate collection to change.

--- a/skills/qdrant-java/SKILL.md
+++ b/skills/qdrant-java/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: qdrant-java
+description: "Best practices for the Qdrant Java client (io.qdrant:client). Use when writing Java code that uses Qdrant. Covers client setup, query, filtering, hybrid search with prefetch, and common gotchas."
+allowed-tools: Read Grep Glob
+license: Apache-2.0
+metadata:
+  author: qdrant
+  version: "1.0"
+---
+
+# Qdrant Java Client
+
+You interact with Qdrant over gRPC (port 6334) using the `io.qdrant:client` Maven artifact. All types are protobuf-generated. Every method returns `ListenableFuture<T>` (call `.get()` to block).
+
+## Setup
+
+**Maven:**
+```xml
+<dependency>
+  <groupId>io.qdrant</groupId>
+  <artifactId>client</artifactId>
+  <version>1.16.2</version>
+</dependency>
+```
+
+**Gradle:**
+```gradle
+implementation 'io.qdrant:client:1.16.2'
+```
+
+```java
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+
+// Local
+QdrantClient client = new QdrantClient(
+    QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+
+// Cloud
+QdrantClient client = new QdrantClient(
+    QdrantGrpcClient.newBuilder("xyz.cloud.qdrant.io", 6334, true)
+        .withApiKey("<api-key>")
+        .build());
+```
+
+## Essential Static Imports
+
+```java
+import static io.qdrant.client.PointIdFactory.id;
+import static io.qdrant.client.ValueFactory.value;
+import static io.qdrant.client.VectorsFactory.vectors;
+import static io.qdrant.client.VectorFactory.vector;
+import static io.qdrant.client.VectorsFactory.namedVectors;
+import static io.qdrant.client.VectorInputFactory.vectorInput;
+import static io.qdrant.client.QueryFactory.nearest;
+import static io.qdrant.client.QueryFactory.fusion;
+import static io.qdrant.client.ConditionFactory.*;
+import static io.qdrant.client.WithPayloadSelectorFactory.enable;
+```
+
+## Decision Table
+
+| Want to... | Do |
+|-----------|-----|
+| Create collection | `client.createCollectionAsync("col", VectorParams.newBuilder().setSize(768).setDistance(Distance.Cosine).build())` |
+| Upsert | `client.upsertAsync("col", List.of(PointStruct.newBuilder().setId(id(1)).setVectors(vectors(0.1f, 0.2f)).putAllPayload(Map.of("k", value("v"))).build()))` |
+| Query | `client.queryAsync(QueryPoints.newBuilder().setCollectionName("col").setQuery(nearest(0.2f, 0.1f)).setLimit(10).build())` |
+| Query with filter | `.setFilter(Filter.newBuilder().addMust(matchKeyword("field", "value")).build())` |
+| Hybrid (RRF) | `.addPrefetch(PrefetchQuery.newBuilder()...)` with `.setQuery(fusion(Fusion.RRF))` |
+| Named vector query | `.setUsing("image")` on `QueryPoints` |
+| Scroll | `client.scrollAsync(ScrollPoints.newBuilder().setCollectionName("col").setLimit(100).build())` |
+| Delete by IDs | `client.deleteAsync("col", List.of(id(0), id(1)))` |
+| Delete by filter | `client.deleteAsync("col", Filter.newBuilder().addMust(...).build())` |
+| Payload index | `client.createPayloadIndexAsync("col", "field", PayloadSchemaType.Keyword, null, null, null, null)` |
+| Recommend | `setQuery(recommend(List.of(vectorInput(id(1))), List.of(vectorInput(id(3)))))` |
+| Discover | `setQuery(discover(vectorInput(id(1)), List.of(new ContextInputPair(vectorInput(id(2)), vectorInput(id(3))))))` |
+| Set payload | `client.setPayloadAsync("col", Map.of("k", value("v")), List.of(id(1)), null, null)` |
+| Delete payload keys | `client.deletePayloadAsync("col", List.of("key1"), List.of(id(1)), null, null)` |
+| Clear payload | `client.clearPayloadAsync("col", List.of(id(1)), null, null)` |
+| Create snapshot | `client.createSnapshotAsync("col")` |
+| List snapshots | `client.listSnapshotAsync("col")` |
+| Create alias | `client.createAliasAsync("alias", "col")` |
+| Delete alias | `client.deleteAliasAsync("alias")` |
+| Update collection | `client.updateCollectionAsync(UpdateCollection.newBuilder().setCollectionName("col").setOptimizersConfig(...).build())` |
+
+## Query with Filter
+
+```java
+client.queryAsync(
+    QueryPoints.newBuilder()
+        .setCollectionName("products")
+        .setQuery(nearest(0.2f, 0.1f, 0.9f, 0.7f))
+        .setFilter(Filter.newBuilder()
+            .addMust(matchKeyword("category", "electronics"))
+            .build())
+        .setWithPayload(enable(true))
+        .setLimit(10)
+        .build()
+).get();
+```
+
+## Upsert with Payload
+
+```java
+client.upsertAsync("col", List.of(
+    PointStruct.newBuilder()
+        .setId(id(1))
+        .setVectors(vectors(0.1f, 0.2f, 0.3f))
+        .putAllPayload(Map.of(
+            "city", value("London"),
+            "population", value(9_000_000L),
+            "active", value(true)))
+        .build()
+)).get();
+```
+
+## Hybrid Search (Dense + Sparse with RRF)
+
+```java
+client.queryAsync(
+    QueryPoints.newBuilder()
+        .setCollectionName("col")
+        .addPrefetch(PrefetchQuery.newBuilder()
+            .setQuery(nearest(List.of(0.22f, 0.8f), List.of(1, 42)))
+            .setUsing("sparse")
+            .setLimit(20)
+            .build())
+        .addPrefetch(PrefetchQuery.newBuilder()
+            .setQuery(nearest(0.01f, 0.45f, 0.67f))
+            .setUsing("dense")
+            .setLimit(20)
+            .build())
+        .setQuery(fusion(Fusion.RRF))
+        .setLimit(10)
+        .build()
+).get();
+```
+
+## Named Vectors
+
+```java
+// Create
+client.createCollectionAsync("col", Map.of(
+    "image", VectorParams.newBuilder().setSize(4).setDistance(Distance.Dot).build(),
+    "text", VectorParams.newBuilder().setSize(8).setDistance(Distance.Cosine).build()
+)).get();
+
+// Upsert
+client.upsertAsync("col", List.of(
+    PointStruct.newBuilder()
+        .setId(id(1))
+        .setVectors(namedVectors(Map.of(
+            "image", vector(List.of(0.9f, 0.1f, 0.1f, 0.2f)),
+            "text", vector(List.of(0.4f, 0.7f, 0.1f, 0.8f)))))
+        .build()
+)).get();
+
+// Query specific vector
+client.queryAsync(QueryPoints.newBuilder()
+    .setCollectionName("col")
+    .setQuery(nearest(0.9f, 0.1f, 0.1f, 0.2f))
+    .setUsing("image")
+    .build()
+).get();
+```
+
+## Filtering (ConditionFactory)
+
+```java
+import static io.qdrant.client.ConditionFactory.*;
+
+// Match
+matchKeyword("city", "Berlin")               // exact keyword
+matchText("desc", "vector database")          // full-text search
+match("active", true)                         // boolean
+match("count", 42L)                           // integer
+matchKeywords("color", List.of("red", "blue"))   // any-of
+matchExceptKeywords("status", List.of("deleted")) // none-of
+
+// Range
+range("price", Range.newBuilder().setGte(10.0).setLte(100.0).build())
+
+// Datetime
+datetimeRange("date", DatetimeRange.newBuilder()
+    .setGte(Timestamps.fromMillis(start)).setLt(Timestamps.fromMillis(end)).build())
+
+// Geo
+geoRadius("location", 52.52, 13.40, 1000.0f)
+
+// Existence
+hasId(id(1))
+isEmpty("tags")
+isNull("email")
+
+// Nested
+nested("reviews", matchKeyword("reviews[].verdict", "positive"))
+
+// Compose
+Filter.newBuilder()
+    .addAllMust(List.of(...))
+    .addAllShould(List.of(...))
+    .addAllMustNot(List.of(...))
+    .build()
+```
+
+## MMR (Diversity)
+
+```java
+client.queryAsync(QueryPoints.newBuilder()
+    .setCollectionName("col")
+    .setQuery(nearest(
+        vectorInput(0.01f, 0.45f, 0.67f),
+        Mmr.newBuilder().setDiversity(0.5f).build()))
+    .setLimit(10)
+    .build()
+).get();
+```
+
+## Recommend (Find Similar)
+
+```java
+import static io.qdrant.client.QueryFactory.recommend;
+
+client.queryAsync(QueryPoints.newBuilder()
+    .setCollectionName("products")
+    .setQuery(recommend(
+        List.of(vectorInput(id(1)), vectorInput(id(2))),  // positive
+        List.of(vectorInput(id(3)))))                       // negative
+    .setLimit(10)
+    .build()
+).get();
+```
+
+## Payload Mutation
+
+```java
+// Set payload (merge)
+client.setPayloadAsync("col",
+    Map.of("status", value("reviewed")),
+    List.of(id(1), id(2)), null, null).get();
+
+// Delete specific keys
+client.deletePayloadAsync("col",
+    List.of("temp_field"),
+    List.of(id(1)), null, null).get();
+
+// Clear all payload
+client.clearPayloadAsync("col", List.of(id(1)), null, null).get();
+```
+
+## Collection Aliases
+
+```java
+// Zero-downtime swap
+client.deleteAliasAsync("production").get();
+client.createAliasAsync("production", "products_v2").get();
+```
+
+## Gotchas
+
+- **gRPC only, port 6334**: Not REST. Port 6333 won't work.
+- **Everything returns `ListenableFuture<T>`**: Call `.get()` to block. No synchronous API.
+- **Builder pattern everywhere**: `VectorParams.newBuilder()...build()`. Very verbose compared to Python dicts.
+- **Factory classes are essential**: Without `import static` for `id()`, `value()`, `vectors()`, `nearest()`, `matchKeyword()`, etc., code is extremely verbose.
+- **`vectors()` vs `vector()`**: Plural `vectors()` creates the `Vectors` wrapper for `PointStruct`. Singular `vector()` creates a `Vector` for named vector maps.
+- **Protobuf types, not POJOs**: All response types use getters: `.getId()`, `.getPayloadMap()`, `.getScore()`.
+- **Payload values need `value()` wrapper**: `value("string")`, `value(42L)`, `value(true)`. Raw Java types don't work.
+- **`nearest()` has many overloads**: `float...`, `List<Float>`, `long` (point ID), `UUID`, `float[][]` (multi-vector), sparse via `List<Float>, List<Integer>`.
+- **Sparse vector upsert is verbose**: Must build `Vectors > NamedVectors > Map<String, Vector>` manually.
+- **Channel lifecycle**: When using custom `ManagedChannel`, pass `true` as second arg to auto-shutdown on close.
+- **`searchAsync` (legacy) uses `addAllVector()`**: The modern `queryAsync` with `nearest()` is preferred.
+- **`PayloadSchemaType.Keyword`**: Index types are `Keyword`, `Integer`, `Float`, `Geo`, `Text`, `Bool`, `Datetime`, `Uuid`.
+- **Never one collection per user**: Use tenant payload index with `IsTenant(true)`.
+- **Vector size must match**: Every upsert and query must match collection dims.
+- **Distance is immutable**: Delete and recreate collection to change it.
+
+## Read More
+
+- [Maven Central: io.qdrant:client](https://central.sonatype.com/artifact/io.qdrant/client)
+- [GitHub: qdrant/java-client](https://github.com/qdrant/java-client)
+- [Qdrant Documentation](https://qdrant.tech/documentation/)

--- a/skills/qdrant-java/references/advanced-indexing.md
+++ b/skills/qdrant-java/references/advanced-indexing.md
@@ -1,0 +1,143 @@
+# Advanced Indexing and Quantization
+
+HNSW, quantization, and multi-vector configuration in Java.
+
+## HNSW Parameters
+
+```java
+// At creation
+client.createCollectionAsync(CreateCollection.newBuilder()
+    .setCollectionName("col")
+    .setVectorsConfig(VectorsConfig.newBuilder()
+        .setParams(VectorParams.newBuilder()
+            .setSize(768).setDistance(Distance.Cosine).build()))
+    .setHnswConfig(HnswConfigDiff.newBuilder()
+        .setM(16)
+        .setEfConstruct(100)
+        .setFullScanThreshold(10000)
+        .build())
+    .build()).get();
+
+// Tune after creation
+client.updateCollectionAsync(UpdateCollection.newBuilder()
+    .setCollectionName("col")
+    .setHnswConfig(HnswConfigDiff.newBuilder()
+        .setM(32)
+        .setEfConstruct(200)
+        .build())
+    .build()).get();
+```
+
+### Search-Time ef
+
+```java
+client.queryAsync(QueryPoints.newBuilder()
+    .setCollectionName("col")
+    .setQuery(nearest(0.2f, 0.1f, 0.9f))
+    .setParams(SearchParams.newBuilder()
+        .setHnswEf(128)
+        .build())
+    .setLimit(10)
+    .build()).get();
+```
+
+## Scalar Quantization
+
+```java
+client.createCollectionAsync(CreateCollection.newBuilder()
+    .setCollectionName("col")
+    .setVectorsConfig(VectorsConfig.newBuilder()
+        .setParams(VectorParams.newBuilder()
+            .setSize(768).setDistance(Distance.Cosine).build()))
+    .setQuantizationConfig(QuantizationConfig.newBuilder()
+        .setScalar(ScalarQuantization.newBuilder()
+            .setType(QuantizationType.Int8)
+            .setQuantile(0.99f)
+            .setAlwaysRam(true)
+            .build())
+        .build())
+    .build()).get();
+```
+
+## Product Quantization
+
+```java
+QuantizationConfig.newBuilder()
+    .setProduct(ProductQuantization.newBuilder()
+        .setCompression(CompressionRatio.x16)
+        .setAlwaysRam(true)
+        .build())
+    .build()
+```
+
+## Binary Quantization
+
+```java
+QuantizationConfig.newBuilder()
+    .setBinary(BinaryQuantization.newBuilder()
+        .setAlwaysRam(true)
+        .build())
+    .build()
+```
+
+## Quantization Search Params
+
+```java
+client.queryAsync(QueryPoints.newBuilder()
+    .setCollectionName("col")
+    .setQuery(nearest(0.2f, 0.1f, 0.9f))
+    .setParams(SearchParams.newBuilder()
+        .setQuantization(QuantizationSearchParams.newBuilder()
+            .setRescore(true)
+            .setOversampling(2.0)
+            .build())
+        .build())
+    .setLimit(10)
+    .build()).get();
+```
+
+## Multi-Vector (ColBERT)
+
+```java
+// Single multi-vector collection
+client.createCollectionAsync(CreateCollection.newBuilder()
+    .setCollectionName("col")
+    .setVectorsConfig(VectorsConfig.newBuilder()
+        .setParams(VectorParams.newBuilder()
+            .setSize(128)
+            .setDistance(Distance.Cosine)
+            .setMultivectorConfig(MultiVectorConfig.newBuilder()
+                .setComparator(MultiVectorComparator.MaxSim)
+                .build())
+            .build()))
+    .build()).get();
+
+// Two-stage with named vectors
+client.createCollectionAsync(CreateCollection.newBuilder()
+    .setCollectionName("col")
+    .setVectorsConfig(VectorsConfig.newBuilder()
+        .setParamsMap(VectorParamsMap.newBuilder()
+            .putMap("dense", VectorParams.newBuilder()
+                .setSize(768).setDistance(Distance.Cosine).build())
+            .putMap("colbert", VectorParams.newBuilder()
+                .setSize(128).setDistance(Distance.Cosine)
+                .setMultivectorConfig(MultiVectorConfig.newBuilder()
+                    .setComparator(MultiVectorComparator.MaxSim).build())
+                .setHnswConfig(HnswConfigDiff.newBuilder()
+                    .setM(0).build())  // disable HNSW
+                .build())
+            .build()))
+    .build()).get();
+```
+
+## What's Mutable at Runtime
+
+| Parameter | Mutable | Method |
+|-----------|---------|--------|
+| Distance | No | Recreate collection |
+| Vector size | No | Recreate collection |
+| HNSW `m`, `ef_construct` | Yes | `updateCollectionAsync` |
+| Quantization | Yes | `updateCollectionAsync` |
+| Optimizer settings | Yes | `updateCollectionAsync` |
+| On-disk flag | No | Set at creation |
+| Multi-vector comparator | No | Recreate collection |

--- a/skills/qdrant-java/references/factories.md
+++ b/skills/qdrant-java/references/factories.md
@@ -1,0 +1,319 @@
+# Factory Classes Reference
+
+Complete reference for Qdrant Java client factory classes and builder patterns.
+
+## Essential Static Imports
+
+These imports are critical for writing readable code:
+
+```java
+import static io.qdrant.client.PointIdFactory.id;
+import static io.qdrant.client.ValueFactory.value;
+import static io.qdrant.client.VectorsFactory.vectors;
+import static io.qdrant.client.VectorFactory.vector;
+import static io.qdrant.client.VectorsFactory.namedVectors;
+import static io.qdrant.client.VectorInputFactory.vectorInput;
+import static io.qdrant.client.QueryFactory.nearest;
+import static io.qdrant.client.QueryFactory.fusion;
+import static io.qdrant.client.QueryFactory.orderBy;
+import static io.qdrant.client.QueryFactory.recommend;
+import static io.qdrant.client.QueryFactory.discover;
+import static io.qdrant.client.ConditionFactory.*;
+import static io.qdrant.client.WithPayloadSelectorFactory.enable;
+import static io.qdrant.client.WithVectorsSelectorFactory.enable as enableVectors;
+```
+
+## PointIdFactory
+
+```java
+id(42)                          // numeric ID (long)
+id(UUID.randomUUID())           // UUID ID
+id("550e8400-e29b-41d4-...")    // UUID from string
+```
+
+## ValueFactory
+
+Wraps Java types into protobuf `Value` for payloads:
+
+```java
+value("Berlin")                 // string
+value(42L)                      // long integer
+value(3.14)                     // double
+value(true)                     // boolean
+value((Object) null)            // null value
+value(List.of(                  // list of values
+    value("a"), value("b")
+))
+value(Map.of(                   // struct (nested object)
+    "nested_key", value("nested_val")
+))
+```
+
+## VectorsFactory vs VectorFactory
+
+This is a common source of confusion:
+
+- `vectors(...)` (plural): creates `Vectors` wrapper for `PointStruct.setVectors()`
+- `vector(...)` (singular): creates `Vector` for named vector maps
+
+### VectorsFactory (for PointStruct)
+
+```java
+// Unnamed dense vector (variadic)
+vectors(0.1f, 0.2f, 0.3f)
+
+// Unnamed dense vector (from list)
+vectors(List.of(0.1f, 0.2f, 0.3f))
+```
+
+### VectorFactory (for named vectors)
+
+```java
+// Dense vector for named maps
+vector(List.of(0.1f, 0.2f, 0.3f))
+
+// Sparse vector
+vector(List.of(0.5f, 0.8f), List.of(1, 42))    // values, indices
+```
+
+### Named Vectors (combining both)
+
+```java
+// namedVectors wraps a map of name -> Vector into Vectors
+PointStruct.newBuilder()
+    .setId(id(1))
+    .setVectors(namedVectors(Map.of(
+        "image", vector(List.of(0.9f, 0.1f, 0.1f, 0.2f)),
+        "text", vector(List.of(0.4f, 0.7f, 0.1f, 0.8f))
+    )))
+    .build();
+```
+
+## VectorInputFactory
+
+Creates `VectorInput` for recommend/discover queries:
+
+```java
+vectorInput(0.1f, 0.2f, 0.3f)              // dense vector
+vectorInput(List.of(0.1f, 0.2f))            // dense from list
+vectorInput(id(42))                          // by point ID
+vectorInput(id(UUID.randomUUID()))           // by UUID
+```
+
+## QueryFactory
+
+### nearest (vector similarity)
+
+```java
+// Dense vector (variadic)
+nearest(0.2f, 0.1f, 0.9f)
+
+// Dense vector (from list)
+nearest(List.of(0.2f, 0.1f, 0.9f))
+
+// Sparse vector (values, indices)
+nearest(List.of(0.22f, 0.8f), List.of(1, 42))
+
+// By point ID
+nearest(id(42))
+nearest(id(UUID.randomUUID()))
+
+// Multi-vector (array of vectors)
+nearest(new float[][] {{0.1f, 0.2f}, {0.3f, 0.4f}})
+
+// With MMR diversity
+nearest(vectorInput(0.1f, 0.2f, 0.3f),
+    Mmr.newBuilder().setDiversity(0.5f).build())
+```
+
+### fusion
+
+```java
+fusion(Fusion.RRF)      // Reciprocal Rank Fusion
+fusion(Fusion.DBSF)     // Distribution-Based Score Fusion
+```
+
+### orderBy
+
+```java
+orderBy("timestamp")    // order by payload field (no vector similarity)
+```
+
+### recommend
+
+```java
+recommend(List.of(vectorInput(id(1)), vectorInput(id(2))),   // positive
+          List.of(vectorInput(id(3))))                         // negative
+```
+
+### discover
+
+```java
+discover(
+    vectorInput(id(1)),                    // target
+    List.of(new ContextInputPair(          // context pairs
+        vectorInput(id(2)),                // positive
+        vectorInput(id(3))                 // negative
+    ))
+)
+```
+
+## ConditionFactory
+
+### Match conditions
+
+```java
+matchKeyword("city", "Berlin")                    // exact keyword
+matchText("description", "vector database")        // full-text (needs text index)
+match("active", true)                              // boolean
+match("count", 42L)                                // integer
+matchKeywords("color", List.of("red", "blue"))     // any-of (keywords)
+matchExceptKeywords("status", List.of("deleted"))  // none-of (keywords)
+matchIntegers("code", List.of(200L, 201L))         // any-of (integers)
+matchExceptIntegers("code", List.of(500L, 502L))   // none-of (integers)
+```
+
+### Range
+
+```java
+range("price", Range.newBuilder()
+    .setGte(10.0)
+    .setLte(100.0)
+    .build())
+```
+
+### Datetime range
+
+```java
+import com.google.protobuf.Timestamp;
+
+datetimeRange("created_at", DatetimeRange.newBuilder()
+    .setGte(Timestamp.newBuilder().setSeconds(startEpoch).build())
+    .setLt(Timestamp.newBuilder().setSeconds(endEpoch).build())
+    .build())
+```
+
+### Geo conditions
+
+```java
+geoRadius("location", 52.52, 13.40, 1000.0f)      // lat, lon, radius (meters)
+
+geoBoundingBox("location",
+    52.52, 13.35,    // top-left lat, lon
+    52.50, 13.45)    // bottom-right lat, lon
+```
+
+### Existence checks
+
+```java
+hasId(id(1))
+hasId(id(1), id(2), id(3))
+isEmpty("tags")
+isNull("email")
+```
+
+### Nested
+
+```java
+nested("reviews", matchKeyword("reviews[].verdict", "positive"))
+nested("reviews",
+    Filter.newBuilder()
+        .addMust(range("reviews[].score", Range.newBuilder().setGte(4.0).build()))
+        .addMust(match("reviews[].verified", true))
+        .build())
+```
+
+## Filter Building
+
+```java
+// Simple filter (single condition auto-wraps into must)
+Filter.newBuilder()
+    .addMust(matchKeyword("category", "electronics"))
+    .build()
+
+// Complex filter
+Filter.newBuilder()
+    .addAllMust(List.of(
+        matchKeyword("category", "electronics"),
+        range("price", Range.newBuilder().setLte(100.0).build())
+    ))
+    .addAllShould(List.of(
+        matchKeyword("brand", "Apple"),
+        matchKeyword("brand", "Samsung")
+    ))
+    .addAllMustNot(List.of(
+        match("discontinued", true)
+    ))
+    .build()
+```
+
+## WithPayloadSelectorFactory
+
+```java
+enable(true)                // all payload
+enable(List.of("field1", "field2"))  // specific fields
+```
+
+## Payload Schema Types
+
+For `createPayloadIndexAsync`:
+
+```java
+PayloadSchemaType.Keyword
+PayloadSchemaType.Integer
+PayloadSchemaType.Float
+PayloadSchemaType.Geo
+PayloadSchemaType.Text
+PayloadSchemaType.Bool
+PayloadSchemaType.Datetime
+PayloadSchemaType.Uuid
+```
+
+## Common Builder Patterns
+
+### Collection with named vectors
+
+```java
+client.createCollectionAsync("col", Map.of(
+    "dense", VectorParams.newBuilder()
+        .setSize(768).setDistance(Distance.Cosine).build(),
+    "image", VectorParams.newBuilder()
+        .setSize(512).setDistance(Distance.Euclid).build()
+)).get();
+```
+
+### Sparse vector collection config
+
+```java
+client.createCollectionAsync(CreateCollection.newBuilder()
+    .setCollectionName("col")
+    .setVectorsConfig(VectorsConfig.newBuilder()
+        .setParamsMap(VectorParamsMap.newBuilder()
+            .putMap("dense", VectorParams.newBuilder()
+                .setSize(768).setDistance(Distance.Cosine).build())
+            .build()))
+    .setSparseVectorsConfig(SparseVectorConfig.newBuilder()
+        .putMap("sparse", SparseVectorParams.newBuilder()
+            .setModifier(Modifier.Idf)
+            .build())
+        .build())
+    .build()
+).get();
+```
+
+### Full query with all options
+
+```java
+client.queryAsync(QueryPoints.newBuilder()
+    .setCollectionName("col")
+    .setQuery(nearest(0.2f, 0.1f, 0.9f))
+    .setFilter(Filter.newBuilder()
+        .addMust(matchKeyword("category", "electronics"))
+        .build())
+    .setWithPayload(enable(true))
+    .setLimit(10)
+    .setScoreThreshold(0.5f)
+    .setUsing("dense")
+    .build()
+).get();
+```

--- a/skills/qdrant-python/AGENTS.md
+++ b/skills/qdrant-python/AGENTS.md
@@ -1,104 +1,43 @@
----
-name: qdrant-python
-description: "Best practices for the Qdrant Python SDK. Use when writing code that uses qdrant-client. Covers query_points, filtering, hybrid search, multi-tenancy, and common gotchas."
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
----
+# Qdrant Python SDK
 
-# Qdrant
+Use `qdrant-client`. All search goes through `query_points` (not `search`, which is removed).
 
-You manage collections, insert points, and run vector searches against a Qdrant instance using `qdrant-client`.
+## Quick Reference
 
-## Decision Table
-
-| Want to... | Do |
-|-----------|-----|
-| Create a collection | `client.create_collection(name, vectors_config=VectorParams(size=N, distance=Distance.COSINE))` |
-| Insert points | `client.upsert(collection, points=[PointStruct(id, vector, payload)])` |
-| Bulk insert | `client.upload_points(collection, points, batch_size=1000)` |
-| Search by vector | `client.query_points(collection, query=vector, limit=10)` |
-| Search with filter | Add `query_filter=Filter(must=[FieldCondition(...)])` to search |
-| Hybrid search | Use `prefetch` with dense + sparse, fuse with `FusionQuery(fusion=Fusion.RRF)` |
-| Diverse results (MMR) | `query=NearestQuery(nearest=emb, mmr=Mmr(diversity=0.5))` |
-| Filtered search (Acorn) | Add `search_params=SearchParams(acorn=True)` with filters |
-| Cloud inference | `query=Document(text="query", model="model-name")` |
-| Scroll all points | `client.scroll(collection, limit=100)` returns `(points, next_offset)` |
-| Create payload index | `client.create_payload_index(collection, field, schema_type=PayloadSchemaType.KEYWORD)` |
-| Multi-tenant | One collection + `create_payload_index(field, is_tenant=True)` + filter per query |
-
-## Search with Filters
-
-```python
-client.query_points("products",
-    query=embedding,
-    query_filter=Filter(must=[
-        FieldCondition(key="category", match=MatchValue(value="electronics")),
-    ]), limit=10)
-```
-
-## Hybrid Search (Dense + Sparse)
-
-```python
-client.query_points("docs",
-    prefetch=[
-        Prefetch(query=dense_emb, using="dense", limit=20),
-        Prefetch(query=sparse_emb, using="sparse", limit=20),
-    ],
-    query=FusionQuery(fusion=Fusion.RRF), limit=10)
-```
-
-## Cloud Inference (No Local Model)
-
-```python
-client = QdrantClient(
-    url="https://xyz.cloud.qdrant.io:6333",
-    api_key=os.environ["QDRANT_API_KEY"],
-    cloud_inference=True,
-)
-
-client.upsert("col", [PointStruct(
-    id=1, payload={"topic": "cooking"},
-    vector=Document(
-        text="Chocolate chip cookie recipe",
-        model="openrouter/thenlper/gte-base",
-        options={"openrouter-api-key": "<key>"},
-    ),
-)])
-
-client.query_points("col", query=Document(
-    text="cookie recipe",
-    model="openrouter/thenlper/gte-base",
-    options={"openrouter-api-key": "<key>"},
-))
-```
-
-## MMR (Diversity-Aware Results)
-
-```python
-client.query_points("col",
-    query=models.NearestQuery(
-        nearest=embedding,
-        mmr=models.Mmr(diversity=0.5),
-    ), limit=5)
-```
+| Operation | Code |
+|-----------|------|
+| Create collection | `client.create_collection(name, vectors_config=VectorParams(size=N, distance=Distance.COSINE))` |
+| Upsert | `client.upsert(col, points=[PointStruct(id, vector, payload)])` |
+| Bulk upsert | `client.upload_points(col, points, batch_size=1000)` |
+| Search | `client.query_points(col, query=vector, limit=10)` |
+| Filter search | add `query_filter=Filter(must=[FieldCondition(key=k, match=MatchValue(value=v))])` |
+| Hybrid (RRF) | `prefetch=[Prefetch(query=dense, using="dense", limit=20), Prefetch(query=sparse, using="sparse", limit=20)]`, `query=FusionQuery(fusion=Fusion.RRF)` |
+| MMR | `query=NearestQuery(nearest=emb, mmr=Mmr(diversity=0.5))` |
+| Scroll | `client.scroll(col, limit=100)` returns `(points, next_offset)` |
+| Payload index | `client.create_payload_index(col, field, schema_type=PayloadSchemaType.KEYWORD)` |
+| Multi-tenant | one collection + `create_payload_index(field, is_tenant=True)` + filter per query |
+| Cloud inference | init with `cloud_inference=True`, query with `Document(text="q", model="model-name")` |
+| Recommend | `query=RecommendQuery(positive=[id1], negative=[id2])` |
+| Discover | `query=DiscoverQuery(target=id, context=[ContextPair(positive=p, negative=n)])` |
+| Set payload | `client.set_payload(col, payload={"k": "v"}, points=[id])` |
+| Delete payload keys | `client.delete_payload(col, keys=["k"], points=[id])` |
+| Snapshot | `client.create_snapshot(col)`, `client.list_snapshots(col)`, `client.download_snapshot(col, name, path)` |
+| Alias (swap) | `client.update_collection_aliases(change_aliases_operations=[DeleteAliasOp, CreateAliasOp])` |
+| Update collection | `client.update_collection(col, optimizer_config=OptimizersConfigDiff(...))` |
 
 ## Gotchas
 
-- **`query_points` not `search`**: All search variants are removed. Use `query_points`.
-- **Never one collection per user**: Use `is_tenant=True` payload index.
-- **Create payload indexes BEFORE bulk upload**: Adding after triggers full re-index.
-- **BM25 requires `Modifier.IDF`**: Without it, sparse search quality is poor.
-- **Prefetch limit > final limit**: Prefetch is the candidate pool.
-- **Scroll offset is a cursor, not skip**: `next_offset` is a point ID.
-- **Don't exact-match floats**: Use `Range(gte=19.98, lte=20.0)`.
-- **Distance is immutable**: Delete and recreate to change it.
-- **Vector size must match**: Every insert and query must match collection dims.
-- **`upload_points` for bulk**: Don't call `upsert` in a loop for 10k+ points.
-- **Acorn only with filters**: `acorn=True` adds overhead without filters.
-- **Cloud inference needs `cloud_inference=True`** on client init.
+- `query_points` not `search`. All search variants removed.
+- Never one collection per user. Use `is_tenant=True` payload index.
+- Create payload indexes BEFORE bulk upload (avoids full re-index).
+- BM25 needs `Modifier.IDF` or sparse quality is poor.
+- Prefetch limit must be > final limit (it's the candidate pool).
+- Scroll offset is a cursor (point ID), not a skip count.
+- Don't exact-match floats. Use `Range(gte=19.98, lte=20.0)`.
+- Distance is immutable. Delete and recreate collection to change.
+- Vector dims must match collection config on every insert and query.
+- Use `upload_points` for bulk. Don't loop `upsert` for 10k+ points.
+- `acorn=True` only helps with filters. Adds overhead without them.
+- Cloud inference requires `cloud_inference=True` on client init.
 
-## Read More
-
-[How to Teach AI Agents to Use Qdrant Without Breaking Things](https://qdrant.tech/blog/qdrant-ai-coding-agents/)
+References: `filtering.md` (filter syntax), `migration-guide.md` (old API to new), `common-errors.md` (runtime errors), `data-ingestion.md` (bulk upload patterns), `fastembed.md` (local embeddings), `advanced-indexing.md` (HNSW, quantization, ColBERT).

--- a/skills/qdrant-python/SKILL.md
+++ b/skills/qdrant-python/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: qdrant-python
 description: "Best practices for the Qdrant Python SDK. Use when writing code that uses qdrant-client. Covers query_points, filtering, hybrid search, multi-tenancy, and common gotchas."
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
+allowed-tools: Read Grep Glob
+license: Apache-2.0
+metadata:
+  author: qdrant
+  version: "1.0"
 ---
 
 # Qdrant
@@ -27,6 +28,19 @@ You manage collections, insert points, and run vector searches against a Qdrant 
 | Scroll all points | `client.scroll(collection, limit=100)` returns `(points, next_offset)` |
 | Create payload index | `client.create_payload_index(collection, field, schema_type=PayloadSchemaType.KEYWORD)` |
 | Multi-tenant | One collection + `create_payload_index(field, is_tenant=True)` + filter per query |
+| Recommend (similar items) | `client.query_points(col, query=RecommendQuery(positive=[id1, id2], negative=[id3]))` |
+| Discover (constrained explore) | `client.query_points(col, query=DiscoverQuery(target=id1, context=[ContextPair(positive=id2, negative=id3)]))` |
+| Set payload | `client.set_payload(col, payload={"key": "new_val"}, points=[point_id])` |
+| Overwrite payload | `client.overwrite_payload(col, payload={"key": "val"}, points=[point_id])` |
+| Delete payload keys | `client.delete_payload(col, keys=["key1", "key2"], points=[point_id])` |
+| Clear all payload | `client.clear_payload(col, points_selector=[point_id])` |
+| Create snapshot | `client.create_snapshot(col)` returns snapshot info |
+| List snapshots | `client.list_snapshots(col)` |
+| Download snapshot | `client.download_snapshot(col, snapshot_name, path="snapshot.tar")` |
+| Full storage snapshot | `client.create_full_snapshot()` |
+| Create alias | `client.update_collection_aliases(change_aliases_operations=[CreateAliasOperation(create_alias=CreateAlias(collection_name="col", alias_name="alias"))])` |
+| Switch alias | Delete old alias + create new in one `change_aliases_operations` call |
+| Update collection | `client.update_collection(col, optimizer_config=OptimizersConfigDiff(indexing_threshold=20000))` |
 
 ## Search with Filters
 
@@ -84,6 +98,59 @@ client.query_points("col",
     ), limit=5)
 ```
 
+## Recommend (Find Similar)
+
+```python
+from qdrant_client.models import RecommendQuery
+
+client.query_points("products",
+    query=RecommendQuery(positive=[1, 2], negative=[3]),
+    limit=10)
+```
+
+## Discover (Constrained Exploration)
+
+```python
+from qdrant_client.models import DiscoverQuery, ContextPair
+
+client.query_points("products",
+    query=DiscoverQuery(
+        target=42,
+        context=[ContextPair(positive=1, negative=2)],
+    ), limit=10)
+```
+
+## Payload Mutation
+
+```python
+# Set (merge new keys into existing payload)
+client.set_payload("col", payload={"status": "reviewed"}, points=[1, 2, 3])
+
+# Overwrite (replace entire payload)
+client.overwrite_payload("col", payload={"status": "clean"}, points=[1])
+
+# Delete specific keys
+client.delete_payload("col", keys=["temp_field"], points=[1, 2])
+
+# Clear all payload
+client.clear_payload("col", points_selector=[1])
+```
+
+## Collection Aliases
+
+```python
+from qdrant_client.models import CreateAliasOperation, CreateAlias, DeleteAliasOperation, DeleteAlias
+
+# Zero-downtime swap: build new collection, then swap alias
+client.update_collection_aliases(
+    change_aliases_operations=[
+        DeleteAliasOperation(delete_alias=DeleteAlias(alias_name="production")),
+        CreateAliasOperation(create_alias=CreateAlias(
+            collection_name="products_v2", alias_name="production")),
+    ]
+)
+```
+
 ## Gotchas
 
 - **`query_points` not `search`**: All search variants are removed. Use `query_points`.
@@ -102,3 +169,12 @@ client.query_points("col",
 ## Read More
 
 [How to Teach AI Agents to Use Qdrant Without Breaking Things](https://qdrant.tech/blog/qdrant-ai-coding-agents/)
+
+## References
+
+- `references/filtering.md`: Filter conditions (match, range, geo, nested, null)
+- `references/migration-guide.md`: Old API to new API migration map
+- `references/common-errors.md`: Runtime error messages and solutions
+- `references/data-ingestion.md`: Batch upload, parallel workers, retry patterns
+- `references/fastembed.md`: FastEmbed local embedding library integration
+- `references/advanced-indexing.md`: HNSW tuning, quantization, ColBERT multi-vector config

--- a/skills/qdrant-python/references/advanced-indexing.md
+++ b/skills/qdrant-python/references/advanced-indexing.md
@@ -1,0 +1,236 @@
+# Advanced Indexing and Quantization
+
+Tuning HNSW parameters, quantization, and multi-vector configuration for production workloads.
+
+## HNSW Parameters
+
+HNSW (Hierarchical Navigable Small World) is the vector index algorithm. Key parameters:
+
+```python
+from qdrant_client.models import HnswConfigDiff
+
+# At collection creation
+client.create_collection("col",
+    vectors_config=VectorParams(size=768, distance=Distance.COSINE),
+    hnsw_config=HnswConfigDiff(
+        m=16,                # connections per node (default: 16)
+        ef_construct=100,    # search width during build (default: 100)
+        full_scan_threshold=10000,  # below this, skip HNSW
+    ))
+
+# Tune after creation
+client.update_collection("col",
+    hnsw_config=HnswConfigDiff(m=32, ef_construct=200))
+```
+
+### Parameter Guide
+
+| Parameter | Default | Effect of increasing |
+|-----------|---------|---------------------|
+| `m` | 16 | Better recall, more memory, slower build |
+| `ef_construct` | 100 | Better recall, slower build |
+| `full_scan_threshold` | 10000 | Larger collections use brute-force (exact) search |
+
+### Search-Time ef
+
+`ef` controls search precision at query time (higher = better recall, slower):
+
+```python
+from qdrant_client.models import SearchParams
+
+client.query_points("col",
+    query=vector,
+    search_params=SearchParams(hnsw_ef=128),  # default: same as ef_construct
+    limit=10)
+```
+
+### When to Tune
+
+- **Recall too low**: Increase `ef_construct` and `m`
+- **Build too slow**: Decrease `ef_construct` (128 is usually enough)
+- **High memory**: Decrease `m` (8 works for small datasets)
+- **Search too slow**: Decrease `hnsw_ef` at query time (trade recall for speed)
+
+## Quantization
+
+Reduces memory by compressing vectors. Three modes:
+
+### Scalar Quantization (fastest, least compression)
+
+Converts float32 to int8. 4x memory reduction with minimal quality loss.
+
+```python
+from qdrant_client.models import ScalarQuantization, ScalarQuantizationConfig, ScalarType
+
+client.create_collection("col",
+    vectors_config=VectorParams(size=768, distance=Distance.COSINE),
+    quantization_config=ScalarQuantization(
+        scalar=ScalarQuantizationConfig(
+            type=ScalarType.INT8,
+            quantile=0.99,        # clip outliers
+            always_ram=True,      # keep quantized vectors in RAM
+        )))
+```
+
+### Product Quantization (most compression)
+
+Compresses vectors into sub-vector codes. Higher compression, more quality loss.
+
+```python
+from qdrant_client.models import ProductQuantization, ProductQuantizationConfig
+
+client.create_collection("col",
+    vectors_config=VectorParams(size=768, distance=Distance.COSINE),
+    quantization_config=ProductQuantization(
+        product=ProductQuantizationConfig(
+            compression=CompressionRatio.X16,  # X4, X8, X16, X32, X64
+            always_ram=True,
+        )))
+```
+
+### Binary Quantization (for normalized vectors only)
+
+Converts each float to a single bit. 32x compression. Only works well with Cosine distance on normalized vectors.
+
+```python
+from qdrant_client.models import BinaryQuantization, BinaryQuantizationConfig
+
+client.create_collection("col",
+    vectors_config=VectorParams(size=768, distance=Distance.COSINE),
+    quantization_config=BinaryQuantization(
+        binary=BinaryQuantizationConfig(always_ram=True)))
+```
+
+### Quantization Search Params
+
+Use oversampling and rescoring for better quality with quantized vectors:
+
+```python
+from qdrant_client.models import SearchParams, QuantizationSearchParams
+
+client.query_points("col",
+    query=vector,
+    search_params=SearchParams(
+        quantization=QuantizationSearchParams(
+            rescore=True,    # re-rank with original vectors
+            oversampling=2.0,  # fetch 2x candidates before rescoring
+        )),
+    limit=10)
+```
+
+### When to Use Each
+
+| Method | Memory savings | Quality loss | Best for |
+|--------|---------------|-------------|----------|
+| Scalar (int8) | 4x | Minimal | Default choice |
+| Product | 16-64x | Moderate | Very large datasets |
+| Binary | 32x | Varies | Normalized embeddings with Cosine |
+
+## On-Disk Vectors
+
+For datasets that exceed RAM, store vectors on disk:
+
+```python
+client.create_collection("col",
+    vectors_config=VectorParams(
+        size=768,
+        distance=Distance.COSINE,
+        on_disk=True,  # store vectors on disk
+    ),
+    hnsw_config=HnswConfigDiff(on_disk=True),  # store HNSW index on disk too
+    quantization_config=ScalarQuantization(
+        scalar=ScalarQuantizationConfig(
+            type=ScalarType.INT8,
+            always_ram=True,  # keep quantized vectors in RAM for fast search
+        )))
+```
+
+This pattern stores original vectors on disk but keeps the quantized versions in RAM. Searches use RAM-resident quantized vectors for speed, then rescore from disk for accuracy.
+
+## Multi-Vector (ColBERT / Late Interaction)
+
+Store token-level embeddings for late interaction models like ColBERT:
+
+```python
+from qdrant_client.models import (
+    VectorParams, MultiVectorConfig, MultiVectorComparator,
+)
+
+# Create collection with multi-vector support
+client.create_collection("col",
+    vectors_config=VectorParams(
+        size=128,  # per-token dimension
+        distance=Distance.COSINE,
+        multivector_config=MultiVectorConfig(
+            comparator=MultiVectorComparator.MAX_SIM,
+        ),
+    ))
+
+# Upsert: each point's vector is a list of token vectors (matrix)
+client.upsert("col", points=[
+    PointStruct(
+        id=1,
+        vector=[[0.1, 0.2, ...], [0.3, 0.4, ...], [0.5, 0.6, ...]],  # N tokens x 128 dims
+        payload={"text": "document text"},
+    ),
+])
+
+# Query: pass a list of query token vectors
+client.query_points("col",
+    query=[[0.1, 0.2, ...], [0.3, 0.4, ...]],  # query tokens
+    limit=10)
+```
+
+### Multi-Vector with HNSW Disabled (Reranking Only)
+
+For large-scale ColBERT, disable HNSW on multi-vectors and use them only for reranking:
+
+```python
+# Named vectors: dense for retrieval, multivec for reranking
+client.create_collection("col",
+    vectors_config={
+        "dense": VectorParams(size=768, distance=Distance.COSINE),
+        "colbert": VectorParams(
+            size=128,
+            distance=Distance.COSINE,
+            multivector_config=MultiVectorConfig(
+                comparator=MultiVectorComparator.MAX_SIM),
+            hnsw_config=HnswConfigDiff(m=0),  # disable HNSW indexing
+        ),
+    })
+
+# Two-stage: retrieve with dense, rescore with ColBERT
+client.query_points("col",
+    prefetch=[Prefetch(query=dense_emb, using="dense", limit=100)],
+    query=colbert_token_vectors,
+    using="colbert",
+    limit=10)
+```
+
+## Optimizer Config
+
+Control background optimization:
+
+```python
+from qdrant_client.models import OptimizersConfigDiff
+
+client.update_collection("col",
+    optimizer_config=OptimizersConfigDiff(
+        indexing_threshold=20000,      # min segment size to trigger indexing
+        memmap_threshold=50000,        # min segment size to use mmap
+        default_segment_number=4,      # target number of segments
+        max_optimization_threads=2,    # parallel optimization workers
+    ))
+```
+
+### What's Mutable at Runtime
+
+| Parameter | Mutable | How to Change |
+|-----------|---------|--------------|
+| Distance | No | Delete and recreate collection |
+| Vector size | No | Delete and recreate collection |
+| HNSW `m`, `ef_construct` | Yes | `update_collection(hnsw_config=...)` |
+| Quantization config | Yes | `update_collection(quantization_config=...)` |
+| Optimizer settings | Yes | `update_collection(optimizer_config=...)` |
+| On-disk flag | No | Set at creation only |
+| Multi-vector comparator | No | Delete and recreate collection |

--- a/skills/qdrant-python/references/common-errors.md
+++ b/skills/qdrant-python/references/common-errors.md
@@ -1,0 +1,128 @@
+# Common Runtime Errors
+
+Error messages you will encounter and how to fix them.
+
+## Connection Errors
+
+### `ConnectionRefusedError: [Errno 111] Connection refused`
+
+Qdrant is not running or wrong port.
+
+```bash
+# Start Qdrant
+docker run -p 6333:6333 -p 6334:6334 qdrant/qdrant
+```
+
+Python uses REST (port 6333) by default. Verify with `curl http://localhost:6333/healthz`.
+
+### `TimeoutError` or `httpx.ReadTimeout`
+
+Server is overloaded or network is slow.
+
+```python
+# Increase timeout
+client = QdrantClient("localhost", port=6333, timeout=60)
+```
+
+Default timeout is 5 seconds. Bulk operations on large collections may need 30-60s.
+
+## Collection Errors
+
+### `ValueError: Collection 'X' not found`
+
+Collection does not exist. Create it first.
+
+```python
+# Check if collection exists
+collections = client.get_collections().collections
+names = [c.name for c in collections]
+if "my_col" not in names:
+    client.create_collection("my_col", vectors_config=VectorParams(...))
+```
+
+### `ValueError: Wrong input: Vector dimension error: expected dim: 768, got 384`
+
+Vector dimensions don't match collection config. Check your embedding model output size.
+
+```python
+# Verify collection config
+info = client.get_collection("col")
+print(info.config.params.vectors.size)  # expected dimensions
+```
+
+### `ValueError: Wrong input: Not existing vector name: dense`
+
+Named vector not configured in collection. Check vector names.
+
+```python
+info = client.get_collection("col")
+print(info.config.params.vectors)  # shows configured vector names
+```
+
+## Payload Errors
+
+### `ValueError: Wrong input: Payload type mismatch`
+
+Field was indexed as one type but you're filtering with another. A keyword index expects strings, not integers.
+
+```python
+# Wrong: filtering keyword field with integer
+FieldCondition(key="status", match=MatchValue(value=1))
+
+# Right: use string
+FieldCondition(key="status", match=MatchValue(value="active"))
+```
+
+### `ValueError: Field 'X' has no text index`
+
+Full-text search requires a text index on the field.
+
+```python
+client.create_payload_index("col", "description",
+    field_schema=PayloadSchemaType.TEXT)
+```
+
+## Search Errors
+
+### `AttributeError: 'QdrantClient' has no attribute 'search'`
+
+Using removed method. `search()` was removed in qdrant-client 2.x.
+
+```python
+# Old (removed)
+client.search("col", query_vector=vec)
+
+# New
+client.query_points("col", query=vec)
+```
+
+### `TypeError: query_points() got unexpected keyword argument 'query_vector'`
+
+Parameter renamed. Use `query=` not `query_vector=`.
+
+## Upload Errors
+
+### `ValueError: Batch size too large`
+
+Reduce batch size. Each batch is sent as a single request.
+
+```python
+client.upload_points("col", points, batch_size=256)  # smaller batches
+```
+
+### `grpc._channel._InactiveRpcError` (when using gRPC)
+
+gRPC channel issues. Common with long-running uploads. Use `prefer_grpc=False` (REST) for reliability, or handle reconnection.
+
+## Distance Errors
+
+### Trying to change distance metric
+
+Distance is immutable after collection creation. You must recreate.
+
+```python
+# Cannot update distance. Must delete and recreate.
+client.delete_collection("col")
+client.create_collection("col", vectors_config=VectorParams(
+    size=768, distance=Distance.EUCLID))  # new distance
+```

--- a/skills/qdrant-python/references/data-ingestion.md
+++ b/skills/qdrant-python/references/data-ingestion.md
@@ -1,0 +1,145 @@
+# Data Ingestion Best Practices
+
+Patterns for uploading data efficiently into Qdrant.
+
+## Use `upload_points` for Bulk Inserts
+
+Never call `upsert` in a loop. Use the batch upload method:
+
+```python
+from qdrant_client.models import PointStruct
+
+points = [
+    PointStruct(id=i, vector=vectors[i], payload=payloads[i])
+    for i in range(len(vectors))
+]
+
+# Good: single call with batching
+client.upload_points("col", points, batch_size=256)
+
+# Bad: one-by-one upsert loop
+for p in points:
+    client.upsert("col", points=[p])  # extremely slow
+```
+
+## Optimal Batch Sizes
+
+| Dataset size | Recommended batch_size | Notes |
+|-------------|----------------------|-------|
+| < 10k points | 256-512 | Default is fine |
+| 10k-100k points | 256 | Balanced speed and memory |
+| 100k-1M points | 128-256 | Monitor server memory |
+| > 1M points | 64-128 | Smaller batches, parallel workers |
+
+The right batch size depends on vector dimensions and payload size. Larger vectors need smaller batches to stay under gRPC/HTTP message limits.
+
+## Parallel Upload
+
+For large datasets, use multiple workers:
+
+```python
+import multiprocessing
+from qdrant_client import QdrantClient
+from qdrant_client.models import PointStruct
+
+def upload_chunk(chunk):
+    client = QdrantClient("localhost", port=6333)
+    client.upload_points("col", chunk, batch_size=256)
+
+# Split points into chunks
+chunks = [points[i::4] for i in range(4)]
+
+with multiprocessing.Pool(4) as pool:
+    pool.map(upload_chunk, chunks)
+```
+
+Each worker needs its own client instance (connections are not thread-safe for upload).
+
+## Create Indexes Before Upload
+
+Always create payload indexes before bulk upload. Adding indexes after triggers a full re-index of existing data:
+
+```python
+# Step 1: Create collection
+client.create_collection("col", vectors_config=VectorParams(size=768, distance=Distance.COSINE))
+
+# Step 2: Create payload indexes BEFORE upload
+client.create_payload_index("col", "category", field_schema=PayloadSchemaType.KEYWORD)
+client.create_payload_index("col", "price", field_schema=PayloadSchemaType.FLOAT)
+client.create_payload_index("col", "tenant_id", field_schema=PayloadSchemaType.KEYWORD, is_tenant=True)
+
+# Step 3: Upload data
+client.upload_points("col", points, batch_size=256)
+```
+
+## Write Ordering
+
+For most use cases, default ordering (weak) is fine. Use strong ordering only when you need immediate consistency:
+
+```python
+from qdrant_client.models import WriteOrdering, WriteOrderingType
+
+# Default (weak): fastest, eventually consistent
+client.upsert("col", points)
+
+# Strong: waits for WAL write on all replicas
+client.upsert("col", points, ordering=WriteOrdering(type=WriteOrderingType.STRONG))
+```
+
+## Retry Pattern
+
+Network errors during bulk upload are common. Wrap uploads with retry logic:
+
+```python
+import time
+
+def upload_with_retry(client, collection, points, max_retries=3):
+    for attempt in range(max_retries):
+        try:
+            client.upload_points(collection, points, batch_size=256)
+            return
+        except Exception as e:
+            if attempt == max_retries - 1:
+                raise
+            print(f"upload failed (attempt {attempt + 1}): {e}")
+            time.sleep(2 ** attempt)
+```
+
+## Streaming Large Datasets
+
+For datasets that don't fit in memory, use generators:
+
+```python
+def read_points(file_path):
+    """Yield PointStruct one at a time from a large file."""
+    with open(file_path) as f:
+        for i, line in enumerate(f):
+            data = json.loads(line)
+            yield PointStruct(
+                id=i,
+                vector=data["vector"],
+                payload=data["metadata"],
+            )
+
+# upload_points accepts iterables, not just lists
+client.upload_points("col", read_points("data.jsonl"), batch_size=256)
+```
+
+## Disable Indexing During Bulk Upload
+
+For very large imports (millions of points), temporarily disable indexing to speed up upload, then re-enable:
+
+```python
+from qdrant_client.models import OptimizersConfigDiff
+
+# Disable indexing (set very high threshold)
+client.update_collection("col",
+    optimizer_config=OptimizersConfigDiff(indexing_threshold=0))
+
+# Upload all data
+client.upload_points("col", points, batch_size=256)
+
+# Re-enable indexing (default threshold is 20000)
+client.update_collection("col",
+    optimizer_config=OptimizersConfigDiff(indexing_threshold=20000))
+```

--- a/skills/qdrant-python/references/fastembed.md
+++ b/skills/qdrant-python/references/fastembed.md
@@ -1,0 +1,140 @@
+# FastEmbed Integration
+
+FastEmbed is Qdrant's lightweight Python embedding library. Small, fast, and runs locally with no GPU required.
+
+## Installation
+
+```bash
+pip install fastembed
+# or with qdrant-client (includes fastembed)
+pip install qdrant-client[fastembed]
+```
+
+## Quick Start
+
+```python
+from fastembed import TextEmbedding
+
+model = TextEmbedding("BAAI/bge-small-en-v1.5")
+
+documents = ["Hello world", "Vector databases are great"]
+embeddings = list(model.embed(documents))
+# embeddings[0].shape -> (384,)
+```
+
+## Available Models
+
+| Model | Dimensions | Speed | Quality |
+|-------|-----------|-------|---------|
+| `BAAI/bge-small-en-v1.5` | 384 | Fast | Good |
+| `BAAI/bge-base-en-v1.5` | 768 | Medium | Better |
+| `BAAI/bge-large-en-v1.5` | 1024 | Slower | Best |
+| `sentence-transformers/all-MiniLM-L6-v2` | 384 | Fast | Good |
+| `nomic-ai/nomic-embed-text-v1.5` | 768 | Medium | Better |
+
+List all supported models:
+
+```python
+from fastembed import TextEmbedding
+print(TextEmbedding.list_supported_models())
+```
+
+## Batch Encoding
+
+```python
+model = TextEmbedding("BAAI/bge-small-en-v1.5")
+
+# embed() returns a generator, wrap in list() if you need all at once
+documents = ["doc1", "doc2", "doc3", ...]
+embeddings = list(model.embed(documents, batch_size=256))
+```
+
+## With Qdrant Client (Built-in Integration)
+
+The qdrant-client has built-in FastEmbed support if you installed with `[fastembed]`:
+
+```python
+from qdrant_client import QdrantClient
+
+client = QdrantClient("localhost", port=6333)
+
+# Set default embedding model on the client
+client.set_model("BAAI/bge-small-en-v1.5")
+
+# Add documents directly (embedding happens automatically)
+client.add("col", documents=["Hello world", "Vector search"], ids=[1, 2])
+
+# Query with text (embedding happens automatically)
+results = client.query("col", query_text="search query", limit=5)
+```
+
+## Manual Integration with upload_points
+
+```python
+from fastembed import TextEmbedding
+from qdrant_client import QdrantClient
+from qdrant_client.models import PointStruct, VectorParams, Distance
+
+model = TextEmbedding("BAAI/bge-small-en-v1.5")
+client = QdrantClient("localhost", port=6333)
+
+# Create collection matching model dimensions
+client.create_collection("docs", vectors_config=VectorParams(
+    size=384,  # bge-small-en-v1.5 output dim
+    distance=Distance.COSINE,
+))
+
+# Encode and upload
+documents = ["doc1 text", "doc2 text", "doc3 text"]
+embeddings = list(model.embed(documents))
+
+points = [
+    PointStruct(id=i, vector=emb.tolist(), payload={"text": doc})
+    for i, (emb, doc) in enumerate(zip(embeddings, documents))
+]
+
+client.upload_points("docs", points, batch_size=256)
+```
+
+## Sparse Embeddings (for Hybrid Search)
+
+```python
+from fastembed import SparseTextEmbedding
+
+sparse_model = SparseTextEmbedding("Qdrant/bm25")
+
+documents = ["Hello world", "Vector databases"]
+sparse_embeddings = list(sparse_model.embed(documents))
+
+# Each sparse embedding has .indices and .values
+for emb in sparse_embeddings:
+    print(emb.indices, emb.values)
+```
+
+## Image Embeddings
+
+```python
+from fastembed import ImageEmbedding
+
+model = ImageEmbedding("Qdrant/clip-ViT-B-32-vision")
+embeddings = list(model.embed(["image1.jpg", "image2.png"]))
+```
+
+## Late Interaction (ColBERT)
+
+```python
+from fastembed import LateInteractionTextEmbedding
+
+model = LateInteractionTextEmbedding("colbert-ir/colbertv2.0")
+embeddings = list(model.embed(["document text"]))
+# Returns token-level embeddings (matrix per document)
+```
+
+## Key Points
+
+- Models are downloaded on first use and cached locally
+- CPU-only by default (no GPU needed)
+- ONNX runtime for fast inference
+- Thread-safe for batch encoding
+- `embed()` returns a generator for memory efficiency
+- Works in AWS Lambda and other serverless environments

--- a/skills/qdrant-python/references/filtering.md
+++ b/skills/qdrant-python/references/filtering.md
@@ -1,0 +1,192 @@
+# Filtering Reference
+
+Complete reference for Qdrant filter conditions in the Python SDK.
+
+## Filter Structure
+
+Filters combine conditions with boolean logic:
+
+```python
+from qdrant_client.models import Filter, FieldCondition, MatchValue, Range
+
+query_filter = Filter(
+    must=[...],        # AND: all conditions must match
+    should=[...],      # OR: at least one must match
+    must_not=[...],    # NOT: none can match
+)
+```
+
+## Match Conditions
+
+### Exact match (keyword/integer)
+
+```python
+FieldCondition(key="city", match=MatchValue(value="Berlin"))
+```
+
+### Match any (IN)
+
+```python
+FieldCondition(key="color", match=MatchAny(any=["red", "blue", "green"]))
+```
+
+### Match except (NOT IN)
+
+```python
+FieldCondition(key="status", match=MatchExcept(except_=["deleted", "archived"]))
+```
+
+### Full-text match
+
+```python
+FieldCondition(key="description", match=MatchText(text="vector database"))
+```
+
+Requires a `text` payload index on the field.
+
+## Range Conditions
+
+```python
+FieldCondition(key="price", range=Range(gte=10.0, lte=100.0))
+FieldCondition(key="count", range=Range(gt=0))
+```
+
+Available operators: `gt`, `gte`, `lt`, `lte`.
+
+## Datetime Filtering
+
+```python
+FieldCondition(
+    key="created_at",
+    range=DatetimeRange(
+        gte="2024-01-01T00:00:00Z",
+        lt="2025-01-01T00:00:00Z",
+    ),
+)
+```
+
+Requires a `datetime` payload index.
+
+## Geo Conditions
+
+### Bounding box
+
+```python
+FieldCondition(
+    key="location",
+    geo_bounding_box=GeoBoundingBox(
+        top_left=GeoPoint(lat=52.52, lon=13.35),
+        bottom_right=GeoPoint(lat=52.50, lon=13.45),
+    ),
+)
+```
+
+### Radius
+
+```python
+FieldCondition(
+    key="location",
+    geo_radius=GeoRadius(
+        center=GeoPoint(lat=52.52, lon=13.405),
+        radius=1000.0,  # meters
+    ),
+)
+```
+
+### Polygon
+
+```python
+FieldCondition(
+    key="location",
+    geo_polygon=GeoPolygon(
+        exterior=GeoLineString(points=[
+            GeoPoint(lat=52.52, lon=13.35),
+            GeoPoint(lat=52.52, lon=13.45),
+            GeoPoint(lat=52.50, lon=13.45),
+            GeoPoint(lat=52.50, lon=13.35),
+            GeoPoint(lat=52.52, lon=13.35),  # close the polygon
+        ]),
+    ),
+)
+```
+
+## Nested Filters
+
+Filter on nested object fields using dot notation:
+
+```python
+FieldCondition(key="address.city", match=MatchValue(value="Berlin"))
+```
+
+For arrays of objects, use `nested`:
+
+```python
+from qdrant_client.models import NestedCondition, Nested
+
+Filter(must=[
+    NestedCondition(
+        nested=Nested(
+            key="reviews",
+            filter=Filter(must=[
+                FieldCondition(key="reviews[].score", range=Range(gte=4)),
+                FieldCondition(key="reviews[].verified", match=MatchValue(value=True)),
+            ]),
+        )
+    )
+])
+```
+
+## Null and Empty Checks
+
+### Field exists (is not null)
+
+```python
+from qdrant_client.models import IsNullCondition, PayloadField
+
+Filter(must_not=[
+    IsNullCondition(is_null=PayloadField(key="email"))
+])
+```
+
+### Field is empty (empty array)
+
+```python
+from qdrant_client.models import IsEmptyCondition
+
+Filter(must_not=[
+    IsEmptyCondition(is_empty=PayloadField(key="tags"))
+])
+```
+
+## Has ID Filter
+
+Filter by point IDs:
+
+```python
+from qdrant_client.models import HasIdCondition
+
+Filter(must=[
+    HasIdCondition(has_id=[1, 2, 3])
+])
+```
+
+## Combining Filters
+
+Nested boolean logic:
+
+```python
+Filter(
+    must=[
+        FieldCondition(key="category", match=MatchValue(value="electronics")),
+    ],
+    should=[
+        FieldCondition(key="brand", match=MatchValue(value="Apple")),
+        FieldCondition(key="brand", match=MatchValue(value="Samsung")),
+    ],
+    must_not=[
+        FieldCondition(key="discontinued", match=MatchValue(value=True)),
+    ],
+)
+```
+
+This matches: category IS electronics AND (brand IS Apple OR brand IS Samsung) AND discontinued IS NOT true.

--- a/skills/qdrant-python/references/migration-guide.md
+++ b/skills/qdrant-python/references/migration-guide.md
@@ -1,0 +1,92 @@
+# Migration Guide: Old API to New API
+
+Complete mapping of deprecated `qdrant-client` methods to their current replacements.
+
+## Search Methods
+
+| Old (removed) | New | Notes |
+|---------------|-----|-------|
+| `client.search(collection, query_vector=vec)` | `client.query_points(collection, query=vec)` | Direct replacement |
+| `client.search(collection, query_vector=("dense", vec))` | `client.query_points(collection, query=vec, using="dense")` | Named vectors |
+| `client.search_batch(collection, requests)` | `client.query_batch_points(collection, requests)` | Batch search |
+| `client.search_groups(collection, ...)` | `client.query_points_groups(collection, ...)` | Grouped search |
+
+## Recommend Methods
+
+| Old (removed) | New | Notes |
+|---------------|-----|-------|
+| `client.recommend(collection, positive=[id1], negative=[id2])` | `client.query_points(collection, query=RecommendQuery(positive=[id1], negative=[id2]))` | Use RecommendQuery |
+| `client.recommend_batch(...)` | `client.query_batch_points(...)` with RecommendQuery | Batch recommend |
+| `client.recommend_groups(...)` | `client.query_points_groups(...)` with RecommendQuery | Grouped recommend |
+
+## Discovery Methods
+
+| Old (removed) | New | Notes |
+|---------------|-----|-------|
+| `client.discover(collection, target=id, context=pairs)` | `client.query_points(collection, query=DiscoverQuery(target=id, context=pairs))` | Use DiscoverQuery |
+| `client.discover_batch(...)` | `client.query_batch_points(...)` with DiscoverQuery | Batch discover |
+
+## Parameter Mapping
+
+| Old parameter | New parameter | On |
+|--------------|---------------|-----|
+| `query_vector` | `query` | `query_points` |
+| `append_payload` | `with_payload` | `query_points` |
+| `with_vectors` | `with_vectors` | Unchanged |
+| `score_threshold` | `score_threshold` | Unchanged |
+| `search_params` | `search_params` | Unchanged |
+
+## Filter Parameter
+
+The filter parameter name changed:
+
+```python
+# Old
+client.search("col", query_vector=vec, query_filter=my_filter)
+
+# New (same name, still query_filter)
+client.query_points("col", query=vec, query_filter=my_filter)
+```
+
+## Hybrid Search Migration
+
+```python
+# Old: separate search calls + manual fusion
+results_dense = client.search("col", query_vector=("dense", dense_vec))
+results_sparse = client.search("col", query_vector=("sparse", sparse_vec))
+# manual RRF...
+
+# New: single query with prefetch
+client.query_points("col",
+    prefetch=[
+        Prefetch(query=dense_vec, using="dense", limit=20),
+        Prefetch(query=sparse_vec, using="sparse", limit=20),
+    ],
+    query=FusionQuery(fusion=Fusion.RRF),
+    limit=10,
+)
+```
+
+## Scroll (unchanged)
+
+`client.scroll()` is unchanged. It was never deprecated.
+
+## Point Operations (unchanged)
+
+These methods have not changed:
+- `client.upsert()`
+- `client.upload_points()`
+- `client.delete()`
+- `client.set_payload()`
+- `client.overwrite_payload()`
+- `client.delete_payload()`
+- `client.get_points()`
+
+## Collection Operations (unchanged)
+
+These methods have not changed:
+- `client.create_collection()`
+- `client.delete_collection()`
+- `client.update_collection()`
+- `client.get_collection()`
+- `client.get_collections()`

--- a/skills/qdrant-rust/AGENTS.md
+++ b/skills/qdrant-rust/AGENTS.md
@@ -1,103 +1,70 @@
----
-name: qdrant-rust
-description: "Best practices for the Qdrant Rust client (qdrant-client crate). Use when writing Rust code that uses qdrant-client. Covers client setup, query, filtering, upsert, and common gotchas."
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
----
-
 # Qdrant Rust Client
 
-You interact with Qdrant over gRPC using the `qdrant-client` crate.
+Uses gRPC (port 6334, not REST 6333) via the `qdrant-client` crate. All methods are async (tokio).
 
 ## Setup
 
-```bash
-cargo add qdrant-client anyhow tonic tokio serde-json --features tokio/rt-multi-thread
-```
-
 ```rust
 use qdrant_client::Qdrant;
-
-// Local
 let client = Qdrant::from_url("http://localhost:6334").build()?;
-
-// Cloud
-let client = Qdrant::from_url("https://xyz.cloud.qdrant.io:6334")
-    .api_key(std::env::var("QDRANT_API_KEY"))
-    .build()?;
+// cloud: .api_key(std::env::var("QDRANT_API_KEY")).build()?
 ```
 
-## Decision Table
+## Quick Reference
 
-| Want to... | Do |
-|-----------|-----|
-| Create a collection | `client.create_collection(CreateCollectionBuilder::new("col").vectors_config(VectorParamsBuilder::new(768, Distance::Cosine)))` |
-| Upsert points | `client.upsert_points(UpsertPointsBuilder::new("col", vec![PointStruct::new(1, vec![0.1, 0.2, ...], json!({"key": "val"}).try_into().unwrap())]))` |
-| Query by vector | `client.query(QueryPointsBuilder::new("col").query(vec![0.2, 0.1, 0.9]))` |
-| Query with filter | Add `.filter(Filter::must([Condition::matches("field", "value".to_string())]))` |
-| Query with payload | Add `.with_payload(true)` to `QueryPointsBuilder` |
-| List collections | `client.list_collections()` |
-| Get collection info | `client.collection_info("col")` |
-| Scroll points | `client.scroll(ScrollPointsBuilder::new("col").limit(100))` |
-| Delete points | `client.delete_points(DeletePointsBuilder::new("col").points(vec![0.into(), 1.into()]))` |
-| Create payload index | `client.create_field_index(CreateFieldIndexCollectionBuilder::new("col", "field", FieldType::Keyword))` |
+| Operation | Code |
+|-----------|------|
+| Create collection | `client.create_collection(CreateCollectionBuilder::new("col").vectors_config(VectorParamsBuilder::new(768, Distance::Cosine)))` |
+| Upsert | `client.upsert_points(UpsertPointsBuilder::new("col", points))` |
+| Query | `client.query(QueryPointsBuilder::new("col").query(vec![0.2, 0.1, 0.9]))` |
+| Filter | `.filter(Filter::must([Condition::matches("field", "value".to_string())]))` |
+| With payload | `.with_payload(true)` |
+| Scroll | `client.scroll(ScrollPointsBuilder::new("col").limit(100))` |
+| Delete | `client.delete_points(DeletePointsBuilder::new("col").points(vec![0.into()]))` |
+| Payload index | `client.create_field_index(CreateFieldIndexCollectionBuilder::new("col", "field", FieldType::Keyword))` |
 
-## Query with Filter
+Payload from JSON: `json!({"k": "v"}).try_into().unwrap()`
+
+| Recommend | `Query::new_recommend(RecommendInput { positive: vec![id.into()], negative: vec![], ..Default::default() })` |
+| Set payload | `client.set_payload(SetPayloadPointsBuilder::new("col", payload).points_selector(vec![id.into()]))` |
+| Delete payload keys | `client.delete_payload(DeletePayloadPointsBuilder::new("col", vec!["key".into()]).points_selector(...))` |
+| Snapshot | `client.create_snapshot(CreateSnapshotRequestBuilder::new("col"))`, `client.list_snapshots("col")` |
+| Alias | `client.create_alias("alias", "col")`, `client.delete_alias("alias")` |
+| Update collection | `client.update_collection(UpdateCollectionBuilder::new("col").optimizers_config(...))` |
+
+## Hybrid Search (RRF)
+
+Use `add_prefetch` with dense + sparse queries, then `Query::new_fusion(Fusion::Rrf)`:
 
 ```rust
-use qdrant_client::qdrant::{Condition, Filter, QueryPointsBuilder};
-
-let results = client
-    .query(
-        QueryPointsBuilder::new("products")
-            .query(vec![0.2, 0.1, 0.9, 0.7])
-            .filter(Filter::must([Condition::matches(
-                "category",
-                "electronics".to_string(),
-            )]))
-            .with_payload(true)
-            .limit(10),
-    )
-    .await?;
+client.query(QueryPointsBuilder::new("col")
+    .add_prefetch(PrefetchQueryBuilder::default().query(Query::new_nearest(dense_vec)).using("dense").limit(20u64))
+    .add_prefetch(PrefetchQueryBuilder::default().query(Query::new_nearest(sparse_vec)).using("sparse").limit(20u64))
+    .query(Query::new_fusion(Fusion::Rrf)).limit(10u64)
+).await?;
 ```
 
-## Upsert with Payload
+## Named Vectors
+
+Use `VectorParamsMap` for multiple vector spaces:
 
 ```rust
-use qdrant_client::qdrant::{PointStruct, UpsertPointsBuilder};
-use serde_json::json;
-
-let points = vec![
-    PointStruct::new(
-        1,
-        vec![0.1, 0.2, 0.3],
-        json!({"city": "London", "population": 9_000_000})
-            .try_into()
-            .unwrap(),
-    ),
-];
-
-client
-    .upsert_points(UpsertPointsBuilder::new("col", points).wait(true))
-    .await?;
+let mut vectors = VectorParamsMap::new();
+vectors.insert("image", VectorParamsBuilder::new(512, Distance::Euclid));
+vectors.insert("text", VectorParamsBuilder::new(768, Distance::Cosine));
+client.create_collection(CreateCollectionBuilder::new("col").vectors_config(vectors)).await?;
 ```
 
 ## Gotchas
 
-- **gRPC only**: The Rust client uses gRPC (port 6334), not REST (6333). Make sure gRPC is enabled.
-- **`query` not `search_points`**: Use `client.query(QueryPointsBuilder)` for searches. `search_points` is the older API.
-- **Payload conversion**: Use `json!({...}).try_into().unwrap()` to convert `serde_json::Value` into `Payload`.
-- **Builder pattern everywhere**: All operations use builders (`CreateCollectionBuilder`, `QueryPointsBuilder`, etc.). Don't try to construct structs directly.
-- **`.wait(true)` for consistency**: Upsert/delete return before indexing by default. Add `.wait(true)` if you need to query immediately after.
-- **Never one collection per user**: Use payload index with `is_tenant=true` and filter per query.
-- **Vector size must match**: Every upsert and query must match the collection's configured dimensions.
-- **Distance is immutable**: Delete and recreate the collection to change it.
-- **Async only**: All client methods are async. You need a tokio runtime.
+- gRPC only (port 6334). REST port 6333 won't work with this client.
+- `client.query(QueryPointsBuilder)` not `search_points` (older API).
+- Payload conversion: always `json!({...}).try_into().unwrap()`.
+- Builder pattern everywhere. Don't construct structs directly.
+- `.wait(true)` for read-after-write consistency. Default returns before indexing.
+- Never one collection per user. Use `is_tenant=true` payload index + filter.
+- Vector dims must match collection config on every upsert and query.
+- Distance is immutable. Delete and recreate collection to change.
+- All client methods are async. Requires tokio runtime.
 
-## Read More
-
-- [qdrant-client on crates.io](https://crates.io/crates/qdrant-client)
-- [API docs on docs.rs](https://docs.rs/qdrant-client)
-- [Qdrant Documentation](https://qdrant.tech/documentation/)
+For comprehensive builder API reference, see `references/builders.md`.

--- a/skills/qdrant-rust/SKILL.md
+++ b/skills/qdrant-rust/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: qdrant-rust
 description: "Best practices for the Qdrant Rust client (qdrant-client crate). Use when writing Rust code that uses qdrant-client. Covers client setup, query, filtering, upsert, and common gotchas."
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
+allowed-tools: Read Grep Glob
+license: Apache-2.0
+metadata:
+  author: qdrant
+  version: "1.0"
 ---
 
 # Qdrant Rust Client
@@ -43,6 +44,17 @@ let client = Qdrant::from_url("https://xyz.cloud.qdrant.io:6334")
 | Scroll points | `client.scroll(ScrollPointsBuilder::new("col").limit(100))` |
 | Delete points | `client.delete_points(DeletePointsBuilder::new("col").points(vec![0.into(), 1.into()]))` |
 | Create payload index | `client.create_field_index(CreateFieldIndexCollectionBuilder::new("col", "field", FieldType::Keyword))` |
+| Recommend | `client.query(QueryPointsBuilder::new("col").query(Query::new_recommend(RecommendInput { positive: vec![id.into()], negative: vec![], ... })))` |
+| Discover | `client.query(QueryPointsBuilder::new("col").query(Query::new_discover(DiscoverInput { target, context, ... })))` |
+| Set payload | `client.set_payload(SetPayloadPointsBuilder::new("col", json!({"k": "v"}).try_into().unwrap()).points_selector(vec![0.into()]))` |
+| Delete payload keys | `client.delete_payload(DeletePayloadPointsBuilder::new("col", vec!["key".into()]).points_selector(vec![0.into()]))` |
+| Clear payload | `client.clear_payload(ClearPayloadPointsBuilder::new("col").points_selector(vec![0.into()]))` |
+| Create snapshot | `client.create_snapshot(CreateSnapshotRequestBuilder::new("col"))` |
+| List snapshots | `client.list_snapshots("col")` |
+| Full snapshot | `client.create_full_snapshot()` |
+| Create alias | `client.create_alias("alias", "col")` |
+| Delete alias | `client.delete_alias("alias")` |
+| Update collection | `client.update_collection(UpdateCollectionBuilder::new("col").optimizers_config(OptimizersConfigDiffBuilder::new().indexing_threshold(20000)))` |
 
 ## Query with Filter
 
@@ -84,6 +96,93 @@ client
     .await?;
 ```
 
+## Hybrid Search (Dense + Sparse with RRF)
+
+```rust
+use qdrant_client::qdrant::{
+    PrefetchQueryBuilder, Query, QueryPointsBuilder, Fusion,
+};
+
+let results = client
+    .query(
+        QueryPointsBuilder::new("collection")
+            .add_prefetch(
+                PrefetchQueryBuilder::default()
+                    .query(Query::new_nearest(dense_vec))
+                    .using("dense")
+                    .limit(20u64),
+            )
+            .add_prefetch(
+                PrefetchQueryBuilder::default()
+                    .query(Query::new_nearest(sparse_vec))
+                    .using("sparse")
+                    .limit(20u64),
+            )
+            .query(Query::new_fusion(Fusion::Rrf))
+            .limit(10u64),
+    )
+    .await?;
+```
+
+## Named Vectors
+
+```rust
+use qdrant_client::qdrant::{
+    CreateCollectionBuilder, VectorParamsBuilder, VectorParamsMap, Distance,
+};
+
+let mut vectors = VectorParamsMap::new();
+vectors.insert("image", VectorParamsBuilder::new(512, Distance::Euclid));
+vectors.insert("text", VectorParamsBuilder::new(768, Distance::Cosine));
+
+client
+    .create_collection(CreateCollectionBuilder::new("col").vectors_config(vectors))
+    .await?;
+```
+
+## Recommend (Find Similar)
+
+```rust
+use qdrant_client::qdrant::{Query, RecommendInput};
+
+client.query(
+    QueryPointsBuilder::new("products")
+        .query(Query::new_recommend(RecommendInput {
+            positive: vec![1.into(), 2.into()],
+            negative: vec![3.into()],
+            ..Default::default()
+        }))
+        .limit(10u64),
+).await?;
+```
+
+## Payload Mutation
+
+```rust
+use qdrant_client::qdrant::{SetPayloadPointsBuilder, DeletePayloadPointsBuilder};
+
+// Set payload (merge)
+client.set_payload(
+    SetPayloadPointsBuilder::new("col", json!({"status": "reviewed"}).try_into().unwrap())
+        .points_selector(vec![1.into(), 2.into()])
+        .wait(true),
+).await?;
+
+// Delete specific keys
+client.delete_payload(
+    DeletePayloadPointsBuilder::new("col", vec!["temp_field".into()])
+        .points_selector(vec![1.into()]),
+).await?;
+```
+
+## Collection Aliases
+
+```rust
+// Zero-downtime swap
+client.delete_alias("production").await?;
+client.create_alias("production", "products_v2").await?;
+```
+
 ## Gotchas
 
 - **gRPC only**: The Rust client uses gRPC (port 6334), not REST (6333). Make sure gRPC is enabled.
@@ -101,3 +200,8 @@ client
 - [qdrant-client on crates.io](https://crates.io/crates/qdrant-client)
 - [API docs on docs.rs](https://docs.rs/qdrant-client)
 - [Qdrant Documentation](https://qdrant.tech/documentation/)
+
+## References
+
+- `references/builders.md`: Comprehensive builder API reference
+- `references/advanced-indexing.md`: HNSW tuning, quantization, ColBERT multi-vector config

--- a/skills/qdrant-rust/references/advanced-indexing.md
+++ b/skills/qdrant-rust/references/advanced-indexing.md
@@ -1,0 +1,182 @@
+# Advanced Indexing and Quantization
+
+Tuning HNSW, quantization, and multi-vector configuration in Rust.
+
+## HNSW Parameters
+
+```rust
+use qdrant_client::qdrant::{
+    CreateCollectionBuilder, VectorParamsBuilder, Distance,
+    HnswConfigDiffBuilder,
+};
+
+// At creation
+client.create_collection(
+    CreateCollectionBuilder::new("col")
+        .vectors_config(VectorParamsBuilder::new(768, Distance::Cosine))
+        .hnsw_config(HnswConfigDiffBuilder::default()
+            .m(16)                    // connections per node
+            .ef_construct(100)        // search width during build
+            .full_scan_threshold(10000)),
+).await?;
+
+// Tune after creation
+client.update_collection(
+    UpdateCollectionBuilder::new("col")
+        .hnsw_config(HnswConfigDiffBuilder::default()
+            .m(32)
+            .ef_construct(200)),
+).await?;
+```
+
+### Search-Time ef
+
+```rust
+use qdrant_client::qdrant::SearchParamsBuilder;
+
+client.query(
+    QueryPointsBuilder::new("col")
+        .query(vec![0.2, 0.1, 0.9])
+        .params(SearchParamsBuilder::default().hnsw_ef(128))
+        .limit(10u64),
+).await?;
+```
+
+## Scalar Quantization
+
+4x memory reduction with minimal quality loss:
+
+```rust
+use qdrant_client::qdrant::{QuantizationType, ScalarQuantizationBuilder};
+
+client.create_collection(
+    CreateCollectionBuilder::new("col")
+        .vectors_config(VectorParamsBuilder::new(768, Distance::Cosine))
+        .quantization_config(ScalarQuantizationBuilder::default()
+            .r#type(QuantizationType::Int8.into())
+            .quantile(0.99f32)
+            .always_ram(true)),
+).await?;
+```
+
+## Product Quantization
+
+Higher compression for large datasets:
+
+```rust
+use qdrant_client::qdrant::{ProductQuantizationBuilder, CompressionRatio};
+
+client.create_collection(
+    CreateCollectionBuilder::new("col")
+        .vectors_config(VectorParamsBuilder::new(768, Distance::Cosine))
+        .quantization_config(ProductQuantizationBuilder::default()
+            .compression(CompressionRatio::X16.into())
+            .always_ram(true)),
+).await?;
+```
+
+## Binary Quantization
+
+32x compression, for normalized vectors with Cosine distance only:
+
+```rust
+use qdrant_client::qdrant::BinaryQuantizationBuilder;
+
+client.create_collection(
+    CreateCollectionBuilder::new("col")
+        .vectors_config(VectorParamsBuilder::new(768, Distance::Cosine))
+        .quantization_config(BinaryQuantizationBuilder::default()
+            .always_ram(true)),
+).await?;
+```
+
+## Quantization Search Params
+
+```rust
+use qdrant_client::qdrant::{SearchParamsBuilder, QuantizationSearchParamsBuilder};
+
+client.query(
+    QueryPointsBuilder::new("col")
+        .query(vec![0.2, 0.1, 0.9])
+        .params(SearchParamsBuilder::default()
+            .quantization(QuantizationSearchParamsBuilder::default()
+                .rescore(true)
+                .oversampling(2.0)))
+        .limit(10u64),
+).await?;
+```
+
+## On-Disk Vectors
+
+```rust
+client.create_collection(
+    CreateCollectionBuilder::new("col")
+        .vectors_config(
+            VectorParamsBuilder::new(768, Distance::Cosine)
+                .on_disk(true))
+        .hnsw_config(HnswConfigDiffBuilder::default()
+            .on_disk(true))
+        .quantization_config(ScalarQuantizationBuilder::default()
+            .r#type(QuantizationType::Int8.into())
+            .always_ram(true)),
+).await?;
+```
+
+## Multi-Vector (ColBERT)
+
+```rust
+use qdrant_client::qdrant::{
+    MultiVectorConfig, MultiVectorComparator, VectorParamsBuilder,
+};
+
+// Single multi-vector collection
+client.create_collection(
+    CreateCollectionBuilder::new("col")
+        .vectors_config(
+            VectorParamsBuilder::new(128, Distance::Cosine)
+                .multivector_config(MultiVectorConfig {
+                    comparator: MultiVectorComparator::MaxSim.into(),
+                })),
+).await?;
+
+// Two-stage: dense retrieval + ColBERT reranking
+let mut vectors = VectorParamsMap::new();
+vectors.insert("dense", VectorParamsBuilder::new(768, Distance::Cosine));
+vectors.insert("colbert",
+    VectorParamsBuilder::new(128, Distance::Cosine)
+        .multivector_config(MultiVectorConfig {
+            comparator: MultiVectorComparator::MaxSim.into(),
+        })
+        .hnsw_config(HnswConfigDiffBuilder::default().m(0u64)));  // disable HNSW
+
+client.create_collection(
+    CreateCollectionBuilder::new("col").vectors_config(vectors),
+).await?;
+```
+
+## Optimizer Config
+
+```rust
+use qdrant_client::qdrant::OptimizersConfigDiffBuilder;
+
+client.update_collection(
+    UpdateCollectionBuilder::new("col")
+        .optimizers_config(OptimizersConfigDiffBuilder::default()
+            .indexing_threshold(20000u64)
+            .memmap_threshold(50000u64)
+            .default_segment_number(4u64)
+            .max_optimization_threads(2u64)),
+).await?;
+```
+
+## What's Mutable at Runtime
+
+| Parameter | Mutable | Method |
+|-----------|---------|--------|
+| Distance | No | Recreate collection |
+| Vector size | No | Recreate collection |
+| HNSW `m`, `ef_construct` | Yes | `update_collection` |
+| Quantization | Yes | `update_collection` |
+| Optimizer settings | Yes | `update_collection` |
+| On-disk flag | No | Set at creation |
+| Multi-vector comparator | No | Recreate collection |

--- a/skills/qdrant-rust/references/builders.md
+++ b/skills/qdrant-rust/references/builders.md
@@ -1,0 +1,268 @@
+# Builder API Reference
+
+Comprehensive reference for the Qdrant Rust client builder types.
+
+## Collection Builders
+
+### CreateCollectionBuilder
+
+```rust
+use qdrant_client::qdrant::{
+    CreateCollectionBuilder, Distance, VectorParamsBuilder,
+};
+
+// Single vector
+CreateCollectionBuilder::new("collection")
+    .vectors_config(VectorParamsBuilder::new(768, Distance::Cosine))
+
+// Named vectors
+use qdrant_client::qdrant::VectorParamsMap;
+
+let mut vectors = VectorParamsMap::new();
+vectors.insert("dense", VectorParamsBuilder::new(768, Distance::Cosine));
+vectors.insert("sparse", /* sparse config */);
+
+CreateCollectionBuilder::new("collection")
+    .vectors_config(vectors)
+```
+
+### UpdateCollectionBuilder
+
+```rust
+use qdrant_client::qdrant::UpdateCollectionBuilder;
+
+UpdateCollectionBuilder::new("collection")
+    .optimizers_config(OptimizersConfigDiffBuilder::new()
+        .indexing_threshold(20000))
+```
+
+## Point Builders
+
+### UpsertPointsBuilder
+
+```rust
+use qdrant_client::qdrant::{PointStruct, UpsertPointsBuilder};
+use serde_json::json;
+
+let points = vec![
+    PointStruct::new(
+        1,                           // id: u64 or String
+        vec![0.1, 0.2, 0.3],       // vector
+        json!({"key": "value"})      // payload
+            .try_into().unwrap(),
+    ),
+];
+
+UpsertPointsBuilder::new("collection", points)
+    .wait(true)          // wait for indexing
+    .ordering(WriteOrdering {
+        r#type: WriteOrderingType::Strong as i32,
+    })
+```
+
+### PointStruct constructors
+
+```rust
+// With u64 ID
+PointStruct::new(1, vec![0.1, 0.2], json!({}).try_into().unwrap())
+
+// With string ID
+PointStruct::new("point-uuid", vec![0.1, 0.2], json!({}).try_into().unwrap())
+
+// Named vectors
+use std::collections::HashMap;
+let mut vectors = HashMap::new();
+vectors.insert("dense".to_string(), vec![0.1, 0.2, 0.3]);
+
+PointStruct::new(1, vectors, json!({"key": "val"}).try_into().unwrap())
+```
+
+## Query Builders
+
+### QueryPointsBuilder
+
+```rust
+use qdrant_client::qdrant::QueryPointsBuilder;
+
+QueryPointsBuilder::new("collection")
+    .query(vec![0.2, 0.1, 0.9])    // vector query
+    .filter(filter)                  // optional filter
+    .with_payload(true)              // return payload
+    .with_vectors(true)              // return vectors
+    .limit(10)                       // max results
+    .offset(0)                       // skip N results
+    .score_threshold(0.5)            // min score
+    .using("dense")                  // named vector
+```
+
+### ScrollPointsBuilder
+
+```rust
+use qdrant_client::qdrant::ScrollPointsBuilder;
+
+ScrollPointsBuilder::new("collection")
+    .filter(filter)
+    .limit(100)
+    .offset(PointId::from(0))       // cursor-based
+    .with_payload(true)
+    .with_vectors(true)
+    .order_by(OrderByBuilder::new("timestamp"))
+```
+
+### RecommendPointsBuilder
+
+```rust
+use qdrant_client::qdrant::RecommendPointsBuilder;
+
+RecommendPointsBuilder::new("collection")
+    .add_positive(PointId::from(1))
+    .add_positive(PointId::from(2))
+    .add_negative(PointId::from(3))
+    .limit(10)
+    .filter(filter)
+    .with_payload(true)
+```
+
+## Filter Builders
+
+### Filter
+
+```rust
+use qdrant_client::qdrant::{Condition, Filter};
+
+// Must (AND)
+Filter::must([
+    Condition::matches("field", "value".to_string()),
+])
+
+// Should (OR)
+Filter::should([
+    Condition::matches("color", "red".to_string()),
+    Condition::matches("color", "blue".to_string()),
+])
+
+// Must not (NOT)
+Filter::must_not([
+    Condition::matches("deleted", true),
+])
+
+// Combined
+Filter {
+    must: vec![Condition::matches("type", "doc".to_string()).into()],
+    should: vec![],
+    must_not: vec![Condition::matches("archived", true).into()],
+    min_should: None,
+}
+```
+
+### Condition types
+
+```rust
+// Exact match
+Condition::matches("field", "value".to_string())
+Condition::matches("field", 42_i64)
+Condition::matches("field", true)
+
+// Range
+use qdrant_client::qdrant::Range;
+Condition::range("price", Range {
+    gte: Some(10.0),
+    lte: Some(100.0),
+    ..Default::default()
+})
+
+// Has ID
+Condition::has_id([1, 2, 3])
+
+// Is null
+Condition::is_null("field")
+
+// Is empty
+Condition::is_empty("tags")
+
+// Nested
+Condition::nested("reviews", Filter::must([
+    Condition::range("reviews[].score", Range {
+        gte: Some(4.0),
+        ..Default::default()
+    }),
+]))
+
+// Geo bounding box
+use qdrant_client::qdrant::{GeoBoundingBox, GeoPoint};
+Condition::geo_bounding_box("location", GeoBoundingBox {
+    top_left: Some(GeoPoint { lat: 52.52, lon: 13.35 }),
+    bottom_right: Some(GeoPoint { lat: 52.50, lon: 13.45 }),
+})
+
+// Geo radius
+use qdrant_client::qdrant::GeoRadius;
+Condition::geo_radius("location", GeoRadius {
+    center: Some(GeoPoint { lat: 52.52, lon: 13.405 }),
+    radius: 1000.0,
+})
+```
+
+## Delete Builders
+
+### DeletePointsBuilder
+
+```rust
+use qdrant_client::qdrant::DeletePointsBuilder;
+
+// By IDs
+DeletePointsBuilder::new("collection")
+    .points(vec![0.into(), 1.into()])
+    .wait(true)
+
+// By filter
+DeletePointsBuilder::new("collection")
+    .points(Filter::must([
+        Condition::matches("status", "expired".to_string()),
+    ]))
+    .wait(true)
+```
+
+## Index Builders
+
+### CreateFieldIndexCollectionBuilder
+
+```rust
+use qdrant_client::qdrant::{CreateFieldIndexCollectionBuilder, FieldType};
+
+// Keyword index
+CreateFieldIndexCollectionBuilder::new("collection", "category", FieldType::Keyword)
+
+// Integer index
+CreateFieldIndexCollectionBuilder::new("collection", "count", FieldType::Integer)
+
+// Float index
+CreateFieldIndexCollectionBuilder::new("collection", "price", FieldType::Float)
+
+// Geo index
+CreateFieldIndexCollectionBuilder::new("collection", "location", FieldType::Geo)
+
+// Datetime index
+CreateFieldIndexCollectionBuilder::new("collection", "created_at", FieldType::Datetime)
+
+// Text (full-text) index
+CreateFieldIndexCollectionBuilder::new("collection", "description", FieldType::Text)
+
+// Tenant index
+CreateFieldIndexCollectionBuilder::new("collection", "tenant_id", FieldType::Keyword)
+    .is_tenant(true)
+```
+
+## Snapshot Builders
+
+### CreateSnapshotBuilder
+
+```rust
+use qdrant_client::qdrant::CreateSnapshotRequestBuilder;
+
+// Collection snapshot
+client.create_snapshot(CreateSnapshotRequestBuilder::new("collection")).await?;
+
+// Full storage snapshot
+client.create_full_snapshot().await?;
+```

--- a/skills/qdrant-typescript/AGENTS.md
+++ b/skills/qdrant-typescript/AGENTS.md
@@ -1,0 +1,41 @@
+# Qdrant TypeScript/JavaScript SDK
+
+Use `@qdrant/js-client-rest` (REST, port 6333). Filters are plain JS objects, no model imports needed.
+
+## Quick Reference
+
+| Operation | Code |
+|-----------|------|
+| Create collection | `client.createCollection('col', { vectors: { size: N, distance: 'Cosine' } })` |
+| Upsert | `client.upsert('col', { points: [{ id: 1, vector: [...], payload: {...} }] })` |
+| Query (preferred) | `client.query('col', { query: vector, limit: 10 })` |
+| Filter query | add `filter: { must: [{ key: k, match: { value: v } }] }` |
+| Hybrid (RRF) | `prefetch: [{ query: dense, using: 'dense', limit: 20 }, { query: sparse, using: 'sparse', limit: 20 }]`, `query: { fusion: 'rrf' }` |
+| MMR | `query: { nearest: vec, mmr: { diversity: 0.5 } }` |
+| Scroll | `client.scroll('col', { limit: 100 })` returns `{ points, next_page_offset }` |
+| Payload index | `client.createPayloadIndex('col', { field_name: 'f', field_schema: 'keyword' })` |
+| Multi-tenant | `field_schema: { type: 'keyword', is_tenant: true }` + filter per query |
+| Named vectors | `vectors: { image: { size: 4, distance: 'Dot' } }`, query with `using: 'image'` |
+| Recommend | `query: { recommend: { positive: [id1], negative: [id2] } }` |
+| Discover | `query: { discover: { target: id, context: [{ positive: p, negative: n }] } }` |
+| Set payload | `client.setPayload('col', { payload: {...}, points: [id] })` |
+| Delete payload keys | `client.deletePayload('col', { keys: ['k'], points: [id] })` |
+| Snapshot | `client.createSnapshot('col')`, `client.listSnapshots('col')` |
+| Alias (swap) | `client.updateCollectionAliases({ actions: [{ delete_alias: ... }, { create_alias: ... }] })` |
+| Update collection | `client.updateCollection('col', { optimizers_config: { indexing_threshold: 20000 } })` |
+
+## Gotchas
+
+- `query()` not `query_points()`. Method name differs from Python.
+- `search()` still exists but `query()` is the modern API. Prefer `query()`.
+- No model classes. Filters are plain objects: `{ must: [{ key: k, match: { value: v } }] }`.
+- No `upload_points`. Only `upsert()`. Batch manually for bulk.
+- Distance values are strings: `'Cosine'`, `'Euclid'`, `'Dot'`, `'Manhattan'`.
+- REST client (port 6333), not gRPC. Separate `@qdrant/js-client-grpc` exists.
+- `upsert` defaults `wait: true`. Writes block until indexed.
+- Scroll returns object `{ points, next_page_offset }`, not a tuple.
+- `prefetch` accepts object (pipeline) or array (fusion). Array for hybrid search.
+- Constructor rejects both `url` and `host` together. Pick one.
+- Never one collection per user. Use `is_tenant: true` payload index.
+- Vector dims must match collection config on every upsert and query.
+- Distance is immutable. Delete and recreate collection to change.

--- a/skills/qdrant-typescript/SKILL.md
+++ b/skills/qdrant-typescript/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: qdrant-typescript
+description: "Best practices for the Qdrant TypeScript/JavaScript SDK (@qdrant/js-client-rest). Use when writing TS/JS code that uses Qdrant. Covers query, filtering, hybrid search, multi-tenancy, and common gotchas."
+allowed-tools: Read Grep Glob
+license: Apache-2.0
+metadata:
+  author: qdrant
+  version: "1.0"
+---
+
+# Qdrant TypeScript/JavaScript Client
+
+You interact with Qdrant over REST using `@qdrant/js-client-rest`.
+
+## Setup
+
+```bash
+pnpm i @qdrant/js-client-rest
+```
+
+```typescript
+import { QdrantClient } from '@qdrant/js-client-rest';
+
+// Local
+const client = new QdrantClient({ url: 'http://127.0.0.1:6333' });
+
+// Cloud
+const client = new QdrantClient({
+    url: 'https://xyz.cloud.qdrant.io',
+    apiKey: process.env.QDRANT_API_KEY,
+});
+```
+
+## Decision Table
+
+| Want to... | Do |
+|-----------|-----|
+| Create a collection | `client.createCollection('col', { vectors: { size: 768, distance: 'Cosine' } })` |
+| Upsert points | `client.upsert('col', { points: [{ id: 1, vector: [...], payload: {...} }] })` |
+| Search (modern) | `client.query('col', { query: vector, limit: 10 })` |
+| Search with filter | Add `filter: { must: [{ key: 'field', match: { value: 'x' } }] }` |
+| Hybrid search (RRF) | Use `prefetch` array with dense + sparse, `query: { fusion: 'rrf' }` |
+| MMR diversity | `query: { nearest: vector, mmr: { diversity: 0.5 } }` |
+| Scroll all points | `client.scroll('col', { limit: 100 })` returns `{ points, next_page_offset }` |
+| Create payload index | `client.createPayloadIndex('col', { field_name: 'f', field_schema: 'keyword' })` |
+| Multi-tenant | `field_schema: { type: 'keyword', is_tenant: true }` + filter per query |
+| Named vectors | `vectors: { image: { size: 4, distance: 'Dot' }, text: { size: 8, distance: 'Cosine' } }` |
+| Recommend | `client.query('col', { query: { recommend: { positive: [1, 2], negative: [3] } }, limit: 10 })` |
+| Discover | `client.query('col', { query: { discover: { target: 1, context: [{ positive: 2, negative: 3 }] } }, limit: 10 })` |
+| Set payload | `client.setPayload('col', { payload: { key: 'val' }, points: [1, 2] })` |
+| Overwrite payload | `client.overwritePayload('col', { payload: { key: 'val' }, points: [1] })` |
+| Delete payload keys | `client.deletePayload('col', { keys: ['key1'], points: [1] })` |
+| Clear payload | `client.clearPayload('col', { points: [1] })` |
+| Create snapshot | `client.createSnapshot('col')` |
+| List snapshots | `client.listSnapshots('col')` |
+| Create alias | `client.updateCollectionAliases({ actions: [{ create_alias: { collection_name: 'col', alias_name: 'alias' } }] })` |
+| Switch alias | Combine `delete_alias` + `create_alias` in one `actions` array |
+| Update collection | `client.updateCollection('col', { optimizers_config: { indexing_threshold: 20000 } })` |
+
+## Query with Filter
+
+```typescript
+client.query('my_collection', {
+    query: [0.2, 0.1, 0.9, 0.7],
+    filter: {
+        must: [{ key: 'category', match: { value: 'electronics' } }],
+    },
+    with_payload: true,
+    limit: 10,
+});
+```
+
+## Hybrid Search (Dense + Sparse with RRF)
+
+```typescript
+client.query('my_collection', {
+    prefetch: [
+        {
+            query: { values: [0.22, 0.8], indices: [1, 42] },
+            using: 'sparse',
+            limit: 20,
+        },
+        {
+            query: [0.01, 0.45, 0.67],
+            using: 'dense',
+            limit: 20,
+        },
+    ],
+    query: { fusion: 'rrf' },
+    limit: 10,
+});
+```
+
+## Named Vectors
+
+```typescript
+// Create
+client.createCollection('col', {
+    vectors: {
+        image: { size: 4, distance: 'Dot' },
+        text: { size: 8, distance: 'Cosine' },
+    },
+    sparse_vectors: { text_sparse: {} },
+});
+
+// Upsert
+client.upsert('col', {
+    points: [{
+        id: 1,
+        vector: {
+            image: [0.9, 0.1, 0.1, 0.2],
+            text: [0.4, 0.7, 0.1, 0.8, 0.1, 0.1, 0.9, 0.2],
+            text_sparse: { indices: [6, 7], values: [1.0, 2.0] },
+        },
+    }],
+});
+
+// Query specific vector
+client.query('col', { query: [0.2, 0.1, 0.9], using: 'image', limit: 10 });
+```
+
+## Filtering (Plain Objects)
+
+```typescript
+// Match exact
+{ key: 'city', match: { value: 'Berlin' } }
+
+// Match any (IN)
+{ key: 'color', match: { any: ['red', 'blue'] } }
+
+// Match except (NOT IN)
+{ key: 'color', match: { except: ['black'] } }
+
+// Range
+{ key: 'price', range: { gte: 10.0, lte: 100.0 } }
+
+// Full-text (requires text index)
+{ key: 'description', match: { text: 'vector database' } }
+
+// Geo radius
+{ key: 'location', geo_radius: { center: { lat: 52.52, lon: 13.40 }, radius: 1000.0 } }
+
+// Nested object
+{ nested: { key: 'reviews', filter: { must: [{ key: 'score', range: { gte: 4 } }] } } }
+
+// Null / empty checks
+{ is_null: { key: 'email' } }
+{ is_empty: { key: 'tags' } }
+
+// Has ID
+{ has_id: [1, 3, 5] }
+```
+
+## Multi-Tenancy
+
+```typescript
+// Create tenant index
+client.createPayloadIndex('col', {
+    field_name: 'group_id',
+    field_schema: { type: 'keyword', is_tenant: true },
+});
+
+// Query with tenant filter
+client.query('col', {
+    query: [0.1, 0.1, 0.9],
+    filter: { must: [{ key: 'group_id', match: { value: 'user_1' } }] },
+    limit: 10,
+});
+```
+
+## Recommend (Find Similar)
+
+```typescript
+client.query('products', {
+    query: { recommend: { positive: [1, 2], negative: [3] } },
+    limit: 10,
+});
+```
+
+## Discover (Constrained Exploration)
+
+```typescript
+client.query('products', {
+    query: { discover: { target: 42, context: [{ positive: 1, negative: 2 }] } },
+    limit: 10,
+});
+```
+
+## Payload Mutation
+
+```typescript
+// Set (merge keys)
+client.setPayload('col', { payload: { status: 'reviewed' }, points: [1, 2, 3] });
+
+// Overwrite (replace entire payload)
+client.overwritePayload('col', { payload: { status: 'clean' }, points: [1] });
+
+// Delete specific keys
+client.deletePayload('col', { keys: ['temp_field'], points: [1, 2] });
+
+// Clear all payload
+client.clearPayload('col', { points: [1] });
+```
+
+## Collection Aliases
+
+```typescript
+// Zero-downtime swap
+client.updateCollectionAliases({
+    actions: [
+        { delete_alias: { alias_name: 'production' } },
+        { create_alias: { collection_name: 'products_v2', alias_name: 'production' } },
+    ],
+});
+```
+
+## Gotchas
+
+- **`search()` still exists but prefer `query()`**: Unlike Python where `search` was removed, the JS client has both. `query()` is the modern unified API.
+- **`query()` not `query_points()`**: The method is just `query`, not `query_points` like Python.
+- **No model classes**: Filters are plain JS objects, not `Filter(must=[FieldCondition(...)])`. No imports needed for conditions.
+- **No `upload_points`**: Only `upsert()` exists. Batch manually for large uploads.
+- **Distance values are strings**: `'Cosine'`, `'Euclid'`, `'Dot'`, `'Manhattan'` (not enums).
+- **REST only (primary client)**: Uses port 6333 (HTTP), not 6334 (gRPC). There is a separate `@qdrant/js-client-grpc` package.
+- **`upsert` `wait` defaults to `true`**: Writes are synchronous by default.
+- **Scroll returns an object**: `{ points, next_page_offset }`, not a tuple like Python.
+- **`prefetch` can be object or array**: Single object for pipeline re-scoring, array for fusion of multiple retrievals.
+- **Constructor rejects `url` + `host` together**: Provide one or the other, never both.
+- **No `cloud_inference` constructor option**: Cloud inference config differs from Python.
+- **Vector size must match**: Every upsert and query must match collection dimensions.
+- **Distance is immutable**: Delete and recreate collection to change it.
+- **Never one collection per user**: Use `is_tenant: true` payload index.
+
+## Read More
+
+- [npm: @qdrant/js-client-rest](https://www.npmjs.com/package/@qdrant/js-client-rest)
+- [GitHub: qdrant/qdrant-js](https://github.com/qdrant/qdrant-js)
+- [Qdrant Documentation](https://qdrant.tech/documentation/)

--- a/skills/qdrant-typescript/references/advanced-indexing.md
+++ b/skills/qdrant-typescript/references/advanced-indexing.md
@@ -1,0 +1,142 @@
+# Advanced Indexing and Quantization
+
+HNSW, quantization, and multi-vector configuration in TypeScript.
+
+## HNSW Parameters
+
+```typescript
+// At creation
+client.createCollection('col', {
+    vectors: { size: 768, distance: 'Cosine' },
+    hnsw_config: {
+        m: 16,                    // connections per node
+        ef_construct: 100,        // search width during build
+        full_scan_threshold: 10000,
+    },
+});
+
+// Tune after creation
+client.updateCollection('col', {
+    hnsw_config: { m: 32, ef_construct: 200 },
+});
+```
+
+### Search-Time ef
+
+```typescript
+client.query('col', {
+    query: vector,
+    params: { hnsw_ef: 128 },
+    limit: 10,
+});
+```
+
+## Scalar Quantization
+
+```typescript
+client.createCollection('col', {
+    vectors: { size: 768, distance: 'Cosine' },
+    quantization_config: {
+        scalar: { type: 'int8', quantile: 0.99, always_ram: true },
+    },
+});
+```
+
+## Product Quantization
+
+```typescript
+client.createCollection('col', {
+    vectors: { size: 768, distance: 'Cosine' },
+    quantization_config: {
+        product: { compression: 'x16', always_ram: true },
+    },
+});
+```
+
+## Binary Quantization
+
+```typescript
+client.createCollection('col', {
+    vectors: { size: 768, distance: 'Cosine' },
+    quantization_config: {
+        binary: { always_ram: true },
+    },
+});
+```
+
+## Quantization Search Params
+
+```typescript
+client.query('col', {
+    query: vector,
+    params: {
+        quantization: { rescore: true, oversampling: 2.0 },
+    },
+    limit: 10,
+});
+```
+
+## On-Disk Vectors
+
+```typescript
+client.createCollection('col', {
+    vectors: { size: 768, distance: 'Cosine', on_disk: true },
+    hnsw_config: { on_disk: true },
+    quantization_config: {
+        scalar: { type: 'int8', always_ram: true },
+    },
+});
+```
+
+## Multi-Vector (ColBERT)
+
+```typescript
+// Single multi-vector collection
+client.createCollection('col', {
+    vectors: {
+        size: 128,
+        distance: 'Cosine',
+        multivector_config: { comparator: 'max_sim' },
+    },
+});
+
+// Upsert: vector is array of token vectors
+client.upsert('col', {
+    points: [{
+        id: 1,
+        vector: [[0.1, 0.2, ...], [0.3, 0.4, ...], [0.5, 0.6, ...]],
+        payload: { text: 'document' },
+    }],
+});
+
+// Query with token vectors
+client.query('col', {
+    query: [[0.1, 0.2, ...], [0.3, 0.4, ...]],
+    limit: 10,
+});
+
+// Two-stage: dense retrieval + ColBERT reranking
+client.createCollection('col', {
+    vectors: {
+        dense: { size: 768, distance: 'Cosine' },
+        colbert: {
+            size: 128,
+            distance: 'Cosine',
+            multivector_config: { comparator: 'max_sim' },
+            hnsw_config: { m: 0 },  // disable HNSW
+        },
+    },
+});
+```
+
+## What's Mutable at Runtime
+
+| Parameter | Mutable | Method |
+|-----------|---------|--------|
+| Distance | No | Recreate collection |
+| Vector size | No | Recreate collection |
+| HNSW `m`, `ef_construct` | Yes | `updateCollection` |
+| Quantization | Yes | `updateCollection` |
+| Optimizer settings | Yes | `updateCollection` |
+| On-disk flag | No | Set at creation |
+| Multi-vector comparator | No | Recreate collection |

--- a/skills/qdrant-typescript/references/filtering.md
+++ b/skills/qdrant-typescript/references/filtering.md
@@ -1,0 +1,197 @@
+# Filtering Reference
+
+Complete reference for Qdrant filter conditions in the TypeScript/JS SDK.
+
+Filters are plain JavaScript objects. No model classes or imports needed.
+
+## Filter Structure
+
+Filters combine conditions with boolean logic:
+
+```typescript
+const filter = {
+    must: [...],        // AND: all conditions must match
+    should: [...],      // OR: at least one must match
+    must_not: [...],    // NOT: none can match
+};
+```
+
+## Match Conditions
+
+### Exact match (keyword/integer/boolean)
+
+```typescript
+{ key: 'city', match: { value: 'Berlin' } }
+{ key: 'count', match: { value: 42 } }
+{ key: 'active', match: { value: true } }
+```
+
+### Match any (IN)
+
+```typescript
+{ key: 'color', match: { any: ['red', 'blue', 'green'] } }
+```
+
+### Match except (NOT IN)
+
+```typescript
+{ key: 'status', match: { except: ['deleted', 'archived'] } }
+```
+
+### Full-text match
+
+```typescript
+{ key: 'description', match: { text: 'vector database' } }
+```
+
+Requires a `text` payload index on the field.
+
+## Range Conditions
+
+```typescript
+{ key: 'price', range: { gte: 10.0, lte: 100.0 } }
+{ key: 'count', range: { gt: 0 } }
+```
+
+Available operators: `gt`, `gte`, `lt`, `lte`.
+
+## Datetime Filtering
+
+```typescript
+{
+    key: 'created_at',
+    range: {
+        gte: '2024-01-01T00:00:00Z',
+        lt: '2025-01-01T00:00:00Z',
+    },
+}
+```
+
+Requires a `datetime` payload index.
+
+## Geo Conditions
+
+### Bounding box
+
+```typescript
+{
+    key: 'location',
+    geo_bounding_box: {
+        top_left: { lat: 52.52, lon: 13.35 },
+        bottom_right: { lat: 52.50, lon: 13.45 },
+    },
+}
+```
+
+### Radius
+
+```typescript
+{
+    key: 'location',
+    geo_radius: {
+        center: { lat: 52.52, lon: 13.405 },
+        radius: 1000.0,  // meters
+    },
+}
+```
+
+### Polygon
+
+```typescript
+{
+    key: 'location',
+    geo_polygon: {
+        exterior: {
+            points: [
+                { lat: 52.52, lon: 13.35 },
+                { lat: 52.52, lon: 13.45 },
+                { lat: 52.50, lon: 13.45 },
+                { lat: 52.50, lon: 13.35 },
+                { lat: 52.52, lon: 13.35 },  // close the polygon
+            ],
+        },
+    },
+}
+```
+
+## Nested Filters
+
+Filter on nested object fields using dot notation:
+
+```typescript
+{ key: 'address.city', match: { value: 'Berlin' } }
+```
+
+For arrays of objects, use `nested`:
+
+```typescript
+{
+    nested: {
+        key: 'reviews',
+        filter: {
+            must: [
+                { key: 'reviews[].score', range: { gte: 4 } },
+                { key: 'reviews[].verified', match: { value: true } },
+            ],
+        },
+    },
+}
+```
+
+## Null and Empty Checks
+
+### Field is null
+
+```typescript
+{ is_null: { key: 'email' } }
+```
+
+### Field is empty (empty array)
+
+```typescript
+{ is_empty: { key: 'tags' } }
+```
+
+## Has ID Filter
+
+Filter by point IDs:
+
+```typescript
+{ has_id: [1, 2, 3] }
+```
+
+## Combining Filters
+
+Nested boolean logic:
+
+```typescript
+{
+    must: [
+        { key: 'category', match: { value: 'electronics' } },
+    ],
+    should: [
+        { key: 'brand', match: { value: 'Apple' } },
+        { key: 'brand', match: { value: 'Samsung' } },
+    ],
+    must_not: [
+        { key: 'discontinued', match: { value: true } },
+    ],
+}
+```
+
+This matches: category IS electronics AND (brand IS Apple OR brand IS Samsung) AND discontinued IS NOT true.
+
+## min_should
+
+Require at least N `should` conditions to match:
+
+```typescript
+{
+    should: [
+        { key: 'tag', match: { value: 'fast' } },
+        { key: 'tag', match: { value: 'cheap' } },
+        { key: 'tag', match: { value: 'reliable' } },
+    ],
+    min_should: { conditions: [], min_count: 2 },
+}
+```

--- a/tests/run-scenarios.py
+++ b/tests/run-scenarios.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Scenario-based skill validation.
+
+For each scenario, verifies that the skill's SKILL.md and AGENTS.md contain
+enough information for an agent to produce code matching the expected patterns
+and avoiding the forbidden patterns.
+
+Two validation modes:
+  1. coverage: (default) checks that expected patterns appear somewhere in the
+     skill files, so an agent reading them would learn the right API.
+  2. eval: (requires LLM) generates code from the prompt + skill context and
+     validates the output against expected/forbidden patterns.
+
+Usage:
+  python3 tests/run-scenarios.py                      # coverage mode, all skills
+  python3 tests/run-scenarios.py --skill qdrant-python # single skill
+  python3 tests/run-scenarios.py --tag search          # filter by tag
+  python3 tests/run-scenarios.py --verbose             # show pattern details
+"""
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("error: pyyaml required. run: pip install pyyaml")
+    sys.exit(1)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+SCENARIOS_DIR = REPO_ROOT / "tests" / "scenarios"
+
+
+def load_skill_content(skill_name: str) -> str:
+    """Load concatenated SKILL.md + AGENTS.md content for a skill."""
+    skill_dir = SKILLS_DIR / skill_name
+    content = ""
+    for fname in ["SKILL.md", "AGENTS.md"]:
+        fpath = skill_dir / fname
+        if fpath.exists():
+            content += fpath.read_text() + "\n"
+    # Also load references if they exist
+    refs_dir = skill_dir / "references"
+    if refs_dir.exists():
+        for ref_file in sorted(refs_dir.glob("*.md")):
+            content += ref_file.read_text() + "\n"
+    return content
+
+
+def check_pattern_in_content(pattern: str, content: str) -> bool:
+    """Check if a pattern (literal or regex) appears in content."""
+    # Try as regex first
+    try:
+        if re.search(pattern, content, re.IGNORECASE | re.MULTILINE):
+            return True
+    except re.error:
+        pass
+    # Fall back to literal substring match
+    return pattern.lower() in content.lower()
+
+
+def run_coverage_check(
+    scenario_file: Path,
+    tag_filter: str | None = None,
+    verbose: bool = False,
+) -> tuple[int, int, list[str]]:
+    """
+    Check that skill content covers what scenarios expect.
+
+    Returns (passed, total, failure_messages).
+    """
+    with open(scenario_file) as f:
+        data = yaml.safe_load(f)
+
+    skill_name = data["skill"]
+    scenarios = data["scenarios"]
+    content = load_skill_content(skill_name)
+
+    if not content.strip():
+        return 0, 1, [f"{skill_name}: skill content is empty"]
+
+    passed = 0
+    total = 0
+    failures = []
+
+    for scenario in scenarios:
+        name = scenario["name"]
+        tags = scenario.get("tags", [])
+
+        if tag_filter and tag_filter not in tags:
+            continue
+
+        total += 1
+        scenario_failures = []
+
+        # Check expected patterns exist in skill content
+        for pattern in scenario.get("expected_patterns", []):
+            if not check_pattern_in_content(pattern, content):
+                scenario_failures.append(f"    expected not found: {pattern}")
+
+        # Check forbidden patterns do NOT exist in skill content
+        # (only check code examples, not gotcha warnings about what NOT to do)
+        # We skip forbidden pattern checks in coverage mode because the skill
+        # files legitimately mention forbidden patterns in "Gotchas" sections
+        # to warn agents away from them.
+
+        if scenario_failures:
+            failures.append(f"  FAIL: {skill_name}/{name}")
+            failures.extend(scenario_failures)
+            if verbose and "notes" in scenario:
+                failures.append(f"    note: {scenario['notes']}")
+        else:
+            passed += 1
+            if verbose:
+                print(f"  pass: {skill_name}/{name}")
+
+    return passed, total, failures
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Scenario-based skill validation")
+    parser.add_argument("--skill", help="Run scenarios for a specific skill only")
+    parser.add_argument("--tag", help="Run only scenarios with this tag")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Show details")
+    parser.add_argument(
+        "--list", action="store_true", help="List all scenarios without running"
+    )
+    args = parser.parse_args()
+
+    scenario_files = sorted(SCENARIOS_DIR.glob("*.yaml"))
+
+    if args.skill:
+        scenario_files = [f for f in scenario_files if f.stem == args.skill]
+        if not scenario_files:
+            print(f"error: no scenario file for skill '{args.skill}'")
+            sys.exit(1)
+
+    if args.list:
+        for sf in scenario_files:
+            with open(sf) as f:
+                data = yaml.safe_load(f)
+            print(f"\n{data['skill']}:")
+            for s in data["scenarios"]:
+                tags = ", ".join(s.get("tags", []))
+                print(f"  {s['name']:<30} [{tags}]")
+        return
+
+    total_passed = 0
+    total_tests = 0
+    all_failures = []
+
+    print("=== scenario coverage tests ===\n")
+
+    for sf in scenario_files:
+        with open(sf) as f:
+            data = yaml.safe_load(f)
+        skill_name = data["skill"]
+        print(f"[{skill_name}]")
+
+        passed, total, failures = run_coverage_check(sf, args.tag, args.verbose)
+        total_passed += passed
+        total_tests += total
+
+        if failures:
+            all_failures.extend(failures)
+            for line in failures:
+                print(line)
+        else:
+            print(f"  all {passed} scenarios covered")
+
+        print()
+
+    print("=== results ===")
+    print(f"{total_passed}/{total_tests} passed, {total_tests - total_passed} failed")
+
+    if all_failures:
+        print(f"\n{len(all_failures)} issues found. Fix skill content to cover these patterns.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scenarios/qdrant-dotnet.yaml
+++ b/tests/scenarios/qdrant-dotnet.yaml
@@ -1,0 +1,106 @@
+skill: qdrant-dotnet
+scenarios:
+  - name: basic_search
+    prompt: "Search a Qdrant collection for nearest vectors using the .NET client"
+    expected_patterns:
+      - "QueryAsync"
+      - "query:"
+    forbidden_patterns:
+      - "SearchAsync"
+      - "query_points"
+    tags: [basic, search]
+
+  - name: filtered_search
+    prompt: "Search 'products' with a filter for electronics category in C#"
+    expected_patterns:
+      - "QueryAsync"
+      - "MatchKeyword"
+      - "electronics"
+    forbidden_patterns:
+      - "Filter("
+      - "FieldCondition"
+    notes: "Uses static Conditions helpers, not model constructors"
+    tags: [search, filtering]
+
+  - name: filter_composition
+    prompt: "Filter Qdrant results where type is 'doc' AND archived is NOT true in C#"
+    expected_patterns:
+      - "&"
+      - "!"
+    forbidden_patterns:
+      - "&&"
+      - "||"
+      - "Must.Add"
+    notes: "C# uses & | ! operators for filter composition, not && ||"
+    tags: [filtering]
+
+  - name: create_collection
+    prompt: "Create a Qdrant collection with 768-dim cosine vectors in C#"
+    expected_patterns:
+      - "CreateCollectionAsync"
+      - "VectorParams"
+      - "768"
+      - "Distance.Cosine"
+    forbidden_patterns:
+      - "Distance.COSINE"
+      - "Distance_Cosine"
+    tags: [basic, collection]
+
+  - name: upsert_with_payload
+    prompt: "Upsert points with string and integer payload into Qdrant in C#"
+    expected_patterns:
+      - "UpsertAsync"
+      - "PointStruct"
+      - "Payload"
+    forbidden_patterns:
+      - "json!"
+      - "Map.of"
+    tags: [basic, upsert]
+
+  - name: point_id_type
+    prompt: "Create a point with numeric ID 42 in Qdrant .NET"
+    expected_patterns:
+      - "ul"
+    forbidden_patterns: []
+    notes: "Must use ulong suffix (42ul), not bare int literal"
+    tags: [basic, gotcha]
+
+  - name: client_setup
+    prompt: "Connect to a local Qdrant instance in C#"
+    expected_patterns:
+      - "QdrantClient"
+      - "localhost"
+    forbidden_patterns:
+      - "6333"
+    notes: ".NET uses gRPC port 6334 (default), not REST 6333"
+    tags: [basic, setup]
+
+  - name: disposable_pattern
+    prompt: "Set up a Qdrant client in C#"
+    expected_patterns:
+      - "using"
+      - "QdrantClient"
+    forbidden_patterns: []
+    notes: "QdrantClient is IDisposable, should use 'using' pattern"
+    tags: [basic, setup]
+
+  - name: static_import
+    prompt: "Write a filtered Qdrant query in C#"
+    expected_patterns:
+      - "using static"
+      - "Conditions"
+    forbidden_patterns: []
+    notes: "Must import static Qdrant.Client.Grpc.Conditions for filter helpers"
+    tags: [filtering]
+
+  - name: hybrid_search
+    prompt: "Do hybrid search with RRF fusion in C# Qdrant"
+    expected_patterns:
+      - "QueryAsync"
+      - "Fusion.Rrf"
+      - "PrefetchQuery"
+    forbidden_patterns:
+      - "Fusion.RRF"
+      - "fusion: 'rrf'"
+    notes: ".NET uses Fusion.Rrf (PascalCase), not Fusion.RRF"
+    tags: [search, hybrid]

--- a/tests/scenarios/qdrant-go.yaml
+++ b/tests/scenarios/qdrant-go.yaml
@@ -1,0 +1,110 @@
+skill: qdrant-go
+scenarios:
+  - name: basic_search
+    prompt: "Search a Qdrant collection for nearest vectors using the Go client"
+    expected_patterns:
+      - "client.Query("
+      - "qdrant.QueryPoints"
+      - "qdrant.NewQuery("
+    forbidden_patterns:
+      - "client.Search("
+      - "SearchPoints"
+    tags: [basic, search]
+
+  - name: filtered_search
+    prompt: "Search 'products' with a filter for electronics category in Go"
+    expected_patterns:
+      - "client.Query("
+      - "qdrant.Filter"
+      - "qdrant.NewMatch("
+      - "Must"
+    forbidden_patterns:
+      - "client.Search("
+    tags: [search, filtering]
+
+  - name: create_collection
+    prompt: "Create a Qdrant collection with 768-dim cosine vectors in Go"
+    expected_patterns:
+      - "client.CreateCollection("
+      - "qdrant.NewVectorsConfig"
+      - "qdrant.VectorParams"
+      - "768"
+      - "qdrant.Distance_Cosine"
+    forbidden_patterns:
+      - "Distance.Cosine"
+      - "Distance.COSINE"
+      - "qdrant.Cosine"
+    notes: "Go uses protobuf enum syntax: qdrant.Distance_Cosine"
+    tags: [basic, collection]
+
+  - name: upsert_with_payload
+    prompt: "Upsert points with payload into Qdrant using Go"
+    expected_patterns:
+      - "client.Upsert("
+      - "qdrant.UpsertPoints"
+      - "qdrant.NewIDNum"
+      - "qdrant.NewVectors("
+      - "qdrant.NewValueMap"
+    forbidden_patterns:
+      - "json.Marshal"
+    notes: "Use NewValueMap for payload, not JSON marshaling"
+    tags: [basic, upsert]
+
+  - name: pointer_api
+    prompt: "Query Qdrant with a limit of 10 results in Go"
+    expected_patterns:
+      - "qdrant.PtrOf("
+    forbidden_patterns: []
+    notes: "Optional fields require qdrant.PtrOf() for pointer conversion"
+    tags: [basic, search]
+
+  - name: scroll_with_offset
+    prompt: "Paginate through all points in a Go Qdrant collection"
+    expected_patterns:
+      - "ScrollAndOffset"
+    forbidden_patterns:
+      - "client.Scroll("
+    notes: "Must use ScrollAndOffset for pagination, plain Scroll discards offset"
+    tags: [basic, scroll]
+
+  - name: grpc_port
+    prompt: "Connect to a local Qdrant instance in Go"
+    expected_patterns:
+      - "6334"
+    forbidden_patterns:
+      - "6333"
+    notes: "Go client is gRPC-only, port 6334"
+    tags: [basic, setup]
+
+  - name: named_vector_query
+    prompt: "Query a specific named vector called 'image' in Go"
+    expected_patterns:
+      - "Using"
+      - "qdrant.PtrOf"
+    forbidden_patterns:
+      - 'Using: "image"'
+    notes: "Using is *string, needs qdrant.PtrOf(\"image\")"
+    tags: [named-vectors]
+
+  - name: hybrid_search
+    prompt: "Do hybrid search with dense and sparse vectors using RRF fusion in Go"
+    expected_patterns:
+      - "Prefetch"
+      - "PrefetchQuery"
+      - "qdrant.NewQueryFusion"
+      - "Fusion_RRF"
+    forbidden_patterns:
+      - "Fusion.RRF"
+      - "fusion: 'rrf'"
+    notes: "Go uses qdrant.Fusion_RRF protobuf enum"
+    tags: [search, hybrid]
+
+  - name: multi_tenancy
+    prompt: "Set up multi-tenant isolation in Go Qdrant client"
+    expected_patterns:
+      - "IsTenant"
+      - "qdrant.PtrOf(true)"
+      - "CreateFieldIndex"
+    forbidden_patterns:
+      - "one collection per"
+    tags: [multi-tenancy]

--- a/tests/scenarios/qdrant-java.yaml
+++ b/tests/scenarios/qdrant-java.yaml
@@ -1,0 +1,130 @@
+skill: qdrant-java
+scenarios:
+  - name: basic_search
+    prompt: "Search a Qdrant collection for nearest vectors using the Java client"
+    expected_patterns:
+      - "queryAsync"
+      - "QueryPoints.newBuilder"
+      - "nearest("
+    forbidden_patterns:
+      - "searchAsync"
+      - "SearchPoints"
+      - "addAllVector"
+    tags: [basic, search]
+
+  - name: filtered_search
+    prompt: "Search 'products' with a filter for electronics category in Java"
+    expected_patterns:
+      - "queryAsync"
+      - "Filter.newBuilder"
+      - "matchKeyword"
+      - "electronics"
+    forbidden_patterns:
+      - "FieldCondition"
+      - "MatchValue"
+    notes: "Uses ConditionFactory static methods, not model constructors"
+    tags: [search, filtering]
+
+  - name: create_collection
+    prompt: "Create a Qdrant collection with 768-dim cosine vectors in Java"
+    expected_patterns:
+      - "createCollectionAsync"
+      - "VectorParams.newBuilder"
+      - "setSize"
+      - "768"
+      - "Distance.Cosine"
+    forbidden_patterns:
+      - "Distance.COSINE"
+      - "Distance_Cosine"
+    tags: [basic, collection]
+
+  - name: upsert_with_payload
+    prompt: "Upsert points with payload into Qdrant using Java"
+    expected_patterns:
+      - "upsertAsync"
+      - "PointStruct.newBuilder"
+      - "setId(id("
+      - "setVectors(vectors("
+      - "putAllPayload"
+      - "value("
+    forbidden_patterns:
+      - "Payload.of"
+      - "new HashMap"
+    notes: "Must use factory methods: id(), vectors(), value()"
+    tags: [basic, upsert]
+
+  - name: factory_imports
+    prompt: "Write code that upserts a point to Qdrant in Java"
+    expected_patterns:
+      - "import static"
+      - "PointIdFactory"
+      - "VectorsFactory"
+      - "ValueFactory"
+    forbidden_patterns: []
+    notes: "Factory static imports are essential for usable code"
+    tags: [basic, setup]
+
+  - name: async_pattern
+    prompt: "Query Qdrant and get results in Java"
+    expected_patterns:
+      - ".get()"
+    forbidden_patterns:
+      - "client.query("
+    notes: "All methods return ListenableFuture, must call .get() to block. Method is queryAsync not query."
+    tags: [basic, async]
+
+  - name: builder_pattern
+    prompt: "Build a Qdrant query with filter and payload in Java"
+    expected_patterns:
+      - ".newBuilder()"
+      - ".build()"
+      - ".setQuery("
+      - ".setFilter("
+    forbidden_patterns:
+      - "new QueryPoints("
+      - "new Filter("
+    notes: "All complex types use builder pattern, no direct constructors"
+    tags: [basic, search]
+
+  - name: vectors_vs_vector
+    prompt: "Upsert a point with named vectors 'image' and 'text' in Java"
+    expected_patterns:
+      - "namedVectors("
+      - "vector("
+    forbidden_patterns:
+      - "vectors(.*Map"
+    notes: "vectors() creates Vectors wrapper for PointStruct; vector() creates Vector for named maps"
+    tags: [named-vectors]
+
+  - name: hybrid_search
+    prompt: "Do hybrid search with dense+sparse and RRF fusion in Java"
+    expected_patterns:
+      - "queryAsync"
+      - "addPrefetch"
+      - "PrefetchQuery.newBuilder"
+      - "fusion(Fusion.RRF)"
+    forbidden_patterns:
+      - "Fusion_RRF"
+      - "fusion: 'rrf'"
+    notes: "Java uses Fusion.RRF enum via QueryFactory.fusion()"
+    tags: [search, hybrid]
+
+  - name: grpc_port
+    prompt: "Connect to a local Qdrant instance in Java"
+    expected_patterns:
+      - "6334"
+      - "QdrantGrpcClient"
+    forbidden_patterns:
+      - "6333"
+      - "RestClient"
+    notes: "Java client is gRPC-only, port 6334"
+    tags: [basic, setup]
+
+  - name: multi_tenancy
+    prompt: "Set up multi-tenant isolation in Java Qdrant client"
+    expected_patterns:
+      - "IsTenant"
+      - "createPayloadIndexAsync"
+    forbidden_patterns:
+      - "one collection per"
+    tags: [multi-tenancy]

--- a/tests/scenarios/qdrant-python.yaml
+++ b/tests/scenarios/qdrant-python.yaml
@@ -1,0 +1,114 @@
+skill: qdrant-python
+scenarios:
+  - name: basic_search
+    prompt: "Search a Qdrant collection called 'products' for the nearest 10 vectors"
+    expected_patterns:
+      - "query_points"
+      - "products"
+      - "limit"
+    forbidden_patterns:
+      - "client.search("
+      - "search_points"
+      - "search_batch"
+    tags: [basic, search]
+
+  - name: filtered_search
+    prompt: "Search 'products' collection for electronics category items using a vector"
+    expected_patterns:
+      - "query_points"
+      - "query_filter"
+      - "Filter"
+      - "FieldCondition"
+      - "MatchValue"
+      - "electronics"
+    forbidden_patterns:
+      - "client.search("
+    tags: [search, filtering]
+
+  - name: create_collection
+    prompt: "Create a Qdrant collection with cosine distance vectors"
+    expected_patterns:
+      - "create_collection"
+      - "VectorParams"
+      - "size"
+      - "Distance.COSINE"
+    forbidden_patterns:
+      - "Distance.Cosine"
+      - "distance='cosine'"
+    tags: [basic, collection]
+
+  - name: hybrid_search
+    prompt: "Do a hybrid search combining dense and sparse vectors with RRF fusion"
+    expected_patterns:
+      - "query_points"
+      - "prefetch"
+      - "Prefetch"
+      - "FusionQuery"
+      - "Fusion.RRF"
+    forbidden_patterns:
+      - "client.search("
+    tags: [search, hybrid]
+
+  - name: bulk_insert
+    prompt: "Insert 50,000 points into a Qdrant collection efficiently"
+    expected_patterns:
+      - "upload_points"
+    forbidden_patterns:
+      - "for.*upsert"
+      - "upsert.*loop"
+    tags: [basic, upsert]
+
+  - name: multi_tenancy
+    prompt: "Set up multi-tenant isolation in a single Qdrant collection"
+    expected_patterns:
+      - "is_tenant"
+      - "create_payload_index"
+    forbidden_patterns:
+      - "create_collection.*user"
+      - "one collection per"
+    tags: [multi-tenancy]
+
+  - name: scroll_pagination
+    prompt: "Paginate through all points in a collection using scroll"
+    expected_patterns:
+      - "scroll"
+      - "next_offset"
+    forbidden_patterns:
+      - "offset.*skip"
+      - "page.*number"
+    tags: [basic, scroll]
+
+  - name: mmr_diversity
+    prompt: "Search with MMR to get diverse results"
+    expected_patterns:
+      - "query_points"
+      - "NearestQuery"
+      - "Mmr"
+      - "diversity"
+    forbidden_patterns:
+      - "client.search("
+    tags: [search, mmr]
+
+  - name: payload_index_before_bulk
+    prompt: "Set up a collection with payload indexes and then bulk insert data"
+    expected_patterns:
+      - "create_payload_index"
+    forbidden_patterns: []
+    notes: "Index creation should appear BEFORE upload_points/upsert calls"
+    tags: [best-practice]
+
+  - name: cloud_inference
+    prompt: "Use Qdrant cloud inference to search without a local embedding model"
+    expected_patterns:
+      - "cloud_inference"
+      - "Document"
+    forbidden_patterns: []
+    tags: [cloud]
+
+  - name: sparse_bm25
+    prompt: "Set up BM25 sparse search with proper IDF modifier"
+    expected_patterns:
+      - "Modifier"
+      - "IDF"
+    forbidden_patterns: []
+    tags: [search, sparse]

--- a/tests/scenarios/qdrant-rust.yaml
+++ b/tests/scenarios/qdrant-rust.yaml
@@ -1,0 +1,112 @@
+skill: qdrant-rust
+scenarios:
+  - name: basic_search
+    prompt: "Search a Qdrant collection for the nearest vectors using the Rust client"
+    expected_patterns:
+      - "client.query("
+      - "QueryPointsBuilder"
+    forbidden_patterns:
+      - "search_points"
+      - "client.search("
+    tags: [basic, search]
+
+  - name: filtered_search
+    prompt: "Search 'products' with a filter for electronics category in Rust"
+    expected_patterns:
+      - "QueryPointsBuilder"
+      - "filter"
+      - "Filter::must"
+      - "Condition::matches"
+      - "electronics"
+    forbidden_patterns:
+      - "search_points"
+    tags: [search, filtering]
+
+  - name: create_collection
+    prompt: "Create a Qdrant collection with 768-dim cosine vectors in Rust"
+    expected_patterns:
+      - "CreateCollectionBuilder"
+      - "VectorParamsBuilder"
+      - "768"
+      - "Distance::Cosine"
+    forbidden_patterns:
+      - "Distance.Cosine"
+      - "Distance.COSINE"
+    tags: [basic, collection]
+
+  - name: upsert_with_payload
+    prompt: "Upsert points with JSON payload into a Qdrant collection in Rust"
+    expected_patterns:
+      - "UpsertPointsBuilder"
+      - "PointStruct::new"
+      - "json!"
+      - "try_into"
+    forbidden_patterns:
+      - "Payload::new"
+      - "HashMap.*payload"
+    notes: "Payload conversion goes through json!({}).try_into().unwrap()"
+    tags: [basic, upsert]
+
+  - name: builder_pattern
+    prompt: "Query Qdrant and return payload with vectors in Rust"
+    expected_patterns:
+      - "QueryPointsBuilder"
+      - "with_payload"
+    forbidden_patterns:
+      - "QueryPoints {"
+      - "QueryPoints{"
+    notes: "Must use builders, not direct struct construction"
+    tags: [basic, search]
+
+  - name: wait_for_consistency
+    prompt: "Upsert points and immediately query them in Rust"
+    expected_patterns:
+      - "wait(true)"
+    forbidden_patterns: []
+    notes: "Must use .wait(true) for read-after-write consistency"
+    tags: [best-practice]
+
+  - name: grpc_port
+    prompt: "Connect to a local Qdrant instance in Rust"
+    expected_patterns:
+      - "6334"
+    forbidden_patterns:
+      - "6333"
+    notes: "Rust client uses gRPC port 6334, not REST 6333"
+    tags: [basic, setup]
+
+  - name: async_runtime
+    prompt: "Set up a Qdrant client and query in Rust"
+    expected_patterns:
+      - "tokio"
+      - "await"
+    forbidden_patterns: []
+    notes: "All client methods are async, requires tokio"
+    tags: [basic, setup]
+
+  - name: hybrid_search
+    prompt: "Do a hybrid search combining dense and sparse vectors with RRF fusion in Rust"
+    expected_patterns:
+      - "prefetch"
+      - "Fusion"
+      - "Rrf"
+    forbidden_patterns:
+      - "search_points"
+    tags: [search, hybrid]
+
+  - name: named_vectors
+    prompt: "Create a collection with separate image and text vector spaces in Rust"
+    expected_patterns:
+      - "VectorParamsMap"
+      - "VectorParamsBuilder"
+    forbidden_patterns: []
+    tags: [named-vectors]
+
+  - name: multi_tenancy
+    prompt: "Set up multi-tenant search in Rust"
+    expected_patterns:
+      - "is_tenant"
+      - "CreateFieldIndexCollectionBuilder"
+    forbidden_patterns:
+      - "one collection per"
+    tags: [multi-tenancy]

--- a/tests/scenarios/qdrant-typescript.yaml
+++ b/tests/scenarios/qdrant-typescript.yaml
@@ -1,0 +1,118 @@
+skill: qdrant-typescript
+scenarios:
+  - name: basic_search
+    prompt: "Search a Qdrant collection for the nearest 10 vectors"
+    expected_patterns:
+      - "client.query("
+      - "limit"
+    forbidden_patterns:
+      - "query_points"
+      - "client.search_points("
+    tags: [basic, search]
+
+  - name: filtered_search
+    prompt: "Search 'products' collection filtering by category equals 'electronics'"
+    expected_patterns:
+      - "client.query("
+      - "filter"
+      - "must"
+      - "key.*category"
+      - "match"
+      - "value.*electronics"
+    forbidden_patterns:
+      - "Filter("
+      - "FieldCondition("
+      - "MatchValue("
+    notes: "TS uses plain objects for filters, not model classes"
+    tags: [search, filtering]
+
+  - name: create_collection
+    prompt: "Create a Qdrant collection with 768-dimensional cosine vectors"
+    expected_patterns:
+      - "createCollection"
+      - "vectors"
+      - "768"
+      - "'Cosine'"
+    forbidden_patterns:
+      - "Distance.COSINE"
+      - "Distance.Cosine"
+      - "distance: Distance"
+    notes: "Distance values are strings in JS, not enums"
+    tags: [basic, collection]
+
+  - name: hybrid_search
+    prompt: "Do a hybrid search combining dense and sparse vectors with RRF fusion"
+    expected_patterns:
+      - "client.query("
+      - "prefetch"
+      - "fusion"
+      - "rrf"
+    forbidden_patterns:
+      - "FusionQuery"
+      - "Fusion.RRF"
+    notes: "TS uses plain string 'rrf', not enum Fusion.RRF"
+    tags: [search, hybrid]
+
+  - name: client_setup
+    prompt: "Connect to a Qdrant Cloud instance"
+    expected_patterns:
+      - "QdrantClient"
+      - "url"
+      - "apiKey"
+    forbidden_patterns:
+      - "host.*url"
+    notes: "Cannot provide both url and host"
+    tags: [basic, setup]
+
+  - name: named_vectors
+    prompt: "Create a collection with separate image and text vector spaces"
+    expected_patterns:
+      - "createCollection"
+      - "vectors"
+      - "image"
+      - "text"
+    forbidden_patterns:
+      - "VectorParams"
+      - "VectorParamsBuilder"
+    notes: "TS uses plain config objects, not builder/param classes"
+    tags: [named-vectors]
+
+  - name: multi_tenancy
+    prompt: "Set up multi-tenant isolation in a Qdrant collection"
+    expected_patterns:
+      - "createPayloadIndex"
+      - "is_tenant"
+      - "true"
+    forbidden_patterns:
+      - "one collection per"
+    tags: [multi-tenancy]
+
+  - name: scroll_pagination
+    prompt: "Paginate through all points in a collection"
+    expected_patterns:
+      - "scroll"
+      - "next_page_offset"
+    forbidden_patterns:
+      - "next_offset"
+    notes: "TS uses next_page_offset, not next_offset like Python"
+    tags: [basic, scroll]
+
+  - name: upsert_points
+    prompt: "Insert points with payload into a collection"
+    expected_patterns:
+      - "client.upsert("
+      - "points"
+      - "payload"
+    forbidden_patterns:
+      - "upload_points"
+    notes: "TS has no upload_points, only upsert"
+    tags: [basic, upsert]
+
+  - name: rest_port
+    prompt: "Connect to a local Qdrant instance"
+    expected_patterns:
+      - "6333"
+    forbidden_patterns:
+      - "6334"
+    notes: "TS REST client uses port 6333, not gRPC 6334"
+    tags: [basic, setup]


### PR DESCRIPTION
Adds 4 new language skills to reach full parity with Python and Rust. Updates all commands for 6-language support and adds missing API coverage across all skills.

- [x] Python
- [x] TypeScript
- [x] Rust
- [x] Go
- [x] .NET
- [x] Java