### PR TITLE
add skill philosophy to contributor docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,6 @@
 <!-- check one -->
 - [ ] new skill
 - [ ] skill improvement
-- [ ] new command
 - [ ] bug fix
 - [ ] repo hygiene
 
@@ -16,10 +15,12 @@
 
 <!-- for new/improved skills, check all that apply -->
 - [ ] `python3 scripts/validate_skills.py` passes
+- [ ] skill answers "when?" or "why?", not "how?"
+- [ ] skill navigates to docs, does not duplicate or replace them
 - [ ] description has `Use when` with 5+ trigger phrases
 - [ ] leaf skills omit `allowed-tools`, hub skills declare them
 - [ ] ends with `## What NOT to Do` section
-- [ ] no code blocks in skills (code belongs in commands/)
+- [ ] no code blocks except minimal snippets when absolutely required (reference the docs instead)
 - [ ] all doc links go to `qdrant.tech/documentation/`
 - [ ] tested with a realistic prompt (paste below or link to eval)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,47 @@
 Skills encode solutions architect knowledge for AI agents. Familiarity with [Qdrant documentation](https://qdrant.tech/documentation/) and the [Agent Skills standard](https://agentskills.io/) is recommended before contributing.
 
 
+## Philosophy
+
+Skills are not a different form of documentation or tutorials.
+
+Documentation answers "how?" Skills answer "when?" and "why?"
+
+Skills serve as agentic-friendly navigation to Qdrant documentation, not a
+replacement for it. They encode the judgment of a Solutions Architect: given a
+symptom, which part of the docs matters, what order to try things, and what to
+avoid. If the guidance could be written by reading a getting-started page for
+10 minutes, it's not a skill. Skills encode judgment that comes from operating
+Qdrant at scale.
+
+### Good skill
+
+```
+## What to do if memory usage is too high?
+- Check collection parameters [link to docs]
+- Apply quantization [link to choosing quantization]
+- Monitor memory usage in prod [link to grafana dashboard]
+```
+
+### Bad skill
+
+```
+## Multimodal RAG: Building Document Search
+- Build a RAG system using embeddings and Ollama for generation
+- Implement basic retrieval from a collection
+```
+
+```
+## Integrating Qdrant with Framework X
+- Install the framework package
+- Configure the vector store
+- Run a similarity search
+```
+
+The first is a tutorial. The second is an integration guide. Neither is a
+skill, because neither requires operational judgment to write.
+
+
 ## Structure
 
 ```
@@ -37,7 +78,7 @@ Leaf skills contain the guidance an agent uses to help users.
 - Each section starts with `Use when:` one-liner
 - Bullets are imperative with inline doc links at the end
 - Ends with `## What NOT to Do` section
-- No code blocks in skills
+- No code blocks in skills beyond absolutely minimal snippets (substantial examples belong in framework docs, Qdrant docs, or [mcp-code-snippets](https://github.com/qdrant/mcp-code-snippets))
 - Links go to `qdrant.tech/documentation/`, not raw GitHub
 - Target 40-80 lines; if over 80, consider splitting into hub + sub-skills
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,9 @@ Qdrant at scale.
 The first is a tutorial. The second is an integration guide. Neither is a
 skill, because neither requires operational judgment to write.
 
+Skills should not create maintenance obligations across external frameworks
+or SDKs. Reference the docs, don't replicate them.
+
 
 ## Structure
 
@@ -78,7 +81,7 @@ Leaf skills contain the guidance an agent uses to help users.
 - Each section starts with `Use when:` one-liner
 - Bullets are imperative with inline doc links at the end
 - Ends with `## What NOT to Do` section
-- No code blocks in skills beyond absolutely minimal snippets (substantial examples belong in framework docs, Qdrant docs, or [mcp-code-snippets](https://github.com/qdrant/mcp-code-snippets))
+- No code blocks in skills beyond absolutely minimal snippets (reference the docs instead)
 - Links go to `qdrant.tech/documentation/`, not raw GitHub
 - Target 40-80 lines; if over 80, consider splitting into hub + sub-skills
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ npx skills add qdrant/skills
 
 ### Claude Code
 
-Add the marketplace, then install the skills you need:
+Add the marketplace, then install all Qdrant skills:
 
 ```
 /plugin marketplace add qdrant/skills
-/plugin install qdrant-scaling@qdrant
+/plugin install qdrant@qdrant
 ```
 
 ### Cursor

--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@
 Skills encode deep Qdrant knowledge so coding agents can make the engineering decisions that determine whether vector search works well: quantization, sharding, tenant isolation, hybrid search, model migration, and more.
 
 
+## Philosophy
+
+Skills are not documentation. Qdrant already has docs in markdown. Skills
+answer "when?" and "why?", not "how?"
+
+They are structured as the handbook of a Solutions Architect working on Qdrant:
+given a problem, navigate to the exact place in the documentation where the
+answer lives. No tutorials, no concept explanations. Only references and
+minimal snippets where absolutely necessary.
+
+
 ## Disclaimer
 
 These skills are under active development. Skill content and structure may change between versions as Qdrant evolves.

--- a/README.md
+++ b/README.md
@@ -33,25 +33,26 @@ These skills are under active development. Skill content and structure may chang
 
 ## Installation
 
+### npx skills
+
+Install using the [`npx skills`](https://skills.sh) CLI:
+
+```bash
+npx skills add qdrant/skills
+```
+
 ### Claude Code
 
-Install using the [plugin marketplace](https://code.claude.com/docs/en/discover-plugins#add-from-github):
+Add the marketplace, then install the skills you need:
 
 ```
 /plugin marketplace add qdrant/skills
+/plugin install qdrant-scaling@qdrant
 ```
 
 ### Cursor
 
 Install from the Cursor Marketplace or add manually via **Settings > Rules > Add Rule > Remote Rule (GitHub)** with `qdrant/skills`.
-
-### npx skills
-
-Install using the [`npx skills`](https://skills.sh) CLI:
-
-```
-npx skills add https://github.com/qdrant/skills
-```
 
 ### Clone / Copy
 


### PR DESCRIPTION
Adds a philosophy section to CONTRIBUTING.md, README.md, and updates the PR
template checklist to reflect the repo's direction.

Skills answer "when?" and "why?", not "how?" They navigate to docs, not
replace them. No tutorials, no framework integration guides, no maintained
code across external SDKs.

Changes:
* CONTRIBUTING.md: add philosophy section with good/bad examples, maintenance policy, update code blocks guidance
* README.md: add short philosophy paragraph, fix install instructions
* PR template: add scope checklist items, drop "new command" type, fix code blocks line
__

This PR was inspired by https://github.com/qdrant/skills/pull/36. I was too vague in the previous docs and left in template language around the legacy commands. Cleaned up and tightened the vision of Qdrant skills to avoid confusion.