### PR TITLE
link new retrieval-evaluation tutorials in search-quality skill

### DIFF
--- a/skills/qdrant-search-quality/SKILL.md
+++ b/skills/qdrant-search-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qdrant-search-quality
-description: "Diagnoses and improves Qdrant search relevance. Use when someone reports 'search results are bad', 'wrong results', 'low precision', 'low recall', 'irrelevant matches', 'missing expected results', or asks 'how to improve search quality?', 'which embedding model?', 'should I use hybrid search?', 'should I use reranking?'. Also use when search quality degrades after quantization, model change, or data growth."
+description: "Diagnoses and improves Qdrant search relevance. Use when someone reports 'search results are bad', 'wrong results', 'low precision', 'low recall', 'irrelevant matches', 'missing expected results', or asks 'how to improve search quality?', 'which embedding model?', 'should I use hybrid search?', 'should I use reranking?', 'how to measure retrieval quality?', 'build a golden set', 'ground truth dataset', or 'how to score recall@k?'. Also use when search quality degrades after quantization, model change, or data growth."
 allowed-tools:
   - Read
   - Grep
@@ -16,7 +16,7 @@ First determine whether the problem is the embedding model, Qdrant configuration
 
 ## Diagnosis and Tuning
 
-Isolate the source of quality issues, tune HNSW parameters, and choose the right embedding model. [Diagnosis and Tuning](diagnosis/SKILL.md)
+Isolate the source of quality issues, establish labeled baselines to measure recall and relevance, tune HNSW parameters, and choose the right embedding model. [Diagnosis and Tuning](diagnosis/SKILL.md)
 
 
 ## Search Strategies

--- a/skills/qdrant-search-quality/diagnosis/SKILL.md
+++ b/skills/qdrant-search-quality/diagnosis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qdrant-search-quality-diagnosis
-description: "Diagnoses Qdrant search quality issues. Use when someone reports 'results are bad', 'wrong results', 'not relevant results', 'missing matches', 'recall is low', 'approximate search worse than exact', 'which embedding model', or 'quality dropped after quantization'. Also use when search quality degrades without obvious changes."
+description: "Diagnoses Qdrant search quality issues. Use when someone reports 'results are bad', 'wrong results', 'not relevant results', 'missing matches', 'recall is low', 'approximate search worse than exact', 'which embedding model', 'quality dropped after quantization', 'how to measure retrieval quality', 'build a golden set', 'ground truth dataset', or 'how to score recall@k'. Also use when search quality degrades without obvious changes."
 ---
 
 # How to Diagnose Bad Search Quality
@@ -11,7 +11,8 @@ Before tuning, establish baselines. Use exact KNN as ground truth, compare again
 
 Use when: results are irrelevant or missing expected matches and you need to isolate the cause.
 
-- Test with `exact=true` to bypass HNSW approximation [Search API](https://search.qdrant.tech/md/documentation/tutorials-search-engineering/retrieval-quality/?s=standard-mode-vs-exact-search)
+- For a no-code quick check, use the Web UI's ANN Recall tab to compare approximate vs exact `recall@k` [Web UI ANN Recall](https://search.qdrant.tech/md/documentation/tutorials-search-engineering/ann-recall/?s=measure-ann-recall-with-the-web-ui)
+- For the same comparison in code (CI gating, regression tests), run each query twice — once approximate, once with `exact=true` — and compute `recall@k` from the overlap [ANN recall in CI](https://search.qdrant.tech/md/documentation/tutorials-search-engineering/ann-recall/?s=automate-in-ci-with-python)
 - Exact search bad = model or search pipeline problem. Exact good, approximate bad = tune HNSW.
 - Check if quantization degrades quality (compare with and without)
 - Check if filters are too restrictive (then you might need to use ACORN)
@@ -37,13 +38,22 @@ Use when: exact search also returns bad results.
 
 Check [Qdrant team recommendations on how to choose an embedding model](https://search.qdrant.tech/md/articles/how-to-choose-an-embedding-model/).
 
-Test top 3 MTEB models on 100-1000 sample queries. [Hosted Qdrant inference](https://search.qdrant.tech/md/documentation/inference/)
+Test top 3 MTEB models on 100-1000 sample queries [Hosted Qdrant inference](https://search.qdrant.tech/md/documentation/inference/). Score them against a labeled set to compare apples to apples [Measuring Retrieval Relevance](https://search.qdrant.tech/md/documentation/improve-search/retrieval-relevance/).
 
 ## Unoptimized Search Pipeline
 
 Use when: exact search also returns bad results and model choice is confirmed by user.
 
 Optimize search according to advanced search-strategies skill.
+
+## Need a Labeled Baseline to Score Recall, MRR, or NDCG
+
+Use when: user has no golden set, asks "how do I know if my search is good?", or needs to gate releases on a retrieval metric.
+
+- Build a labeled query set — human, log-based, or LLM-synthetic — and score retrieval with `ranx` [Measuring Retrieval Relevance](https://search.qdrant.tech/md/documentation/improve-search/retrieval-relevance/)
+- Pick the metric by usage: `Recall@k` for RAG, `MRR`/`Hits@1` for single-answer, `NDCG@k` for re-ranking [Choosing the metric](https://search.qdrant.tech/md/documentation/improve-search/retrieval-relevance/?s=choosing-the-right-metric)
+- For full RAG pipelines, also score generation with Ragas and use the retrieval-vs-generation 2x2 to isolate regressions [Pipeline Output Quality](https://search.qdrant.tech/md/documentation/improve-search/pipeline-output-quality/)
+- Gate CI on a per-metric threshold to catch regressions from embedding-model swaps, prompt changes, or index config changes
 
 ## What NOT to Do
 

--- a/skills/qdrant-search-quality/search-strategies/SKILL.md
+++ b/skills/qdrant-search-quality/search-strategies/SKILL.md
@@ -65,4 +65,4 @@ Check how to set up in [Score Boosting docs](https://search.qdrant.tech/md/docum
 ## What NOT to Do
 
 - Use hybrid search before verifying pure vector search quality (adds complexity, may mask model issues)
-- Skip evaluation when adding relevance feedback (it's good to check on real queries that it actually could help)
+- Skip evaluation when adding relevance feedback — score the end-to-end pipeline to confirm it actually helps [Pipeline Output Quality](https://search.qdrant.tech/md/documentation/improve-search/pipeline-output-quality/)


### PR DESCRIPTION
## Summary

Wires the three new retrieval-evaluation tutorials into the `qdrant-search-quality` skill so agents can route users from symptom to the right evaluation harness. This is a first step in our broader push toward agent-driven evaluations — more skill updates to follow.

New tutorial pages referenced:
- [Measuring ANN Recall](https://qdrant.tech/documentation/tutorials-search-engineering/ann-recall/)
- [Measuring Retrieval Relevance](https://qdrant.tech/documentation/improve-search/retrieval-relevance/)
- [Evaluating Pipeline Output Quality](https://qdrant.tech/documentation/improve-search/pipeline-output-quality/)

## Changes

* Fix broken anchor on the old `retrieval-quality` URL (the heading no longer exists in the rewritten tutorial)
* Add Web UI ANN Recall tab as a no-code quick check in diagnosis
* Link MTEB model testing to the retrieval-relevance harness
* New diagnosis section "Need a Labeled Baseline to Score Recall, MRR, or NDCG" pointing to ranx and Ragas tutorials
* Expand hub description with evaluation trigger phrases and reframe Diagnosis and Tuning bullet
* Link the relevance-feedback evaluation note in search-strategies to the pipeline-output-quality tutorial

Related upstream: qdrant/landing_page#2305

## Test plan

- [ ] Hub description triggers on new phrases ("build a golden set", "how to score recall@k", "ground truth dataset")
- [ ] All `?s=` anchors resolve correctly on search.qdrant.tech
- [ ] No broken links in modified files (`scripts/validate_skills.py`, link checker)
- [ ] Diagnosis and search-strategies skills still under the 80-line target

🤖 Generated with [Claude Code](https://claude.com/claude-code)