### PR TITLE
Proxy /search/* to search.qdrant.tech

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,12 @@
   to = "/index.md"
   status = 200
 
+[[redirects]]
+  from = "/search/*"
+  to = "https://search.qdrant.tech/:splat"
+  status = 200
+  force = true
+
 [[headers]]
   for = "/*.md"
   [headers.values]


### PR DESCRIPTION
## Summary
- Adds a Netlify rewrite so `/search/*` on `skills.qdrant.tech` is proxied (status 200, same-origin) to `https://search.qdrant.tech/:splat`.
- Lets the search backend share the site's origin — no CORS setup, no separate subdomain on the client side.
- `force = true` so the rule wins over any static file or fallback at that path.

Note: the `/search/` prefix is stripped before forwarding (e.g. `/search/api/v1` → `/api/v1` on the backend). If the backend expects the prefix preserved, switch `to` to `https://search.qdrant.tech/search/:splat`.

## Test plan
- [ ] After deploy, `curl -i https://skills.qdrant.tech/search/<known-endpoint>` returns the backend's response with a 2xx and same-origin headers.
- [ ] Confirm `search.qdrant.tech` serves valid HTTPS (Netlify refuses to proxy invalid certs).
- [ ] Confirm no existing `/search/...` static path is shadowed by the rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)