### PR TITLE
add .lycheeignore for cursor docs

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,1 @@
+https://docs.cursor.com/context/skills


### PR DESCRIPTION
cursor docs (docs.cursor.com) returns 429 on all automated requests, causing linkcheck CI to fail. adds .lycheeignore to skip that URL.