### PR TITLE
fix: change snippets url

### DIFF
--- a/skills/qdrant-clients-sdk/SKILL.md
+++ b/skills/qdrant-clients-sdk/SKILL.md
@@ -32,7 +32,7 @@ All interaction with Qdrant can happen through the REST API or gRPC API. We reco
 To obtain code examples for a specific client and use case, you can send a search request to the library of curated code snippets for the Qdrant client.
 
 ```bash
-curl -X GET "https://snippets.qdrant.tech/search?language=python&query=how+to+upload+points"
+curl -X GET "https://search.qdrant.tech/snippets/search?language=python&query=how+to+upload+points"
 ```
 
 Available languages: `python`, `typescript`, `rust`, `java`, `go`, `csharp`


### PR DESCRIPTION
## What this PR does

<!-- 1-2 sentences. what changed and why. -->
Change snippet search URL to the endpoint that's part of the general search API (implemented in rust) instead of the outdated python impl. I verified that the URL works, let me know if this actually needs to be evaluated through claude.

## Type

<!-- check one -->
- [ ] new skill
- [ ] skill improvement
- [x] bug fix
- [ ] repo hygiene

## Checklist

<!-- for new/improved skills, check all that apply -->
- [x] `python3 scripts/validate_skills.py` passes
- [ ] ~skill answers "when?" or "why?", not "how?"~
- [ ] ~skill navigates to docs, does not duplicate or replace them~
- [ ] ~description has `Use when` with 5+ trigger phrases~
- [ ] ~leaf skills omit `allowed-tools`, hub skills declare them~
- [ ] ~ends with `## What NOT to Do` section~
- [ ] ~no code blocks except minimal snippets when absolutely required (reference the docs instead)~
- [ ] ~all doc links go to `search.qdrant.tech/md/documentation/`~
- [ ] ~tested with a realistic prompt (paste below or link to eval)~