### PR TITLE
add skill eval pipeline on push to main

### DIFF
--- a/.github/workflows/eval-skills.yml
+++ b/.github/workflows/eval-skills.yml
@@ -1,0 +1,34 @@
+name: eval skills
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'skills/**'
+      - 'evals/**'
+      - 'scripts/run_eval.py'
+
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: install claude cli
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: run skill evals
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: python3 scripts/run_eval.py
+
+      - name: upload eval results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-results
+          path: eval-results.json

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -1,0 +1,77 @@
+{
+  "skill_name": "qdrant-scaling",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "hey so we have about 50M vectors with 768 dimensions in qdrant and we're running on a single 64gb ram node. searches are getting slow, like 200ms p99, and we need to get that under 50ms. should we add more nodes or what?",
+      "expected_output": "Should recommend vertical scaling first (quantization, RAM check, HNSW tuning), explain latency vs throughput tradeoff, suggest segment count increase for latency, mention quantization to reduce memory footprint",
+      "expectations": [
+        "Mentions quantization as a way to reduce memory usage",
+        "Distinguishes between latency and throughput optimization",
+        "Recommends checking RAM utilization before adding nodes",
+        "Suggests increasing segment count for lower latency",
+        "Does not immediately jump to horizontal scaling"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "we're building a multi-tenant SaaS and currently have about 5000 tenants each with maybe 10k-100k vectors. we've been creating one collection per tenant but we're hitting limits. what's the right architecture?",
+      "expected_output": "Should strongly recommend payload partitioning over collection-per-tenant, mention is_tenant=true index, explain that collection-per-tenant doesn't scale past hundreds",
+      "expectations": [
+        "Recommends against one collection per tenant",
+        "Suggests payload partitioning as the primary approach",
+        "Mentions is_tenant=true for the tenant index",
+        "References the multitenancy documentation",
+        "Mentions that collection-per-tenant doesn't scale past a few hundred"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "we index social media posts for semantic search and only care about the last 3 months. right now we just delete old posts with a cron job but the cluster performance keeps degrading after deletes. any better approach?",
+      "expected_output": "Should recommend shard rotation over filter-and-delete, explain that deletes create tombstones that degrade search, mention shard key per time period with instant resource reclamation",
+      "expectations": [
+        "Recommends shard rotation as the preferred approach",
+        "Explains why filter-and-delete causes performance degradation (tombstones)",
+        "Mentions that deleting a shard key reclaims resources instantly",
+        "Describes the shard rotation workflow (create shard key per period, delete oldest)",
+        "References the user-defined sharding documentation"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "our qdrant cluster has 3 nodes with 2 shards and we want to add 2 more nodes for capacity. but after adding the nodes the data is still on the original nodes. how do we redistribute?",
+      "expected_output": "Should explain that shards don't auto-redistribute, mention shard move API, recommend 6 shards for a 5-node cluster, warn about resharding cost",
+      "expectations": [
+        "Explains that adding nodes doesn't automatically redistribute data",
+        "Mentions the shard move API for redistribution",
+        "Recommends a shard count that's a multiple of node count",
+        "Warns that resharding is expensive and time-consuming",
+        "Mentions that resharding is only available in Qdrant Cloud"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "we're running qdrant 1.14 and want to upgrade to 1.17. our cluster has replication factor 1 and 2 nodes. what's the safest upgrade path?",
+      "expected_output": "Should warn about step-by-step upgrade requirement (1.14->1.15->1.16->1.17), warn that replication_factor:1 means downtime during upgrade, recommend upgrading SDK first",
+      "expectations": [
+        "States that storage compatibility is only guaranteed for one minor version",
+        "Recommends upgrading step by step: 1.14 to 1.15 to 1.16 to 1.17",
+        "Warns that replication_factor:1 cannot guarantee zero-downtime upgrade",
+        "Recommends upgrading SDK before server",
+        "Mentions Qdrant Cloud can automate multi-version jumps"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "we need to handle about 500 QPS on our qdrant instance but currently maxing out at around 150. single node, 32gb ram, 8 cpu cores, 20M vectors at 384 dims. what should we tune?",
+      "expected_output": "Should recommend fewer larger segments, quantization with always_ram, batch search API, and if still not enough then read replicas",
+      "expectations": [
+        "Recommends reducing segment count (default_segment_number: 2)",
+        "Suggests quantization with always_ram=true",
+        "Mentions batch search API to amortize overhead",
+        "Suggests limiting optimizer CPU budget to reserve cores for queries",
+        "Only recommends horizontal scaling (replicas) after tuning is exhausted"
+      ]
+    }
+  ]
+}

--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Run skill evals using claude -p and grade responses."""
+
+import json
+import subprocess
+import sys
+import re
+from pathlib import Path
+
+# skill -> list of skill files to read
+SKILL_MAP = {
+    1: [
+        "skills/qdrant-scaling/SKILL.md",
+        "skills/qdrant-scaling/minimize-latency/SKILL.md",
+        "skills/qdrant-scaling/scaling-data-volume/vertical-scaling/SKILL.md",
+        "skills/qdrant-scaling/scaling-data-volume/horizontal-scaling/SKILL.md",
+    ],
+    2: [
+        "skills/qdrant-scaling/SKILL.md",
+        "skills/qdrant-scaling/scaling-data-volume/tenant-scaling/SKILL.md",
+    ],
+    3: [
+        "skills/qdrant-scaling/SKILL.md",
+        "skills/qdrant-scaling/scaling-data-volume/sliding-time-window/SKILL.md",
+    ],
+    4: [
+        "skills/qdrant-scaling/SKILL.md",
+        "skills/qdrant-scaling/scaling-data-volume/horizontal-scaling/SKILL.md",
+    ],
+    5: [
+        "skills/qdrant-version-upgrade/SKILL.md",
+    ],
+    6: [
+        "skills/qdrant-scaling/SKILL.md",
+        "skills/qdrant-scaling/scaling-qps/SKILL.md",
+    ],
+}
+
+
+def load_skill_context(eval_id: int, repo_root: Path) -> str:
+    files = SKILL_MAP.get(eval_id, [])
+    parts = []
+    for f in files:
+        path = repo_root / f
+        if path.exists():
+            parts.append(f"--- {f} ---\n{path.read_text()}")
+    return "\n\n".join(parts)
+
+
+def run_claude(prompt: str) -> str:
+    result = subprocess.run(
+        ["claude", "-p", "--output-format", "text"],
+        input=prompt,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        print(f"  claude -p failed: {result.stderr[:200]}", file=sys.stderr)
+        return ""
+    return result.stdout
+
+
+def grade_response(response: str, expectations: list[str]) -> list[dict]:
+    grade_prompt = f"""Grade this response against each assertion. For each, output exactly one line:
+PASS|<assertion>|<brief evidence>
+or
+FAIL|<assertion>|<brief reason>
+
+Response to grade:
+{response}
+
+Assertions:
+{chr(10).join(f'- {e}' for e in expectations)}
+
+Output only the PASS/FAIL lines, nothing else."""
+
+    output = run_claude(grade_prompt)
+    results = []
+    for exp in expectations:
+        passed = False
+        evidence = "no grading output"
+        for line in output.strip().split("\n"):
+            if exp.lower()[:40] in line.lower():
+                passed = line.upper().startswith("PASS")
+                parts = line.split("|", 2)
+                evidence = parts[2].strip() if len(parts) > 2 else ""
+                break
+        results.append({"text": exp, "passed": passed, "evidence": evidence})
+    return results
+
+
+def main():
+    repo_root = Path(__file__).parent.parent
+    evals_path = repo_root / "evals" / "evals.json"
+
+    if not evals_path.exists():
+        print("error: evals/evals.json not found")
+        sys.exit(1)
+
+    evals = json.loads(evals_path.read_text())
+
+    total_passed = 0
+    total_assertions = 0
+    results = []
+
+    for ev in evals["evals"]:
+        eval_id = ev["id"]
+        prompt = ev["prompt"]
+        expectations = ev["expectations"]
+
+        print(f"\n=== eval {eval_id}: {prompt[:60]}... ===")
+
+        # run with skill context
+        skill_context = load_skill_context(eval_id, repo_root)
+        full_prompt = f"""You have access to the following Qdrant skill knowledge:
+
+{skill_context}
+
+Using this knowledge, answer the following question. Be specific with config recommendations and include doc links where the skill provides them.
+
+User question: {prompt}"""
+
+        print("  running claude with skill...")
+        response = run_claude(full_prompt)
+
+        if not response:
+            print("  ERROR: no response from claude")
+            for exp in expectations:
+                results.append({"eval_id": eval_id, "text": exp, "passed": False, "evidence": "no response"})
+            total_assertions += len(expectations)
+            continue
+
+        print("  grading...")
+        grades = grade_response(response, expectations)
+
+        passed = sum(1 for g in grades if g["passed"])
+        total = len(grades)
+        total_passed += passed
+        total_assertions += total
+
+        for g in grades:
+            status = "PASS" if g["passed"] else "FAIL"
+            print(f"  {status}: {g['text']}")
+            results.append({"eval_id": eval_id, **g})
+
+        print(f"  score: {passed}/{total}")
+
+    print(f"\n{'='*50}")
+    print(f"TOTAL: {total_passed}/{total_assertions} ({total_passed/total_assertions*100:.0f}%)")
+
+    # write results
+    output_path = repo_root / "eval-results.json"
+    output_path.write_text(json.dumps({
+        "total_passed": total_passed,
+        "total_assertions": total_assertions,
+        "pass_rate": total_passed / total_assertions if total_assertions > 0 else 0,
+        "results": results,
+    }, indent=2))
+    print(f"results written to {output_path}")
+
+    # fail if pass rate drops below 80%
+    pass_rate = total_passed / total_assertions if total_assertions > 0 else 0
+    if pass_rate < 0.8:
+        print(f"\nFAIL: pass rate {pass_rate:.0%} below 80% threshold")
+        sys.exit(1)
+    else:
+        print(f"\nPASS: {pass_rate:.0%} pass rate")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
runs skill evals after merge to main. catches quality regressions without burning API credits on every PR.

- **evals/evals.json**: 6 test prompts with 30 assertions across scaling, tenants, time windows, resharding, version upgrade, QPS
- **scripts/run_eval.py**: runs claude -p with skill context, grades responses, fails below 80% pass rate
- **eval-skills.yml**: triggers on push to main when skills/ or evals/ change, uploads results as artifact

requires ANTHROPIC_API_KEY repo secret (already set).