### PR TITLE
add relevance feedback skill

### DIFF
--- a/skills/qdrant-search-quality/search-strategies/SKILL.md
+++ b/skills/qdrant-search-quality/search-strategies/SKILL.md
@@ -16,7 +16,7 @@ If the user wants to use a weaker embedding model because it is small, fast, and
 
 Use when: pure vector search misses keyword/domain term matches, or the use case benefits from combining searches on multiple representations (including languages and modalities) of the same item.
 
-See how to use [hybrid search](hybrid-search/SKILL.md)
+See how to use [hybrid search](https://skills.qdrant.tech/qdrant-search-quality/search-strategies/hybrid-search/SKILL.md)
 
 ## Right Documents Found But Not in the Top Results
 
@@ -25,20 +25,11 @@ Use when: good recall but poor precision (right docs in top-100, not top-10).
 - See how to use [Multistage queries](https://search.qdrant.tech/md/documentation/search/hybrid-queries/?s=multi-stage-queries), for example with late interaction rerankers through [Multivectors](https://search.qdrant.tech/md/documentation/manage-data/vectors/?s=multivectors).
 - Cross-encoder rerankers via FastEmbed [Rerankers](https://search.qdrant.tech/md/documentation/fastembed/fastembed-rerankers/)
 
-## Right Documents Not Found But They Are There
+## Dense Retriever Misses Relevant Items or Reranking Is Too Costly
 
-Use when: basic retrieval is in place but the retriever misses relevant items you know exist in the dataset. Works on any embeddable data (text, images, etc.).
+Use when: dense retriever misses relevant items you know exist in the collection; relevant documents lie outside the initial ANN retrieval pool; reranking a large candidate pool is too slow or expensive; using a small/cheap embedding model but need quality close to a larger model; or want to improve top-1/3 precision without the full cost of reranking.
 
-Relevance Feedback (RF) Query uses a feedback model's scores on retrieved results to steer the retriever through the full vector space on subsequent iterations, like reranking the entire collection through the retriever. Complementary to reranking: a reranker sees a limited subset, RF leverages feedback signals collection-wide. Even 3–5 feedback scores are enough. Can run multiple iterations.
-
-A feedback model is anything producing a relevance score per document: a bi-encoder, cross-encoder, late-interaction model, LLM-as-judge. Fuzzy relevance scores work, not just binary (good/bad, relevant/irrelevant), due to the fact that feedback is expressed as a graded relevance score (higher = more relevant).
-
-Skip when: if the retriever already has strong recall, or if retriever and feedback model strongly agree on relevance.
-
-- RF Query is currently based on a [3-parameter naive formula](https://search.qdrant.tech/md/documentation/search/search-relevance/?s=naive-strategy) with no universal defaults, so it must be tuned per dataset, retriever, and feedback model
-- Use [qdrant-relevance-feedback](https://pypi.org/project/qdrant-relevance-feedback/) to tune parameters, evaluate impact with Evaluator, and check retriever-feedback agreement. See README for setup instructions. No GPUs are needed, and the framework also provides predefined retriever and feedback model options.
-- Check the configuration of the [Relevance Feedback Query API](https://search.qdrant.tech/md/documentation/search/search-relevance/?s=relevance-feedback)
-- Use this as a helper end-to-end text retrieval example with parameter tuning and evals to understand how to use the API and run the `qdrant-relevance-feedback` framework: [RF tutorial](https://search.qdrant.tech/md/documentation/tutorials-search-engineering/using-relevance-feedback/)
+See [Relevance Feedback in Qdrant](https://skills.qdrant.tech/qdrant-search-quality/search-strategies/relevance-feedback/SKILL.md)
 
 ## Results Too Similar
 

--- a/skills/qdrant-search-quality/search-strategies/relevance-feedback/SKILL.md
+++ b/skills/qdrant-search-quality/search-strategies/relevance-feedback/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: qdrant-relevance-feedback
+description: "Use when someone asks about 'Qdrant\'s Relevance Feedback API', 'improving dense search relevance/recall', 'how to discover/get more relevant results from vector search', 'cheaper/better alternative to reranking', 'using a more heavy/big embedding model for dense search but can\'t afford it', 'finding more relevant documents beyond the initial search pool', or 'feedback loops'. Also trigger when the user has a search quality problem due to a dense retriever being weak and is considering reranking as a solution — this API may be a better fit."
+---
+
+Reranking reorders documents that have already been retrieved. Qdrant's Relevance Feedback (RF) instead modifies the vector search process itself based on a small amount of reranker feedback, distilling reranker (feedback model) knowledge into the search step. This allows to surface documents that the initial ANN search did not score highly enough.
+
+The RF is intended for tasks where relevance correlates with similarity in vector space.
+
+How you apply the RF depends on your goals.  
+First, understand how the RF works, read the ENTIRE section. Then define your goals and choose the appropriate usage pattern described below. Make sure to avoid the listed anti-patterns ("DO NOTs"). Before implementing anything, read CAREFULLY to avoid missing important details.
+
+## How It Works
+
+The [Qdrant Query Point API with a type RelevanceFeedbackQuery](https://api.qdrant.tech/api-reference/search/query-points) takes:
+
+- a query (`target`)
+- a small list of seed documents (`feedback`) with relevance scores (often 4–5 seeds are enough)
+- formula weights, which MUST be trained once per general search use case (your dataset, dense retriever, and feedback model)
+
+If you do not train the formula weights, results will at best be random, will not align with your data distribution or model behavior. Training is lightweight because the formula itself is simple.
+
+During search, the it scores each candidate by combining similarity to the original query, similarity to highly rated seed documents and dissimilarity to poorly rated ones.
+
+### Feedback Model
+
+A **feedback model** is any model that can produce a float relevance score for `(query, document)` pairs. Higher scores must always mean higher relevance.
+
+Examples: a cross-encoder,  embedding similarity (f.e., cosine similarity between query and document embeddings, or max_sim for late interaction models), an LLM-based scorer, a custom ranker.
+
+The feedback model used during training and inference MUST be the same model. Formula weights during training are calibrated to that model's score distribution. If you switch feedback models, you must retrain.
+
+**What is a Good Feedback Model:**
+- If the model does not improve ranking quality when used as a reranker on retrieved documents,  the RF search will not have a meaningful signal to amplify.
+- RF search quality depends heavily on how well the feedback model scores partial matches. The training loss of RF formula relies on relative ordering, so poor score separation in the middle range (documents that are neither clearly relevant nor clearly irrelevant) weakens results.
+
+### To Make the RF API Work, You Need to Calibrate Weights First
+
+Use when: setting up RF for a new use case — a new collection, feedback model, or embedding model powering ANN search.
+
+RF uses a weighted formula that combines the original query vector with feedback signals.
+
+For the currently available `naive` strategy, the learned weights control:
+- `a` — how much to trust the original ANN query-document similarity
+- `b` — how strongly differences in feedback scores matter
+- `c` — how strongly to follow the feedback direction (toward relevant documents and away from irrelevant ones)
+
+These weights must be learned from your data before use. You cannot safely use arbitrary values.
+
+- Install the [qdrant-relevance-feedback](https://pypi.org/project/qdrant-relevance-feedback/) Python library. Study what goes into RelevanceFeedback.
+- Initialize a `RelevanceFeedback` instance. You can use provided QdrantRetriever or FastembedFeedback, or define your own.
+- Inform yourself on `train` parameters. The library retrieves `limit` candidates per train query, scores them with the feedback model, learns the weighting parameters, and returns the calibrated values.
+- Call `train` on 50–200 representative, real, non-synthetic queries. Generate train queries yourself based on the use case, but give the option to the user to provide them, too. Inform user on cost & quality trade-offs of training.
+- Check train metrics which show if RF had a signal  (disagreement between retriever and feedback model) to distill and learn from. If there was no signal to learn from, adapt training parameters, queries or change a feedback model and retrain until RF learns well. 
+- Store the resulting RF parameters in your configuration and use them during inference. Retrain if your query distribution or corpus changes significantly.
+- You can also evaluate resulting formula with `Evaluator ` on a separate test set of representative, real, non-synthetic queries. If results seem unsatisfactory, investigate and inform user.  
+
+The retriever, feedback model, and related parameters defined during training are assumed to remain the same during inference.
+
+## Want High-Quality Top-1/3 Results at Reasonable Cost
+
+Use when: top-1 or top-3 precision matters most, and reranking a large pool of documents would be too expensive or slow. This pattern below can match reranking quality at the top of the ranking for semantic similarity tasks, but it performs worse at deeper cutoffs. Do not use this approach when top-10+ recall is the priority.
+
+Only score a small set of seed documents. Five seeds is a robust default across many task types and scoring them costs user roughly 5× less than reranking a 25-document pool.
+
+- Retrieve the top 5 documents using ANN search. These become the feedback seeds. You'll need their stored embeddings.
+- Score them with the feedback model used in training.
+- Call Qdrant's Query API using the relevance feedback query:
+  - set `target` to the query retriever embedding (also possible to use Qdrant Cloud Inference).
+  - set `feedback` to a list of items where each item contains:
+    - `example=<seed vector, same embedding model as for `target`>` (also possible to use Qdrant Cloud Inference)
+    - `score=<feedback model score>`
+- don't forget to assign `using` to retriever's handle, we operate in retriever's vector space. 
+- set `strategy` to `naive` with your calibrated parameters
+- set `limit` to the number of final results you need and use the RF results directly as final results.
+
+ Check the [Relevance Feedback Query API  documentation](https://search.qdrant.tech/md/documentation/search/search-relevance/?s=relevance-feedback) and study code/methods of the relevant SDK before filling in anything.
+
+Using a point ID in `example` causes the RF API to automatically exclude that document from the final results. Using stored embeddings used for retrieval instead potentially keeps the document in the final results.
+
+## Want to Find Relevant Documents Beyond the Initial Search Results
+
+Use when: recall matters more than latency or cost (research, legal, medical, compliance), and relevant documents may exist outside the initial ANN retrieval pool.
+
+It performs two feedback model scoring rounds:
+1. on feedback seeds
+2. on newly surfaced RF results
+
+The second reranking pass safely promotes newly discovered documents into the top-10 of the final ranking. The advantage over standard reranking is that RF can reach relevant documents that lie completely outside the initial ANN pool, while a reranker with the same budget cannot. The tradeoff is higher latency due to two rounds of feedback-model scoring.
+
+- Retrieve and score 5 seed documents. These become the feedback seeds. You'll need their point IDs.
+- Call Qdrant's query API using the relevance feedback query:
+  - set `target` to the query retriever embedding (also possible to use Qdrant Cloud Inference)
+  - set `feedback` to a list of items where each item contains:
+    - `example=<seed point ID>`
+    - `score=<feedback score>`
+- don't forget to assign `using` to retriever's handle, we operate in retriever's vector space. 
+- set `strategy` to `naive` with your calibrated parameters
+- set `limit` to the number of results user can afford to rerank based on the available cost budget. The total scoring cost equals the cost of scoring both the seeds and the RF results, roughly equivalent to reranking a pool of the same combined size. Inform & consult with a user.
+- score the returned RF results with your feedback model.
+- Merge the original seeds and RF results, then sort by feedback score. These will be your final results.
+
+ Check the [Relevance Feedback Query API  documentation](https://search.qdrant.tech/md/documentation/search/search-relevance/?s=relevance-feedback) and study code/methods of the relevant SDK before filling in anything.
+
+Using a point ID in `example` causes the RF API to automatically exclude that document from the final results. Using stored embeddings used for retrieval instead potentially keeps the document in the final results.
+
+## What NOT to Do
+
+- Do not skip calibration and use random formula weights. Untrained weights produce arbitrary results. (`a=1, b=0, c=0` can be used if you only want vanilla ANN behavior through the RF API.)
+- Do not use the RF API on sparse vectors.
+- Do not use a feedback model where higher scores mean lower relevance. Scores must be monotonic: higher = more relevant.
+- Do not use fewer than 2 feedback seeds. A single seed provides no contrastive signal. The formula needs at least one relatively more relevant and one relatively less relevant example to establish direction. Two is the minimum; five is the recommended default.
+- Do not use significantly more than 5 seeds expecting better quality. Additional seeds usually add noise and increase scoring cost without meaningful gains.
+- Do not use a different feedback model during inference than the one used during calibration. The learned weights are tied to that model's score scale and distribution.
+- Do not use feedback model that does not improve retrieval quality as a standard reranker on your data.
+- Do not proceed to inference if training and evaluation metrics of qdrant-relevance-feedback package demonstrated unsatisfactory results, find a good training set of representative queries, a feedback model providing a meaningful signal and well-working train parameters.

--- a/skills/qdrant-search-quality/search-strategies/relevance-feedback/SKILL.md
+++ b/skills/qdrant-search-quality/search-strategies/relevance-feedback/SKILL.md
@@ -3,7 +3,7 @@ name: qdrant-relevance-feedback
 description: "Use when someone asks about 'Qdrant\'s Relevance Feedback API', 'improving dense search relevance/recall', 'how to discover/get more relevant results from vector search', 'cheaper/better alternative to reranking', 'using a more heavy/big embedding model for dense search but can\'t afford it', 'finding more relevant documents beyond the initial search pool', or 'feedback loops'. Also trigger when the user has a search quality problem due to a dense retriever being weak and is considering reranking as a solution — this API may be a better fit."
 ---
 
-Reranking reorders documents that have already been retrieved. Qdrant's Relevance Feedback (RF) instead modifies the vector search process itself based on a small amount of reranker feedback, distilling reranker (feedback model) knowledge into the search step. This allows to surface documents that the initial ANN search did not score highly enough.
+Reranking reorders documents that have already been retrieved. Qdrant's Relevance Feedback (RF) instead modifies the vector search process itself based on a small amount of reranker feedback, distilling reranker (feedback model) knowledge into the search step. This allows RF to surface documents that the initial ANN search did not score highly enough.
 
 The RF is intended for tasks where relevance correlates with similarity in vector space.
 
@@ -20,13 +20,13 @@ The [Qdrant Query Point API with a type RelevanceFeedbackQuery](https://api.qdra
 
 If you do not train the formula weights, results will at best be random, will not align with your data distribution or model behavior. Training is lightweight because the formula itself is simple.
 
-During search, the it scores each candidate by combining similarity to the original query, similarity to highly rated seed documents and dissimilarity to poorly rated ones.
+During search, it scores each candidate by combining similarity to the original query, similarity to highly rated seed documents and dissimilarity to poorly rated ones.
 
 ### Feedback Model
 
 A **feedback model** is any model that can produce a float relevance score for `(query, document)` pairs. Higher scores must always mean higher relevance.
 
-Examples: a cross-encoder,  embedding similarity (f.e., cosine similarity between query and document embeddings, or max_sim for late interaction models), an LLM-based scorer, a custom ranker.
+Examples: a cross-encoder, embedding similarity (for example, cosine similarity between query and document embeddings, or max_sim for late interaction models), an LLM-based scorer, a custom ranker.
 
 The feedback model used during training and inference MUST be the same model. Formula weights during training are calibrated to that model's score distribution. If you switch feedback models, you must retrain.
 
@@ -49,11 +49,13 @@ These weights must be learned from your data before use. You cannot safely use a
 
 - Install the [qdrant-relevance-feedback](https://pypi.org/project/qdrant-relevance-feedback/) Python library. Study what goes into RelevanceFeedback.
 - Initialize a `RelevanceFeedback` instance. You can use provided QdrantRetriever or FastembedFeedback, or define your own.
-- Inform yourself on `train` parameters. The library retrieves `limit` candidates per train query, scores them with the feedback model, learns the weighting parameters, and returns the calibrated values.
-- Call `train` on 50–200 representative, real, non-synthetic queries. Generate train queries yourself based on the use case, but give the option to the user to provide them, too. Inform user on cost & quality trade-offs of training.
+- Review `train` parameters before calling `train`. The library retrieves `limit` candidates per train query, scores them with the feedback model, learns the weighting parameters, and returns the calibrated values.
+- Call `train` on 50–200 representative, real, non-synthetic queries.
+  - Generate train queries yourself based on the use case, but give the option to the user to provide them, too.
+  - Inform user on cost and quality trade-offs of training.
 - Check train metrics which show if RF had a signal  (disagreement between retriever and feedback model) to distill and learn from. If there was no signal to learn from, adapt training parameters, queries or change a feedback model and retrain until RF learns well. 
 - Store the resulting RF parameters in your configuration and use them during inference. Retrain if your query distribution or corpus changes significantly.
-- You can also evaluate resulting formula with `Evaluator ` on a separate test set of representative, real, non-synthetic queries. If results seem unsatisfactory, investigate and inform user.  
+- Evaluate resulting formula with `Evaluator` on a separate test set of representative, real, non-synthetic queries. If results seem unsatisfactory, investigate and inform user.  
 
 The retriever, feedback model, and related parameters defined during training are assumed to remain the same during inference.
 
@@ -94,10 +96,10 @@ The second reranking pass safely promotes newly discovered documents into the to
   - set `feedback` to a list of items where each item contains:
     - `example=<seed point ID>`
     - `score=<feedback score>`
-- don't forget to assign `using` to retriever's handle, we operate in retriever's vector space. 
-- set `strategy` to `naive` with your calibrated parameters
-- set `limit` to the number of results user can afford to rerank based on the available cost budget. The total scoring cost equals the cost of scoring both the seeds and the RF results, roughly equivalent to reranking a pool of the same combined size. Inform & consult with a user.
-- score the returned RF results with your feedback model.
+  - set `using` to retriever's handle, RF operates in retriever's vector space. 
+  - set `strategy` to `naive` with your calibrated parameters
+  - set `limit` to the number of results user can afford to rerank based on the available cost budget. The total scoring cost equals the cost of scoring both the seeds and the RF results, roughly equivalent to reranking a pool of the same combined size. Inform and consult with the user.
+  - score the returned RF results with your feedback model.
 - Merge the original seeds and RF results, then sort by feedback score. These will be your final results.
 
  Check the [Relevance Feedback Query API  documentation](https://search.qdrant.tech/md/documentation/search/search-relevance/?s=relevance-feedback) and study code/methods of the relevant SDK before filling in anything.
@@ -112,5 +114,5 @@ Using a point ID in `example` causes the RF API to automatically exclude that do
 - Do not use fewer than 2 feedback seeds. A single seed provides no contrastive signal. The formula needs at least one relatively more relevant and one relatively less relevant example to establish direction. Two is the minimum; five is the recommended default.
 - Do not use significantly more than 5 seeds expecting better quality. Additional seeds usually add noise and increase scoring cost without meaningful gains.
 - Do not use a different feedback model during inference than the one used during calibration. The learned weights are tied to that model's score scale and distribution.
-- Do not use feedback model that does not improve retrieval quality as a standard reranker on your data.
-- Do not proceed to inference if training and evaluation metrics of qdrant-relevance-feedback package demonstrated unsatisfactory results, find a good training set of representative queries, a feedback model providing a meaningful signal and well-working train parameters.
+- Do not use a feedback model that does not improve retrieval quality as a standard reranker on your data.
+- Do not proceed to inference if training and evaluation metrics of qdrant-relevance-feedback package demonstrated unsatisfactory results, instead find a good training set of representative queries, a feedback model providing a meaningful signal and effective train parameters.

--- a/skills/qdrant-search-quality/search-strategies/relevance-feedback/SKILL.md
+++ b/skills/qdrant-search-quality/search-strategies/relevance-feedback/SKILL.md
@@ -72,9 +72,9 @@ Only score a small set of seed documents. Five seeds is a robust default across 
   - set `feedback` to a list of items where each item contains:
     - `example=<seed vector, same embedding model as for `target`>` (also possible to use Qdrant Cloud Inference)
     - `score=<feedback model score>`
-- don't forget to assign `using` to retriever's handle, we operate in retriever's vector space. 
-- set `strategy` to `naive` with your calibrated parameters
-- set `limit` to the number of final results you need and use the RF results directly as final results.
+  - set `using` to retriever's handle, RF operates in retriever's vector space. 
+  - set `strategy` to `naive` with your calibrated parameters
+  - set `limit` to the number of final results you need and use the RF results directly as final results.
 
  Check the [Relevance Feedback Query API  documentation](https://search.qdrant.tech/md/documentation/search/search-relevance/?s=relevance-feedback) and study code/methods of the relevant SDK before filling in anything.
 


### PR DESCRIPTION
## What this PR does

Adds `qdrant-relevance-feedback` as a new leaf sub-skill under `search-strategies/relevance-feedback/`, at the same level as `hybrid-search/`. Updates the parent `search-strategies/SKILL.md` to replace the inline RF content with a reference link and improve the section header and "Use when:" line.

## Type

- [x] new skill
- [x] skill improvement

## Checklist

- [x] `python3 scripts/validate_skills.py` passes — 2 warnings: line count (116, intentional — RF requires prerequisite calibration context) and em-dash (pre-existing style)
- [ ] skill answers "when?" or "why?", not "how?" — intentionally more procedural: RF requires one-time calibration before use, so the skill covers the setup steps needed to make it work
- [x] skill navigates to docs, does not duplicate or replace them
- [x] description has `Use when` with 5+ trigger phrases
- [x] leaf skills omit `allowed-tools`
- [x] ends with `## What NOT to Do` section
- [x] no code blocks except minimal snippets when absolutely required
- [ ] all doc links go to `search.qdrant.tech/md/documentation/` — two exceptions: `api.qdrant.tech/api-reference/search/query-points` (RF API reference) and `pypi.org/project/qdrant-relevance-feedback/` (calibration library), both intentional

## Test prompt
I have a context engineering workshop where I create a collection and populate it.
Currently, it uses a tool based on the retrieve_papers_based_on_query in search_engine_query.py,
which uses hybrid search + reranker, and as a dense search arm, it uses text-embedding-3-small, cut to 1024 dims.

I'd love to use text-embedding-3-large as the dense retriever instead for better quality,
but it's too expensive. Is there any cheaper alternative? Use Qdrant skills, recommend something to me.