### PR TITLE
Remove $schema key from marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://code.claude.com/schemas/marketplace.json",
   "name": "qdrant",
   "owner": {
     "name": "Qdrant",


### PR DESCRIPTION
The `$schema` key in `.claude-plugin/marketplace.json` is rejected by `claude plugin validate` as an unrecognized key, which causes validation failures during the marketplace review pipeline.

Removing it resolves the error. The validator passes with only a non-blocking warning about the optional marketplace description.

**Before:**
```
✘ Found 1 error:
  ❯ root: Unrecognized key: "$schema"
```

**After:**
```
✔ Validation passed with warnings
```