### PR TITLE
Update model migration skill to cover named vector migration for 1.18+

### DIFF
--- a/skills/qdrant-model-migration/SKILL.md
+++ b/skills/qdrant-model-migration/SKILL.md
@@ -36,13 +36,15 @@ Careful, the alias swap only redirects queries. Payloads must be re-uploaded sep
 
 Use when: A/B testing models, multi-modal (dense + sparse), or evaluating a new model before committing.
 
-You cannot add a named vector to an existing collection. Create a new collection with both vector fields defined upfront:
+- v1.18+: Use `PUT /collections/{name}/vectors/{new_vector_name}` to add the new vector field directly to the existing collection, then backfill with `UpdateVectors`.
 
-- Create new collection with old and new named vectors both defined [Collection with multiple vectors](https://search.qdrant.tech/md/documentation/manage-data/collections/?s=collection-with-multiple-vectors)
-- Migrate data from old collection, preserving existing vectors in the old named field
-- Backfill new model embeddings incrementally using `UpdateVectors` [Update vectors](https://search.qdrant.tech/md/documentation/manage-data/points/?s=update-vectors)
-- Compare quality by querying with `using: "old_model"` vs `using: "new_model"`
-- Swap alias to new collection once satisfied
+- Pre-v1.18: You cannot add a named vector to an existing collection. Create a new collection with both vector fields defined upfront:
+
+  - Create new collection with old and new named vectors both defined [Collection with multiple vectors](https://search.qdrant.tech/md/documentation/manage-data/collections/?s=collection-with-multiple-vectors)
+  - Migrate data from old collection, preserving existing vectors in the old named field
+  - Backfill new model embeddings incrementally using `UpdateVectors` [Update vectors](https://search.qdrant.tech/md/documentation/manage-data/points/?s=update-vectors)
+  - Compare quality by querying with `using: "old_model"` vs `using: "new_model"`
+  - Swap alias to new collection once satisfied
 
 Co-locating large multi-vectors (especially ColBERT) with dense vectors degrades ALL queries, even those only using dense. At millions of points, users report 13s latency dropping to 2s after removing ColBERT. Put large vectors on disk during side-by-side migration.
 
@@ -77,7 +79,7 @@ For 400GB+ datasets, expect days. For small datasets (<25MB), re-indexing from s
 
 ## What NOT to Do
 
-- Assume you can add named vectors to an existing collection (must be defined at creation time)
+- Assume you can add named vectors to an existing collection on pre-v1.18 servers — check your server version first (`GET /` returns it)
 - Delete the old collection before verifying the new one
 - Forget to update the query embedding model in your application code
 - Skip payload migration when using alias swap (aliases redirect queries, they do not copy data)

--- a/skills/qdrant-model-migration/SKILL.md
+++ b/skills/qdrant-model-migration/SKILL.md
@@ -79,7 +79,7 @@ For 400GB+ datasets, expect days. For small datasets (<25MB), re-indexing from s
 
 ## What NOT to Do
 
-- Assume you can add named vectors to an existing collection on pre-v1.18 servers — check your server version first (`GET /` returns it)
+- Assume you can add named vectors to an existing collection on pre-v1.18 servers; check your server version first (`GET /` returns it)
 - Delete the old collection before verifying the new one
 - Forget to update the query embedding model in your application code
 - Skip payload migration when using alias swap (aliases redirect queries, they do not copy data)

--- a/skills/qdrant-model-migration/SKILL.md
+++ b/skills/qdrant-model-migration/SKILL.md
@@ -5,7 +5,7 @@ description: "Guides embedding model migration in Qdrant without downtime. Use w
 
 # What to Do When Changing Embedding Models
 
-Vectors from different models are incompatible. You cannot mix old and new embeddings in the same vector space. You also cannot add new named vector fields to an existing collection. All named vectors must be defined at collection creation time. Both migration strategies below require creating a new collection.
+Vectors from different models are incompatible. You cannot mix old and new embeddings in the same vector space. All named vectors must be defined at collection creation time. Both migration strategies below require creating a new collection.
 
 - Understand collection aliases before choosing a strategy [Collection aliases](https://search.qdrant.tech/md/documentation/manage-data/collections/?s=collection-aliases)
 
@@ -19,9 +19,17 @@ You MUST re-embed if: changing model provider (OpenAI to Cohere), changing archi
 You CAN avoid re-embedding if: using Matryoshka models (use `dimensions` parameter to output lower-dimensional embeddings, learn linear transformation from sample data, some recall loss, good for 100M+ datasets). Or changing quantization (binary to scalar): Qdrant re-quantizes automatically. [Quantization](https://search.qdrant.tech/md/documentation/manage-data/quantization/)
 
 
-## Need Zero Downtime (Alias Swap)
+## Need Zero Downtime
 
 Use when: production must stay available. Recommended for model replacement at scale.
+
+- If the cluster is v1.18 or later AND the collection has named vectors:
+
+  - Add the new vector field directly to the existing collection [Update vector schema](https://search.qdrant.tech/md/documentation/manage-data/collections/?s=update-vector-schema)
+  - Re-embed all data in the background using `UpdateVectors` [Update vectors](https://search.qdrant.tech/md/documentation/manage-data/points/?s=update-vectors)
+  - Verify search quality, then delete old vector field
+
+- If the cluster is v1.17 or earlier OR the collection doesn't have named vectors:
 
 - Create a new collection with the new model's dimensions and distance metric
 - Re-embed all data into the new collection in the background
@@ -36,9 +44,12 @@ Careful, the alias swap only redirects queries. Payloads must be re-uploaded sep
 
 Use when: A/B testing models, multi-modal (dense + sparse), or evaluating a new model before committing.
 
-- v1.18+: Use `PUT /collections/{name}/vectors/{new_vector_name}` to add the new vector field directly to the existing collection, then backfill with `UpdateVectors`.
+- If the cluster is v1.18 or later:
 
-- Pre-v1.18: You cannot add a named vector to an existing collection. Create a new collection with both vector fields defined upfront:
+  - Add the new vector field directly to the existing collection [Update vector schema](https://search.qdrant.tech/md/documentation/manage-data/collections/?s=update-vector-schema)
+  - Backfill new model embeddings incrementally using `UpdateVectors` [Update vectors](https://search.qdrant.tech/md/documentation/manage-data/points/?s=update-vectors)
+
+- If the cluster is v1.17 or earlier: You cannot add a named vector to an existing collection. Create a new collection with both vector fields defined upfront:
 
   - Create new collection with old and new named vectors both defined [Collection with multiple vectors](https://search.qdrant.tech/md/documentation/manage-data/collections/?s=collection-with-multiple-vectors)
   - Migrate data from old collection, preserving existing vectors in the old named field
@@ -79,7 +90,7 @@ For 400GB+ datasets, expect days. For small datasets (<25MB), re-indexing from s
 
 ## What NOT to Do
 
-- Assume you can add named vectors to an existing collection on pre-v1.18 servers; check your server version first (`GET /` returns it)
+- Assume you can add named vectors to an existing collection on v1.17 or earlier servers; check your server version first
 - Delete the old collection before verifying the new one
 - Forget to update the query embedding model in your application code
 - Skip payload migration when using alias swap (aliases redirect queries, they do not copy data)

--- a/skills/qdrant-search-quality/search-strategies/hybrid-search/combining-searches/SKILL.md
+++ b/skills/qdrant-search-quality/search-strategies/hybrid-search/combining-searches/SKILL.md
@@ -39,7 +39,7 @@ You can use any type of vector as an outer query over the prefetches, to perform
 
 Instead of using client-side fusion through cross-encoders, a popular option is **Late interaction models-based fusion**, through reranking on multivectors (e.g. ColBERT for text, ColPali and ColQwen for images).
 - Most precise but highest compute/resource usage.
-- Configure multivectors used for fusion through reranking with HNSW disabled like in [Hybrid Search with Reranking tutorial](https://search.qdrant.tech/md/documentation/tutorials-search-engineering/reranking-hybrid-search/).
+- Configure multivectors used for fusion through reranking with HNSW disabled like in [Hybrid Search with Reranking tutorial](https://search.qdrant.tech/md/documentation/tutorials-basics/reranking-hybrid-search/).
 
 ## What NOT to Do
 


### PR DESCRIPTION
## What this PR does

Qdrant v1.18 added PUT and DELETE endpoints for named vectors on existing collections, making the alias-swap approach unnecessary for named vector collections. This PR updates the skill to reflect both pre- and post-v1.18 behavior.

This PR also fixes a broken URL in the combining searches skill.

## Type

- [ ] new skill
- [x] skill improvement
- [ ] bug fix
- [ ] repo hygiene

## Checklist

<!-- for new/improved skills, check all that apply -->
- [x] `python3 scripts/validate_skills.py` passes
- [x] skill answers "when?" or "why?", not "how?"
- [x] ends with `## What NOT to Do` section

## Test prompt

<!-- paste a realistic user question you tested this skill against, and summarize what the agent responded. skip for non-skill PRs. -->

1. I want to make to changes to the Qdrant cluster at [endpoint]. My API token is [api-key]
2. Create a collection `agent-collection`, with a dense vector of 384 dimensions, and cosine similarity. Use a named vector with the name `my-vector`.
3. Ingest the dataset at [url]. Use the description field to generate embeddings for the dense vector with Cloud Inference.
4. Use the Qdrant migration skill at [skill url] to migrate to the qdrant/clip-vit-b-32-text model.

[dataset url](https://raw.githubusercontent.com/qdrant/examples/refs/heads/master/sci-fi-books/top_100_scifi_books_full.csv)