### PR TITLE
update documentation link convention

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@
 - [ ] leaf skills omit `allowed-tools`, hub skills declare them
 - [ ] ends with `## What NOT to Do` section
 - [ ] no code blocks except minimal snippets when absolutely required (reference the docs instead)
-- [ ] all doc links go to `qdrant.tech/documentation/`
+- [ ] all doc links go to `search.qdrant.tech/md/documentation/`
 - [ ] tested with a realistic prompt (paste below or link to eval)
 
 ## Test prompt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,8 @@ Every SKILL.md has YAML frontmatter (`name`, `description`) and a markdown body.
 
 ### Documentation links
 
-All links point to `qdrant.tech/documentation/`, inline at the end of bullets:
+All links point to `search.qdrant.tech/md/documentation/`, inline at the end of bullets:
 
 ```
-- Enable scalar quantization with `always_ram=true` [Scalar quantization](https://qdrant.tech/documentation/guides/quantization/#scalar-quantization)
+- Enable scalar quantization with `always_ram=true` [Scalar quantization](https://search.qdrant.tech/md/documentation/manage-data/quantization/?s=scalar-quantization)
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,18 @@ skills/
     scaling-qps/
     scaling-query-volume/
   qdrant-performance-optimization/
+    SKILL.md
+    indexing-performance-optimization/
+    memory-usage-optimization/
+    search-speed-optimization/
   qdrant-search-quality/
+    SKILL.md
+    diagnosis/
+    search-strategies/
   qdrant-monitoring/
+    SKILL.md
+    debugging/
+    setup/
   qdrant-clients-sdk/
   qdrant-deployment-options/
   qdrant-model-migration/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Leaf skills contain the guidance an agent uses to help users.
 - Bullets are imperative with inline doc links at the end
 - Ends with `## What NOT to Do` section
 - No code blocks in skills beyond absolutely minimal snippets (reference the docs instead)
-- Links go to `qdrant.tech/documentation/`, not raw GitHub
+- Links go to `search.qdrant.tech/md/documentation/`, not raw GitHub
 - Target 40-80 lines; if over 80, consider splitting into hub + sub-skills
 
 


### PR DESCRIPTION
All skill files use `search.qdrant.tech/md/documentation/` but AGENTS.md, CONTRIBUTING.md, and the PR template still reference `qdrant.tech/documentation/`. Updates all three to match actual usage.

Also adds missing sub-skills to the project structure tree in AGENTS.md (monitoring, performance-optimization, search-quality).