### PR TITLE
repo docs, readme rewrite, license, drop commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "qdrant",
       "source": "./",
-      "description": "Skills for the Qdrant vector search platform"
+      "description": "Agent skills for Qdrant vector search"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qdrant",
-  "description": "Skills for the Qdrant vector search platform: Python SDK, search, filtering, hybrid search, and multi-tenancy",
+  "description": "Agent skills for Qdrant vector search: scaling, performance optimization, search quality, monitoring, deployment, model migration, version upgrades, and SDK usage",
   "version": "1.0.0",
   "author": {
     "name": "Qdrant"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# OS
+.DS_Store
+
+# Eval workspace (generated outputs, not source)
+skills-eval-workspace/
+eval-results.json
+
+# Editor
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Python
+__pycache__/
+*.pyc
+.venv/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Agent skills for [Qdrant](https://qdrant.tech) vector search, built on the [Agen
 
 - **Repository:** `github.com/qdrant/skills`
 - **Format:** Markdown SKILL.md files with YAML frontmatter
-- **Compatible agents:** Claude Code, OpenCode, OpenAI Codex, Pi
+- **Compatible agents:** Claude Code, Cursor, OpenCode, OpenAI Codex, Pi
 
 ## Project structure
 
@@ -31,30 +31,11 @@ skills/
   qdrant-deployment-options/
   qdrant-model-migration/
   qdrant-version-upgrade/
-commands/
-  setup-collection.md
-  hybrid-search.md
-  add-multitenancy.md
-  migrate-search.md
-  connect.md
-scripts/
-  validate_skills.py           # skill linter
-```
-
-## Verification
-
-Run the skill linter:
-
-```bash
-python3 scripts/validate_skills.py
 ```
 
 ## Conventions
 
-### Skills vs commands
-
 - **Skills** are passive knowledge. Hub skills declare `allowed-tools: [Read, Grep, Glob]`. Leaf skills omit `allowed-tools`.
-- **Commands** are user-invoked actions with `allowed-tools: [Read, Glob, Grep, Bash, Write, Edit]`.
 
 ### Skill anatomy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# Qdrant Skills
+
+## Project overview
+
+Agent skills for [Qdrant](https://qdrant.tech) vector search, built on the [Agent Skills standard](https://agentskills.io/).
+
+- **Repository:** `github.com/qdrant/skills`
+- **Format:** Markdown SKILL.md files with YAML frontmatter
+- **Compatible agents:** Claude Code, OpenCode, OpenAI Codex, Pi
+
+## Project structure
+
+```
+skills/
+  qdrant-scaling/              # hub: links to sub-skills
+    SKILL.md
+    minimize-latency/          # leaf: actual guidance
+      SKILL.md
+    scaling-data-volume/       # hub: links to sub-skills
+      SKILL.md
+      horizontal-scaling/
+      vertical-scaling/
+      sliding-time-window/
+      tenant-scaling/
+    scaling-qps/
+    scaling-query-volume/
+  qdrant-performance-optimization/
+  qdrant-search-quality/
+  qdrant-monitoring/
+  qdrant-clients-sdk/
+  qdrant-deployment-options/
+  qdrant-model-migration/
+  qdrant-version-upgrade/
+commands/
+  setup-collection.md
+  hybrid-search.md
+  add-multitenancy.md
+  migrate-search.md
+  connect.md
+scripts/
+  validate_skills.py           # skill linter
+```
+
+## Verification
+
+Run the skill linter:
+
+```bash
+python3 scripts/validate_skills.py
+```
+
+## Conventions
+
+### Skills vs commands
+
+- **Skills** are passive knowledge. Hub skills declare `allowed-tools: [Read, Grep, Glob]`. Leaf skills omit `allowed-tools`.
+- **Commands** are user-invoked actions with `allowed-tools: [Read, Glob, Grep, Bash, Write, Edit]`.
+
+### Skill anatomy
+
+Every SKILL.md has YAML frontmatter (`name`, `description`) and a markdown body. Descriptions use `Use when` with exact user phrases for trigger matching. Sections are named by symptom, not feature. Each leaf skill ends with `## What NOT to Do`.
+
+### Documentation links
+
+All links point to `qdrant.tech/documentation/`, inline at the end of bullets:
+
+```
+- Enable scalar quantization with `always_ram=true` [Scalar quantization](https://qdrant.tech/documentation/guides/quantization/#scalar-quantization)
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,15 +11,9 @@ skills/
     SKILL.md              # skill definition (frontmatter + guidance)
     <sub-skill>/
       SKILL.md            # sub-skill for a specific topic
-commands/
-  <command-name>.md       # user-invoked slash commands
-scripts/
-  validate_skills.py      # skill linter
 ```
 
 **Skills** (`skills/`): passive knowledge triggered by description matching. Diagnosis and guidance. Read-only tools.
-
-**Commands** (`commands/`): user-invoked slash commands. Have `$ARGUMENTS`, `## Instructions`, write tools (`Write`, `Edit`, `Bash`).
 
 
 ## Writing a skill
@@ -43,20 +37,9 @@ Leaf skills contain the guidance an agent uses to help users.
 - Each section starts with `Use when:` one-liner
 - Bullets are imperative with inline doc links at the end
 - Ends with `## What NOT to Do` section
-- No code blocks (code lives in commands/, not skills/)
+- No code blocks in skills
 - Links go to `qdrant.tech/documentation/`, not raw GitHub
 - Target 40-80 lines; if over 80, consider splitting into hub + sub-skills
-
-
-## Validation
-
-Run the linter before opening a PR:
-
-```bash
-python3 scripts/validate_skills.py
-```
-
-This checks frontmatter, trigger phrases, section structure, permissions, and formatting.
 
 
 ## Conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing to Qdrant Skills
+
+Skills encode solutions architect knowledge for AI agents. Familiarity with [Qdrant documentation](https://qdrant.tech/documentation/) and the [Agent Skills standard](https://agentskills.io/) is recommended before contributing.
+
+
+## Structure
+
+```
+skills/
+  <skill-name>/
+    SKILL.md              # skill definition (frontmatter + guidance)
+    <sub-skill>/
+      SKILL.md            # sub-skill for a specific topic
+commands/
+  <command-name>.md       # user-invoked slash commands
+scripts/
+  validate_skills.py      # skill linter
+```
+
+**Skills** (`skills/`): passive knowledge triggered by description matching. Diagnosis and guidance. Read-only tools.
+
+**Commands** (`commands/`): user-invoked slash commands. Have `$ARGUMENTS`, `## Instructions`, write tools (`Write`, `Edit`, `Bash`).
+
+
+## Writing a skill
+
+### Hub skills (navigation only)
+
+Hub skills are directories containing sub-skills. They provide a framing paragraph and links to sub-skills.
+
+- Declare `allowed-tools: [Read, Grep, Glob]` in frontmatter
+- Include `name` and `description` with trigger phrases
+- Body is navigation only: title, framing paragraph, links
+
+### Leaf skills (actual content)
+
+Leaf skills contain the guidance an agent uses to help users.
+
+- Omit `allowed-tools` from frontmatter (exception: skills that need `Bash` for external API calls)
+- Description contains `Use when` with 5+ trigger phrases using exact user language
+- First paragraph corrects a wrong assumption or forces a diagnostic fork
+- Sections named by symptom/scenario, not by feature
+- Each section starts with `Use when:` one-liner
+- Bullets are imperative with inline doc links at the end
+- Ends with `## What NOT to Do` section
+- No code blocks (code lives in commands/, not skills/)
+- Links go to `qdrant.tech/documentation/`, not raw GitHub
+- Target 40-80 lines; if over 80, consider splitting into hub + sub-skills
+
+
+## Validation
+
+Run the linter before opening a PR:
+
+```bash
+python3 scripts/validate_skills.py
+```
+
+This checks frontmatter, trigger phrases, section structure, permissions, and formatting.
+
+
+## Conventions
+
+### Commit messages
+
+- Lowercase, imperative, no period at end
+- Short and direct: `"fix broken links"`, `"add sliding time window skill"`
+- Multi-step changes use `*` bullet points in body
+
+### PR titles
+
+- Lowercase, technical, under 70 chars
+- Action or problem focused: `"fix X"`, `"add docs for Y"`, `"refactor Z"`
+
+### PRs
+
+- Small, focused: one logical change per PR
+- 1-2 sentence summary of what the PR does
+- Link related PRs/issues

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 Qdrant
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Qdrant Solutions GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,26 @@
-# Qdrant Skills
+# Qdrant Skills - Agent Skills for Qdrant Vector Search
 
-A collection of [Agent Skills](https://agentskills.io/) for building with Qdrant vector search.
+<p align="center">
+  <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/qdrant/qdrant/raw/master/docs/logo-dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://github.com/qdrant/qdrant/raw/master/docs/logo-light.svg">
+      <img height="100" alt="Qdrant" src="https://github.com/qdrant/qdrant/raw/master/docs/logo.svg">
+  </picture>
+</p>
 
-## Installing
+<p align="center">
+    <b>Agent skills for building with Qdrant vector search</b>
+</p>
 
-These skills work with any agent that supports the Agent Skills standard, including Claude Code, OpenCode, OpenAI Codex, and Pi.
+Skills encode deep Qdrant knowledge so coding agents can make the engineering decisions that determine whether vector search works well: quantization, sharding, tenant isolation, hybrid search, model migration, and more.
+
+
+## Disclaimer
+
+These skills are under active development. Skill content and structure may change between versions as Qdrant evolves.
+
+
+## Installation
 
 ### Claude Code
 
@@ -13,6 +29,10 @@ Install using the [plugin marketplace](https://code.claude.com/docs/en/discover-
 ```
 /plugin marketplace add qdrant/skills
 ```
+
+### Cursor
+
+Install from the Cursor Marketplace or add manually via **Settings > Rules > Add Rule > Remote Rule (Github)** with `qdrant/skills`.
 
 ### npx skills
 
@@ -29,9 +49,27 @@ Clone this repo and copy the skill folders into the appropriate directory for yo
 | Agent | Skill Directory | Docs |
 |-------|-----------------|------|
 | Claude Code | `~/.claude/skills/` | [docs](https://code.claude.com/docs/en/skills) |
+| Cursor | `.cursor/skills/` | [docs](https://docs.cursor.com/context/skills) |
 | OpenCode | `~/.config/opencode/skill/` | [docs](https://opencode.ai/docs/skills/) |
 | OpenAI Codex | `~/.codex/skills/` | [docs](https://developers.openai.com/codex/skills/) |
 | Pi | `~/.pi/agent/skills/` | [docs](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent#skills) |
+
+
+## Quick Start
+
+After installing, just ask your agent about Qdrant. Skills are triggered automatically when your question matches their description.
+
+```
+"I have 50M vectors on a single node and search is slow, should I add more nodes?"
+→ qdrant-scaling skill activates, recommends quantization and vertical scaling before adding nodes
+
+"My search results are returning irrelevant matches"
+→ qdrant-search-quality skill activates, walks through diagnosis and search strategy options
+
+"How do I switch from OpenAI embeddings to Cohere without downtime?"
+→ qdrant-model-migration skill activates, guides zero-downtime migration with dual vectors
+```
+
 
 ## Skills
 
@@ -48,8 +86,26 @@ Skills are triggered automatically when your question matches their description.
 | qdrant-model-migration | Switching embedding models without downtime |
 | qdrant-version-upgrade | Safe upgrade paths, compatibility guarantees, rolling upgrades |
 
-## Resources
 
-- [Qdrant Documentation](https://search.qdrant.tech/md/documentation/)
-- [mcp-code-snippets](https://github.com/qdrant/mcp-code-snippets) - MCP server for searching Qdrant docs and code examples
-- [mcp-server-qdrant](https://github.com/qdrant/mcp-server-qdrant) - Official Qdrant MCP server
+## MCP Servers
+
+For additional Qdrant context, pair skills with these MCP servers:
+
+| Server | Purpose |
+|--------|---------|
+| [mcp-code-snippets](https://github.com/qdrant/mcp-code-snippets) | Search Qdrant docs and code examples across all SDKs |
+| [mcp-server-qdrant](https://github.com/qdrant/mcp-server-qdrant) | Store and retrieve memories, manage collections directly |
+
+
+## Getting Help
+
+Found a bug or wrong advice in a skill? [Open an issue](https://github.com/qdrant/skills/issues/new) on GitHub and include:
+
+- The skill name
+- The prompt you gave your agent
+- What the agent said vs what it should have said
+
+
+## Contributing
+
+If you are interested in contributing follow the instructions in [CONTRIBUTING.md](./CONTRIBUTING.md).


### PR DESCRIPTION
updates repo documentation and cleans up for release.

- **README.md**: full rewrite with logo, disclaimer, quick start, cursor support, 8 correct skills, MCP servers, getting help, contributing link
- **LICENSE**: MIT to Apache 2.0 (Qdrant Solutions GmbH), matching qdrant/qdrant and qcloud-cli
- **plugin.json / marketplace.json**: updated descriptions to match actual skills
- **AGENTS.md / CONTRIBUTING.md**: removed stale commands/ and scripts/ references
- **commands/**: deleted (supersedes #22 drop-commands)
- **.gitignore**: OS, eval workspace, editor, python artifacts