### PR TITLE
add PR template and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,32 @@
+name: bug report
+description: skill gives wrong or outdated advice
+labels: ["bug"]
+body:
+  - type: input
+    id: skill
+    attributes:
+      label: skill name
+      placeholder: "e.g., qdrant-scaling, qdrant-search-quality"
+    validations:
+      required: true
+  - type: textarea
+    id: prompt
+    attributes:
+      label: what did you ask?
+      description: paste the prompt you gave the agent
+    validations:
+      required: true
+  - type: textarea
+    id: wrong-advice
+    attributes:
+      label: what did the agent recommend?
+      description: what was wrong or misleading about the response?
+    validations:
+      required: true
+  - type: textarea
+    id: correct-advice
+    attributes:
+      label: what should it recommend instead?
+      description: the correct advice, with links to docs if possible
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/skill-request.yml
+++ b/.github/ISSUE_TEMPLATE/skill-request.yml
@@ -1,0 +1,38 @@
+name: skill request
+description: request a new skill or improvement to an existing one
+labels: ["skill-request"]
+body:
+  - type: textarea
+    id: scenario
+    attributes:
+      label: scenario
+      description: what production question or situation should the skill handle?
+      placeholder: "e.g., 'my qdrant cluster memory keeps growing after bulk uploads'"
+    validations:
+      required: true
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: what does the agent do today?
+      description: without the skill, what does the agent recommend? what's wrong with it?
+      placeholder: "e.g., 'suggests generic quantization without checking what's actually using memory'"
+    validations:
+      required: false
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: what should the agent recommend?
+      description: what would a solutions architect say? include specific config values or diagnostic steps if you know them.
+      placeholder: "e.g., 'check /telemetry for per-segment breakdown first, distinguish RSSAnon from page cache'"
+    validations:
+      required: true
+  - type: dropdown
+    id: existing-skill
+    attributes:
+      label: does a related skill already exist?
+      options:
+        - "no, this is a new topic"
+        - "yes, but it's missing this case"
+        - "not sure"
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## What this PR does
+
+<!-- 1-2 sentences. what changed and why. -->
+
+
+## Type
+
+<!-- check one -->
+- [ ] new skill
+- [ ] skill improvement
+- [ ] new command
+- [ ] bug fix
+- [ ] repo hygiene
+
+## Checklist
+
+<!-- for new/improved skills, check all that apply -->
+- [ ] `python3 scripts/validate_skills.py` passes
+- [ ] description has `Use when` with 5+ trigger phrases
+- [ ] leaf skills omit `allowed-tools`, hub skills declare them
+- [ ] ends with `## What NOT to Do` section
+- [ ] no code blocks in skills (code belongs in commands/)
+- [ ] all doc links go to `qdrant.tech/documentation/`
+- [ ] tested with a realistic prompt (paste below or link to eval)
+
+## Test prompt
+
+<!-- paste a realistic user question you tested this skill against, and summarize what the agent responded. skip for non-skill PRs. -->
+
+```
+<prompt here>
+```


### PR DESCRIPTION
adds GitHub templates for consistent contribution flow.

- **PR template**: skill checklist (trigger phrases, permissions, "What NOT to Do"), test prompt section
- **issue templates**: skill request (scenario, current vs expected behavior) and bug report (wrong advice)