### PR TITLE
fix: correct grammar and capitalization in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Install using the [plugin marketplace](https://code.claude.com/docs/en/discover-
 
 ### Cursor
 
-Install from the Cursor Marketplace or add manually via **Settings > Rules > Add Rule > Remote Rule (Github)** with `qdrant/skills`.
+Install from the Cursor Marketplace or add manually via **Settings > Rules > Add Rule > Remote Rule (GitHub)** with `qdrant/skills`.
 
 ### npx skills
 
@@ -108,4 +108,4 @@ Found a bug or wrong advice in a skill? [Open an issue](https://github.com/qdran
 
 ## Contributing
 
-If you are interested in contributing follow the instructions in [CONTRIBUTING.md](./CONTRIBUTING.md).
+If you are interested in contributing, follow the instructions in [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/skills/qdrant-clients-sdk/SKILL.md
+++ b/skills/qdrant-clients-sdk/SKILL.md
@@ -22,15 +22,14 @@ Qdrant has the following officially supported client SDKs:
 
 ## API Reference
 
-All interaction with Qdrant takes place via the REST API. We recommend using REST API if you are using Qdrant for the first time or if you are working on a 
-prototype.
+All interaction with Qdrant can happen through the REST API or gRPC API. We recommend using the REST API if you are using Qdrant for the first time or working on a prototype.
 
 * REST API - [OpenAPI Reference](https://api.qdrant.tech/api-reference) - [GitHub](https://github.com/qdrant/qdrant/blob/master/docs/redoc/master/openapi.json)
 * gRPC API - [gRPC protobuf definitions](https://github.com/qdrant/qdrant/tree/master/lib/api/src/grpc/proto)
 
 ## Code examples
 
-To obtain code examples for a specific client and use-case, you can make a search request to library of curated code snippets for Qdrant client.
+To obtain code examples for a specific client and use case, you can send a search request to the library of curated code snippets for the Qdrant client.
 
 ```bash
 curl -X GET "https://snippets.qdrant.tech/search?language=python&query=how+to+upload+points"
@@ -72,4 +71,4 @@ client.upload_points(
 )
 ```
 
-If snippet output is required in json format, you can add `&format=json` to the query string
+If snippet output is required in JSON format, you can add `&format=json` to the query string.

--- a/skills/qdrant-performance-optimization/SKILL.md
+++ b/skills/qdrant-performance-optimization/SKILL.md
@@ -24,7 +24,7 @@ More on search speed optimization can be found in the [Search Speed Optimization
 
 ## Indexing Performance Optimization
 
-Qdrant needs to build vector index in order to perform efficient similarity search. The time it takes to build the index can vary depending on the size of your dataset, hardware or configuration.
+Qdrant needs to build a vector index to perform efficient similarity search. The time it takes to build the index can vary depending on the size of your dataset, hardware, and configuration.
 
 More on indexing performance optimization can be found in the [Indexing Performance Optimization](indexing-performance-optimization/SKILL.md) skill.
 
@@ -32,6 +32,6 @@ More on indexing performance optimization can be found in the [Indexing Performa
 ## Memory Usage Optimization
 
 Vector search can be memory intensive, especially when dealing with large datasets.
-Qdrant have a flexible memory management system, which allows you to precisely control which part of the storage is kept in memory and which part is stored on disk. This can help you optimize memory usage without sacrificing performance.
+Qdrant has a flexible memory management system, which allows you to precisely control which parts of storage are kept in memory and which are stored on disk. This can help you optimize memory usage without sacrificing performance.
 
 More on memory usage optimization can be found in the [Memory Usage Optimization](memory-usage-optimization/SKILL.md) skill.

--- a/skills/qdrant-performance-optimization/indexing-performance-optimization/SKILL.md
+++ b/skills/qdrant-performance-optimization/indexing-performance-optimization/SKILL.md
@@ -56,16 +56,15 @@ Use when: HNSW index build dominates total indexing time.
 
 ## HNSW index for multi-tenant collections
 
-If you have a multi-tenant use-case, where all data is split by some payload field (e.g. `tenant_id`), you can avoid building global HNSW index and instead rely on `payload_m` value to only build HNSW index for subsets of data.
+If you have a multi-tenant use case where all data is split by some payload field (e.g. `tenant_id`), you can avoid building a global HNSW index and instead rely on `payload_m` to build HNSW index only for subsets of data.
 Skipping global HNSW index can significantly reduce indexing time.
 
 See [Multi-tenant collections](https://search.qdrant.tech/md/documentation/manage-data/multitenancy/) for details.
 
-## Additional payload indexes is too slow
+## Additional Payload Indexes Are Too Slow
 
 Qdrant builds extra HNSW links for all payload indexes to ensure that quality of filtered vector search does not degrade.
-Some payload indexes (e.g. `text` type with long texts) can have very high number or 
-unique values per point, which can lead to long HNSW build time.
+Some payload indexes (e.g. `text` fields with long texts) can have a very high number of unique values per point, which can lead to long HNSW build time.
 
 You can disable building extra HNSW links for specific payload index and instead rely on slightly slower query-time strategies like ACORN.
 
@@ -77,5 +76,5 @@ Read more about ACORN in [documentation](https://search.qdrant.tech/md/documenta
 ## What NOT to Do
 
 - Do not create payload indexes AFTER HNSW is built (breaks filterable vector index)
-- Do not use `m=0` for bulk uploads into existing collection, it might drop existing HNSW and cause long reindexing 
+- Do not use `m=0` for bulk uploads into an existing collection, it might drop the existing HNSW and cause long reindexing 
 - Do not upload one point at a time (per-request overhead dominates)

--- a/skills/qdrant-performance-optimization/memory-usage-optimization/SKILL.md
+++ b/skills/qdrant-performance-optimization/memory-usage-optimization/SKILL.md
@@ -5,17 +5,17 @@ description: "Diagnoses and reduces Qdrant memory usage. Use when someone report
 
 # Understanding memory usage
 
-Qdrant operates with 2 types of RAM memory: 
+Qdrant operates with two types of memory:
 
-- Resident memory (aka RSSAnon) - memory used for internal data structures like ID tracker, and some components forced to stay in RAM, quantized vectors if `always_ram=true`, payload indexes, e.t.c.
+- Resident memory (aka RSSAnon) - memory used for internal data structures like the ID tracker, plus components that must stay in RAM, such as quantized vectors when `always_ram=true` and payload indexes.
 
 - OS page cache - memory used for caching disk reads, which can be released when needed. Original vectors are normally stored in page cache, so the service won't crash if RAM is full, but performance may degrade.
 
-It is normal for OS page cache to occupy whole available RAM, but if resident memory is above 80% of total, it's a sign of a problem.
+It is normal for the OS page cache to occupy all available RAM, but if resident memory is above 80% of total RAM, it is a sign of a problem.
 
 ## Memory usage monitoring
 
-- Qdrant exposes memory usage with `/metrics` endpoint see more in [Monitoring docs](https://search.qdrant.tech/md/documentation/operations/monitoring/).
+- Qdrant exposes memory usage through the `/metrics` endpoint. See [Monitoring docs](https://search.qdrant.tech/md/documentation/operations/monitoring/).
 
 <!-- ToDo: Talk about memory usage of each components once API is available -->
 
@@ -24,14 +24,14 @@ It is normal for OS page cache to occupy whole available RAM, but if resident me
 
 Optimal memory usage depends on the use case.
 
-- For regular search scenarios general guidelines are provided in [Capacity planning docs](https://search.qdrant.tech/md/documentation/operations/capacity-planning/).
+- For regular search scenarios, general guidelines are provided in the [Capacity planning docs](https://search.qdrant.tech/md/documentation/operations/capacity-planning/).
 
-For detailed breakdown of memory usage on a large scale example see [Large scale memory usage example](https://search.qdrant.tech/md/documentation/tutorials-operations/large-scale-search/?s=memory-usage).
+For a detailed breakdown of memory usage at large scale, see [Large scale memory usage example](https://search.qdrant.tech/md/documentation/tutorials-operations/large-scale-search/?s=memory-usage).
 
 Payload indexes and HNSW graph also require memory, along with vectors themselves, so it's important to consider them in calculations.
 
-Additionally, qdrant requires some extra memory for optimizations. During optimization, optimized segments are fully loaded into RAM, so it is important to have some headroom for that.
-Larger the `max_segment_size`, more headroom is needed.
+Additionally, Qdrant requires some extra memory for optimizations. During optimization, optimized segments are fully loaded into RAM, so it is important to leave enough headroom.
+The larger `max_segment_size` is, the more headroom is needed.
 
 
 ### When to put HNSW index on disk
@@ -49,19 +49,19 @@ There are some scenarios, however, when it can be a good option:
 The main challenge is to put on disk those parts of data, which are rarely accessed.
 Here are the main techniques to achieve that:
 
-- Use quantization to store only compressed vectors in ram [Quantization docs](https://search.qdrant.tech/md/documentation/manage-data/quantization/)
+- Use quantization to store only compressed vectors in RAM [Quantization docs](https://search.qdrant.tech/md/documentation/manage-data/quantization/)
 
 - Use float16 or int8 datatypes to reduce memory usage of vectors by 2x or 4x respectively, with some tradeoff in precision. Read more about vector datatypes in [documentation](https://search.qdrant.tech/md/documentation/manage-data/vectors/?s=datatypes)
 
-- Leverage Matryoshka Representation Learning (MRL) to store only small vectors in RAM, while keeping large vectors on disk. Examples of how to use MRL with qdrant cloud inference: [MRL docs](https://search.qdrant.tech/md/documentation/inference/?s=reduce-vector-dimensionality-with-matryoshka-models)
+- Leverage Matryoshka Representation Learning (MRL) to store only small vectors in RAM while keeping large vectors on disk. Examples of how to use MRL with Qdrant Cloud inference: [MRL docs](https://search.qdrant.tech/md/documentation/inference/?s=reduce-vector-dimensionality-with-matryoshka-models)
 
-- For multi-tenant deployments with small tenants, vectors might be stored on-disk, as same tenant data is stored together [Multitenancy docs](https://search.qdrant.tech/md/documentation/manage-data/multitenancy/?s=calibrate-performance)
+- For multi-tenant deployments with small tenants, vectors might be stored on disk because the same tenant's data is stored together [Multitenancy docs](https://search.qdrant.tech/md/documentation/manage-data/multitenancy/?s=calibrate-performance)
 
 - For deployments with fast local storage and relatively low requirements for search throughput, it may be possible to store all components of vector store on disk. Read more about the performance implications of on-disk storage in [the article](https://qdrant.tech/articles/memory-consumption/)
 
 - For low RAM environments, consider `async_scorer` config, which enables support of `io_uring` for parallel disk access, which can significantly improve performance of on-disk storage. Read more about `async_scorer` in [the article](https://qdrant.tech/articles/io_uring/) (only available on Linux with kernel 5.11+)
 
-- Consider storing Sparse Vectors and text payload on disk, as they are usually more disk-friently compared to dense vectors. 
-    - Configuring payload indexes to be stored on disk [docs](https://search.qdrant.tech/md/documentation/manage-data/indexing/?s=on-disk-payload-index)
-    - Configuring sparse vectors to be stored on disk [docs](https://search.qdrant.tech/md/documentation/manage-data/indexing/?s=sparse-vector-index)
+- Consider storing Sparse Vectors and text payload on disk, as they are usually more disk-friendly than dense vectors.
+- Configure payload indexes to be stored on disk [docs](https://search.qdrant.tech/md/documentation/manage-data/indexing/?s=on-disk-payload-index)
+- Configure sparse vectors to be stored on disk [docs](https://search.qdrant.tech/md/documentation/manage-data/indexing/?s=sparse-vector-index)
 

--- a/skills/qdrant-scaling/scaling-data-volume/SKILL.md
+++ b/skills/qdrant-scaling/scaling-data-volume/SKILL.md
@@ -9,12 +9,12 @@ allowed-tools:
 
 # Scaling Data Volume
 
-This document covers scenarios of scaling for data volume,
- where the total size of the dataset exceeds the capacity of a single node.
+This document covers data volume scaling scenarios,
+where the total size of the dataset exceeds the capacity of a single node.
 
 ## Tenant Scaling
 
-If the use-case is multi-tenant, meaning that the single user only have access to a subset of the data, 
+If the use case is multi-tenant, meaning that each user only has access to a subset of the data,
 and we never need to query across all the data, then we can use multi-tenancy patterns to scale.
 
 The recommended way is to use multi-tenant workloads with payload partitioning, per-tenant indexes, and tiered multitenancy.
@@ -31,7 +31,7 @@ Learn more [Sliding Time Window](sliding-time-window/SKILL.md)
 ## Global Search
 
 Most general use-cases require global search across all data.
-In this situations, we might need to fallback to vertical scaling,
+In these situations, we might need to fall back to vertical scaling,
 and then horizontal scaling when we reach the limits of vertical scaling.
 
 

--- a/skills/qdrant-scaling/scaling-data-volume/tenant-scaling/SKILL.md
+++ b/skills/qdrant-scaling/scaling-data-volume/tenant-scaling/SKILL.md
@@ -13,16 +13,16 @@ Here is a short summary of the patterns:
 
 ## Number of Tenants is around 10k
 
-Use default strategy of multitenancy via payload filtering.
+Use the default multitenancy strategy via payload filtering.
 
 Read about [Partition by payload](https://search.qdrant.tech/md/documentation/manage-data/multitenancy/?s=partition-by-payload) and [Calibrate performance](https://search.qdrant.tech/md/documentation/manage-data/multitenancy/?s=calibrate-performance) for best practices on indexing and query performance.
 
 
 ## Number of Tenants is around 100k and more
 
-At this scale, cluster may consist of several peers.
+At this scale, the cluster may consist of several peers.
 To localize tenant data and improve performance, use [custom sharding](https://search.qdrant.tech/md/documentation/operations/distributed_deployment/?s=user-defined-sharding) to assign tenants to specific shards based on tenant ID hash.
-This will localize tenant request to only specific nodes instead of broadcasting to all nodes, improving performance and reducing load on each node.
+This will localize tenant requests to specific nodes instead of broadcasting them to all nodes, improving performance and reducing load on each node.
 
 ## If tenants are unevenly sized
 

--- a/skills/qdrant-search-quality/search-strategies/SKILL.md
+++ b/skills/qdrant-search-quality/search-strategies/SKILL.md
@@ -6,7 +6,7 @@ description: "Guides Qdrant search strategy selection. Use when someone asks 'sh
 # How to Improve Search Results with Advanced Strategies
 
 These strategies complement basic vector search. Use them after confirming the embedding model is fitting the task and HNSW config is correct. If exact search returns bad results, verify the selection of the embedding model (retriever) first.
-If user wants to use weak embedding model (small but fast and cheap), you can use reranking or relevance feedback to increase its search quality.
+If the user wants to use a weaker embedding model because it is small, fast, and cheap, use reranking or relevance feedback to improve search quality.
 
 ## Missing Obvious Keyword Matches
 
@@ -17,15 +17,15 @@ Use when: pure vector search misses results that contain obvious keyword matches
 - For non-English languages, [configure sparse BM25 parameters accordingly](https://search.qdrant.tech/md/documentation/search/text-search/?s=language-specific-settings)
 - RRF: good default, supports weighted (v1.17+) [RRF](https://search.qdrant.tech/md/documentation/search/hybrid-queries/?s=reciprocal-rank-fusion-rrf)
 - DBSF with asymmetric limits (sparse_limit=250, dense_limit=100) can outperform RRF for technical docs [DBSF](https://search.qdrant.tech/md/documentation/search/hybrid-queries/?s=distribution-based-score-fusion-dbsf)
-- Fusion can be also done through reranking
+- Fusion can also be done through reranking
 
 ## Right Documents Found But Wrong Order
 
 Use when: good recall but poor precision (right docs in top-100, not top-10).
 
 - Cross-encoder rerankers via FastEmbed [Rerankers](https://search.qdrant.tech/md/documentation/fastembed/fastembed-rerankers/)
-- Check on how to do [Multistage queries](https://search.qdrant.tech/md/documentation/search/hybrid-queries/?s=multi-stage-queries) in Qdrant
-- ColBERT and ColPali/ColQwen reranking is especially precise due to late interaction mechanisms, however, heavy. It's important to configure & store multivectors without building HNSW for them, to save on resources, see more [Multivector-representation](https://search.qdrant.tech/md/documentation/tutorials-search-engineering/using-multivector-representations/)
+- See how to use [Multistage queries](https://search.qdrant.tech/md/documentation/search/hybrid-queries/?s=multi-stage-queries) in Qdrant
+- ColBERT and ColPali/ColQwen reranking is especially precise due to late interaction mechanisms, but it is heavy. It is important to configure and store multivectors without building HNSW for them to save resources. See [Multivector representation](https://search.qdrant.tech/md/documentation/tutorials-search-engineering/using-multivector-representations/)
 
 ## Right Documents Not Found But They Are There
 
@@ -38,9 +38,9 @@ A feedback model is anything producing a relevance score per document: a bi-enco
 Skip when: if the retriever already has strong recall, or if retriever and feedback model strongly agree on relevance.
 
 - RF Query is currently based on a [3-parameter naive formula](https://search.qdrant.tech/md/documentation/search/search-relevance/?s=naive-strategy) with no universal defaults, so it must be tuned per dataset, retriever, and feedback model
-- Use [qdrant-relevance-feedback](https://pypi.org/project/qdrant-relevance-feedback/) to tune parameters, evaluate impact with Evaluator, and check retriever-feedback agreement. See README for setup instructions. No GPUs needed for running & framework also provides predefined retriever & feedback model options.
-- Check configuration of [Relevance Feedback Query API](https://search.qdrant.tech/md/documentation/search/search-relevance/?s=relevance-feedback)
-- Use as a helper end-to-end text retrieval example with parameter tuning and evals to understand on how to use the API & run the `qdrant-relevance-feedback` framework: [RF tutorial](https://search.qdrant.tech/md/documentation/tutorials-search-engineering/using-relevance-feedback/)
+- Use [qdrant-relevance-feedback](https://pypi.org/project/qdrant-relevance-feedback/) to tune parameters, evaluate impact with Evaluator, and check retriever-feedback agreement. See README for setup instructions. No GPUs are needed, and the framework also provides predefined retriever and feedback model options.
+- Check the configuration of the [Relevance Feedback Query API](https://search.qdrant.tech/md/documentation/search/search-relevance/?s=relevance-feedback)
+- Use this as a helper end-to-end text retrieval example with parameter tuning and evals to understand how to use the API and run the `qdrant-relevance-feedback` framework: [RF tutorial](https://search.qdrant.tech/md/documentation/tutorials-search-engineering/using-relevance-feedback/)
 
 ## Results Too Similar
 

--- a/skills/qdrant-version-upgrade/SKILL.md
+++ b/skills/qdrant-version-upgrade/SKILL.md
@@ -12,10 +12,10 @@ Qdrant has the following guarantees about version compatibility:
 
 - Qdrant is tested for backward compatibility between minor versions. For example, Qdrant 1.17.x should be compatible with SDK 1.16.x. Qdrant server 1.16.x is also expected to be compatible with SDK 1.17.x, but only for the subset of features that were available in 1.16.x.
 
-- For migration to next minor version, it is recommended to first upgrade the SDK to the next minor version, and then upgrade the Qdrant server.
+- For migration to the next minor version, it is recommended to first upgrade the SDK to the next minor version and then upgrade the Qdrant server.
 
-- Storage compatibility is only guaranteed for one minor version. For example, data stored with Qdrant 1.16.x is expected to be compatible with Qdrant 1.17.x. If you need to migrate more than 1 minor version, it is required do the upgrade step by step, one minor version at a time. E.g. to migrate from 1.15.x to 1.17.x, you need to first upgrade to 1.16.x, and then to 1.17.x. Note: Qdrant cloud automates this process, so you can directly upgrade from 1.15.x to 1.17.x without intermediate steps.
+- Storage compatibility is only guaranteed for one minor version. For example, data stored with Qdrant 1.16.x is expected to be compatible with Qdrant 1.17.x. If you need to migrate more than one minor version, it is required do the upgrade step by step, one minor version at a time. For example, to migrate from 1.15.x to 1.17.x, you need to first upgrade to 1.16.x and then to 1.17.x. Note: Qdrant Cloud automates this process, so you can directly upgrade from 1.15.x to 1.17.x without intermediate steps.
 
-- Qdrant cluster with replication factor of 2 and above can be upgraded without downtime, by performing a rolling upgrade. This means that you can upgrade one node at a time, while the other nodes continue to serve requests. This allows you to maintain availability of your application during the upgrade process. More about replication factor: [Replication factor](https://search.qdrant.tech/md/documentation/operations/distributed_deployment/?s=replication-factor)
+- A Qdrant cluster with a replication factor of 2 or higher can be upgraded without downtime by performing a rolling upgrade. This means that you can upgrade one node at a time while the other nodes continue to serve requests. This allows you to maintain availability of your application during the upgrade process. More about replication factor: [Replication factor](https://search.qdrant.tech/md/documentation/operations/distributed_deployment/?s=replication-factor)
 
-For managing qdrant version upgrades in qdrant cloud you can use [qcloud](https://github.com/qdrant/qcloud-cli) CLI tool
+For managing Qdrant version upgrades in Qdrant Cloud, you can use the [qcloud](https://github.com/qdrant/qcloud-cli) CLI tool.


### PR DESCRIPTION
## What this PR does

fix docs grammar and capitalization and improve phrasing for consistency and readability


## Type

- [ ] new skill
- [ ] skill improvement
- [ ] new command
- [ ] bug fix
- [x] repo hygiene

## Checklist

<!-- for new/improved skills, check all that apply -->
- [ ] `python3 scripts/validate_skills.py` passes
- [ ] description has `Use when` with 5+ trigger phrases
- [ ] leaf skills omit `allowed-tools`, hub skills declare them
- [ ] ends with `## What NOT to Do` section
- [ ] no code blocks in skills (code belongs in commands/)
- [ ] all doc links go to `qdrant.tech/documentation/`
- [ ] tested with a realistic prompt (paste below or link to eval)

## Test prompt

 N/A - documentation only changes, no skill logic modified

