### PR TITLE
[new-skill]qdrant framework integrations support

### DIFF
--- a/skills/qdrant-integrations/SKILL.md
+++ b/skills/qdrant-integrations/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: qdrant-integrations
+description: "Guidance for integrating Qdrant with LangChain, LlamaIndex, Haystack, Cognee, and Google ADK. Use when someone asks: 'integrate Qdrant with LangChain', 'use Qdrant with LlamaIndex', 'connect Haystack to Qdrant', 'set up Cognee with Qdrant', 'use Google ADK with Qdrant', or 'how do I configure Qdrant in my framework app'."
+---
+
+# Qdrant Integrations
+
+Use this skill to pick the right integration package and configuration for common LLM/agent frameworks.
+
+## Need a Fast Integration Starting Point
+
+Use when: user has not chosen a framework-specific setup yet.
+
+- Start from the Qdrant frameworks index and jump to the exact integration page [Framework integrations](https://qdrant.tech/documentation/frameworks/)
+- Prefer the framework-specific Qdrant page over older blog posts for setup details [Framework integrations](https://qdrant.tech/documentation/frameworks/)
+
+## LangChain App Needs Dense, Sparse, or Hybrid Retrieval
+
+Use when: user asks for LangChain + Qdrant vector store setup.
+
+- Install the partner package: `pip install langchain-qdrant` [LangChain](https://qdrant.tech/documentation/frameworks/langchain/)
+- Use `QdrantVectorStore.from_texts` or `QdrantVectorStore.from_documents` for bootstrap [LangChain](https://qdrant.tech/documentation/frameworks/langchain/)
+- Set `retrieval_mode` explicitly (`DENSE`, `SPARSE`, `HYBRID`) to match your retrieval strategy [LangChain](https://qdrant.tech/documentation/frameworks/langchain/)
+- For sparse or hybrid retrieval, provide sparse embeddings (for example `FastEmbedSparse`) in addition to dense embeddings where required [LangChain](https://qdrant.tech/documentation/frameworks/langchain/)
+- Starter command + snippet: [LangChain](commands/langchain.md) [LangChain docs](https://qdrant.tech/documentation/frameworks/langchain/)
+
+## LlamaIndex Pipeline Needs Qdrant Vector Store
+
+Use when: user asks for LlamaIndex indexing/retrieval with Qdrant.
+
+- Install integration packages: `pip install llama-index llama-index-vector-stores-qdrant` [LlamaIndex](https://qdrant.tech/documentation/frameworks/llama-index/)
+- Create a `QdrantClient` and pass it into `QdrantVectorStore` [LlamaIndex](https://qdrant.tech/documentation/frameworks/llama-index/)
+- Build the index from that vector store (for example `VectorStoreIndex.from_vector_store`) [LlamaIndex](https://qdrant.tech/documentation/frameworks/llama-index/)
+- Starter command + snippet: [LlamaIndex](commands/llamaindex.md) [LlamaIndex docs](https://qdrant.tech/documentation/frameworks/llama-index/)
+
+## Haystack RAG Pipeline Needs a Qdrant Document Store
+
+Use when: user is building Haystack pipelines and needs Qdrant persistence/search.
+
+- Install the Qdrant Haystack package: `pip install qdrant-haystack` [Haystack](https://qdrant.tech/documentation/frameworks/haystack/)
+- Use `QdrantDocumentStore` as the backing store for documents and vectors [Haystack](https://qdrant.tech/documentation/frameworks/haystack/)
+- Apply advanced Qdrant collection/client options (including quantization config) through `QdrantDocumentStore` constructor settings [Haystack](https://qdrant.tech/documentation/frameworks/haystack/)
+- Starter command + snippet: [Haystack](commands/haystack.md) [Haystack docs](https://qdrant.tech/documentation/frameworks/haystack/)
+
+## Cognee Memory Graph Needs Qdrant as Vector Backend
+
+Use when: user wants Cognee memory + graph workflows backed by Qdrant.
+
+- Install adapter package: `pip install Cognee-community-vector-adapter-qdrant` [Cognee](https://qdrant.tech/documentation/frameworks/cognee/)
+- Register/configure Cognee with `vector_db_provider=qdrant` and `vector_dataset_database_handler=qdrant` [Cognee](https://qdrant.tech/documentation/frameworks/cognee/)
+- Set Qdrant connection values (`vector_db_url`, `vector_db_key`) in config or environment variables [Cognee](https://qdrant.tech/documentation/frameworks/cognee/)
+- Starter command + snippet: [Cognee](commands/cognee.md) [Cognee docs](https://qdrant.tech/documentation/frameworks/cognee/)
+
+## Google ADK Agent Needs Qdrant Tools
+
+Use when: user wants ADK agents to store/retrieve knowledge via Qdrant.
+
+- Install ADK: `pip install google-adk` [Google ADK](https://qdrant.tech/documentation/frameworks/google-adk/)
+- Connect ADK to Qdrant via Qdrant MCP Server in `McpToolset` configuration [Google ADK](https://qdrant.tech/documentation/frameworks/google-adk/)
+- Configure runtime variables like `QDRANT_URL` and `COLLECTION_NAME` for the MCP server process [Google ADK](https://qdrant.tech/documentation/frameworks/google-adk/)
+- Starter command + snippet: [Google ADK](commands/google-adk.md) [Google ADK docs](https://qdrant.tech/documentation/frameworks/google-adk/)
+
+## What NOT to Do
+
+- Do not mix integration packages across frameworks (for example, `qdrant-haystack` in a LangChain setup)
+- Do not set LangChain sparse/hybrid retrieval without configuring sparse embeddings
+- Do not leave Qdrant URL, API key, or collection names implicit when moving from local to cloud
+- Do not use generic framework docs as the primary source when a Qdrant integration page exists

--- a/skills/qdrant-integrations/commands/cognee.md
+++ b/skills/qdrant-integrations/commands/cognee.md
@@ -1,0 +1,55 @@
+# Cognee + Qdrant
+
+Docs: [Cognee](https://qdrant.tech/documentation/frameworks/cognee/)
+
+## Run
+
+`python3 commands/cognee.py`
+
+## Snippet
+
+```python
+import os,pathlib
+import asyncio
+
+import cognee
+from cognee_community_vector_adapter_qdrant import register 
+from constant import MY_PREFERENCE
+
+from dotenv import load_dotenv
+load_dotenv()
+
+system_path = pathlib.Path(__file__).parent
+cognee.config.system_root_directory(os.path.join(system_path, ".cognee_system"))
+cognee.config.data_root_directory(os.path.join(system_path, ".data_storage"))
+
+cognee.config.set_relational_db_config(
+    {
+        "db_provider": "sqlite",
+    }
+)
+cognee.config.set_vector_db_config({
+    "vector_db_provider": "qdrant",
+    "vector_db_url": os.getenv("QDRANT_API_URL", "http://localhost:6333"),
+    "vector_db_key": os.getenv("QDRANT_API_KEY", ""),
+    "vector_dataset_database_handler":"qdrant"
+})
+
+async def main():
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+
+    await cognee.add(MY_PREFERENCE,node_set="personal_tarun")
+    await cognee.add("- In Food I usually prefer Thali and Indian Vegetarian food places",node_set=["food"])
+
+    await cognee.cognify()
+    await cognee.memify()
+
+    results = await cognee.search("plan 3 days Itinerary for Rome based on my preference")
+
+    for result in results:
+        print(result)
+
+if __name__ == '__main__':
+    asyncio.run(main())
+```

--- a/skills/qdrant-integrations/commands/google-adk.md
+++ b/skills/qdrant-integrations/commands/google-adk.md
@@ -1,0 +1,37 @@
+# Google ADK + Qdrant
+
+Docs: [Google ADK](https://qdrant.tech/documentation/frameworks/google-adk/)
+
+## Run
+
+`python3 commands/google-adk.py`
+
+## Snippet
+
+```python
+from google.adk.agents import Agent
+from google.adk.tools.mcp_tool import McpToolset
+from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
+from mcp import StdioServerParameters
+
+root_agent = Agent(
+    model="gemini-2.5-pro",
+    name="qdrant_agent",
+    instruction="Help users store and retrieve information using semantic search",
+    tools=[
+        McpToolset(
+            connection_params=StdioConnectionParams(
+                server_params=StdioServerParameters(
+                    command="uvx",
+                    args=["mcp-server-qdrant"],
+                    env={
+                        "QDRANT_URL": "http://localhost:6333",
+                        "COLLECTION_NAME": "my_collection",
+                    },
+                ),
+                timeout=30,
+            )
+        )
+    ],
+)
+```

--- a/skills/qdrant-integrations/commands/haystack.md
+++ b/skills/qdrant-integrations/commands/haystack.md
@@ -1,0 +1,28 @@
+# Haystack + Qdrant
+
+Docs: [Haystack](https://qdrant.tech/documentation/frameworks/haystack/)
+
+## Run
+
+`python3 commands/haystack.py`
+
+## Snippet
+
+```python
+from qdrant_haystack.document_stores import QdrantDocumentStore
+from qdrant_client import models
+
+document_store = QdrantDocumentStore(
+    ":memory:",
+    index="Document",
+    embedding_dim=512,
+    recreate_index=True,
+    quantization_config=models.ScalarQuantization(
+        scalar=models.ScalarQuantizationConfig(
+            type=models.ScalarType.INT8,
+            quantile=0.99,
+            always_ram=True,
+        ),
+    ),
+)
+```

--- a/skills/qdrant-integrations/commands/langchain.md
+++ b/skills/qdrant-integrations/commands/langchain.md
@@ -1,0 +1,53 @@
+# LangChain + Qdrant
+
+Docs: [LangChain](https://qdrant.tech/documentation/frameworks/langchain/)
+
+## Run
+
+`python3 commands/langchain.py`
+
+## Snippet
+
+```python
+from langchain_qdrant import FastEmbedSparse, QdrantVectorStore, RetrievalMode
+from qdrant_client import QdrantClient, models
+from langchain_openai import OpenAIEmbeddings
+
+embeddings = OpenAIEmbeddings()
+sparse_embeddings = FastEmbedSparse(model_name="Qdrant/bm25")
+
+collection_name = "collection-name" # replace with your own
+dense_vector_name = "dense"
+sparse_vector_name = "sparse"
+
+client = QdrantClient(
+    url=QDRANT_URL,
+    api_key=QDRANT_API_KEY
+)
+client.create_collection(
+    collection_name = collection_name,
+    vectors_config = {
+        dense_vector_name : models.VectorParams(size = 1536,
+                                     distance = models.Distance.COSINE
+                                     )},
+    sparse_vectors_config={
+        sparse_vector_name: models.SparseVectorParams(
+            index = models.SparseIndexParams(on_disk=False),
+            modifier = models.Modifier.IDF,
+        )
+    })
+
+db = QdrantVectorStore(
+    client = client,
+    collection_name = collection_name,
+    embedding = dense_embeddings,
+    sparse_embedding = sparse_embeddings,
+    retrieval_mode = RetrievalMode.HYBRID,
+    vector_name =dense_vector_name,
+    sparse_vector_name = sparse_vector_name,
+)
+db.add_documents(documents=chunks) 
+
+results = db.similarity_search("find relevant context")
+print(results)
+```

--- a/skills/qdrant-integrations/commands/llamaindex.md
+++ b/skills/qdrant-integrations/commands/llamaindex.md
@@ -1,0 +1,23 @@
+# LlamaIndex + Qdrant
+
+Docs: [LlamaIndex](https://qdrant.tech/documentation/frameworks/llama-index/)
+
+## Run
+
+`python3 commands/llamaindex.py`
+
+## Snippet
+
+```python
+import qdrant_client
+from llama_index.core.indices.vector_store.base import VectorStoreIndex
+from llama_index.vector_stores.qdrant import QdrantVectorStore
+
+client = qdrant_client.QdrantClient(
+    "<qdrant-url>",
+    api_key="<qdrant-api-key>",
+)
+
+vector_store = QdrantVectorStore(client=client, collection_name="documents")
+index = VectorStoreIndex.from_vector_store(vector_store=vector_store)
+```


### PR DESCRIPTION
## What this PR does

 Add new qdrant-integrations skill with framework-specific setup guides

 ## What’s new

  - Added a new skill: skills/qdrant-integrations/SKILL.md
  - Added framework integration command guides under skills/qdrant-integrations/commands/:
      - langchain.md
      - llamaindex.md
      - haystack.md
      - cognee.md
      - google-adk.md

> Note-1: I have also ran the validate_scripts:
```
PASS  skills/qdrant-integrations/SKILL.md
```

> Note-2: Code snippets are inside Command as per the AgentSkills level-3 resource syntax

## Type

<!-- check one -->
- [x] new skill
- [ ] skill improvement
- [ ] new command
- [ ] bug fix
- [ ] repo hygiene

## Checklist

<!-- for new/improved skills, check all that apply -->
- [x] `python3 scripts/validate_skills.py` passes
- [x] description has `Use when` with 5+ trigger phrases
- [ ] leaf skills omit `allowed-tools`, hub skills declare them
- [x] ends with `## What NOT to Do` section
- [x] no code blocks in skills (code belongs in commands/)
- [x] all doc links go to `qdrant.tech/documentation/`
- [x] tested with a realistic prompt (paste below or link to eval)

## Test prompt

> Used Google Antigravity

```
Show me how to use Qdrant with LangChain in Python: initialize the Qdrant vector store, upsert a
  few sample documents, run a similarity search, and include a minimal end-to-end code example.
```

<img width="678" height="431" alt="Screenshot 2026-03-31 at 21 52 43" src="https://github.com/user-attachments/assets/adfee560-0011-4413-ae7f-89bfe5f692d6" />
