### PR TITLE
[Infra] Add absolute link rewriting to build and test it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,32 @@ Leaf skills contain the guidance an agent uses to help users.
 - Target 40-80 lines; if over 80, consider splitting into hub + sub-skills
 
 
+## Testing
+
+### Build script tests
+
+`scripts/test_make_links_absolute.py` covers the link-rewriting step in `build.sh`. It tests the two public entry points of `scripts/make_links_absolute.py`:
+
+- **`make_absolute(filepath, url, public_dir)`** — resolves a single URL relative to a file path. Unit tests cover: simple relative links at root and nested levels, `../` traversal, and all the passthrough cases (`https://`, `http://`, `/`, `#`, `mailto:`).
+- **`run(public_dir)`** — walks a directory and rewrites all relative markdown links in every `.md` file. Integration tests write real files to a temporary directory and verify the output.
+
+Run manually from the repo root:
+
+```
+cd scripts && python3 -m unittest test_make_links_absolute -v
+```
+
+### Skill validation
+
+`scripts/validate_skills.py` checks all `SKILL.md` files against the quality rules described in the Writing a skill section above. Run it from the repo root:
+
+```
+python3 scripts/validate_skills.py
+```
+
+It exits non-zero if any hard `FAIL` rules are violated.
+
+
 ## Conventions
 
 ### Commit messages

--- a/build.sh
+++ b/build.sh
@@ -6,4 +6,6 @@ cp -r skills public
 
 find public -name '*.md' -print0 | xargs -0 sed -i 's|https://search\.qdrant\.tech/md/|/md/|g'
 
+python3 scripts/make_links_absolute.py
+
 bash scripts/generate_sitemap.sh public

--- a/scripts/generate_sitemap.sh
+++ b/scripts/generate_sitemap.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE_URL="${SITE_URL:-https://skills.qdrant.tech}"
+BASE_URL="${SITE_URL:-${DEPLOY_PRIME_URL:-${URL:-https://skills.qdrant.tech}}}"
+BASE_URL="${BASE_URL%/}"
 PUBLIC_DIR="${1:-public}"
 OUTPUT="${PUBLIC_DIR}/sitemap.xml"
 TODAY=$(date -u +"%Y-%m-%d")

--- a/scripts/make_links_absolute.py
+++ b/scripts/make_links_absolute.py
@@ -3,22 +3,31 @@
 
 import os
 import re
+from urllib.parse import urljoin, urlsplit
 
-BASE_URL = "https://skills.qdrant.tech"
+# On Netlify, DEPLOY_PRIME_URL / URL are injected with the deploy's real domain
+# (including branch deploys and deploy previews). Fall back to the production
+# domain for local builds.
+BASE_URL = (
+    os.environ.get("DEPLOY_PRIME_URL")
+    or os.environ.get("URL")
+    or "https://skills.qdrant.tech"
+).rstrip("/")
 PUBLIC_DIR = "public"
 
 LINK_RE = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
 
 
 def make_absolute(filepath, url, public_dir):
-    if url.startswith(("http://", "https://", "/", "#", "mailto:")):
+    # Leave anchors, root-relative paths, and anything carrying a scheme
+    # (http, https, mailto, …) untouched.
+    if url.startswith(("/", "#")) or urlsplit(url).scheme:
         return url
+    # URL path of the file's directory relative to the site root.
     file_dir = os.path.relpath(os.path.dirname(filepath), public_dir)
-    if file_dir == ".":
-        abs_path = url
-    else:
-        abs_path = os.path.normpath(os.path.join(file_dir, url))
-    return f"{BASE_URL}/{abs_path}"
+    base_path = "/" if file_dir == os.curdir else "/" + file_dir.replace(os.sep, "/") + "/"
+    # Resolve the link against its directory, then against the site origin.
+    return urljoin(BASE_URL, urljoin(base_path, url))
 
 
 def run(public_dir):

--- a/scripts/make_links_absolute.py
+++ b/scripts/make_links_absolute.py
@@ -19,14 +19,17 @@ LINK_RE = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
 
 
 def make_absolute(filepath, url, public_dir):
-    # Leave anchors, root-relative paths, and anything carrying a scheme
-    # (http, https, mailto, …) untouched.
-    if url.startswith(("/", "#")) or urlsplit(url).scheme:
+    # Leave in-page anchors and anything carrying a scheme (http, https,
+    # mailto, …) untouched. Root-relative ("/…") and directory-relative links
+    # are both resolved to an absolute site URL below.
+    if url.startswith("#") or urlsplit(url).scheme:
         return url
     # URL path of the file's directory relative to the site root.
     file_dir = os.path.relpath(os.path.dirname(filepath), public_dir)
     base_path = "/" if file_dir == os.curdir else "/" + file_dir.replace(os.sep, "/") + "/"
-    # Resolve the link against its directory, then against the site origin.
+    # Resolve the link against its directory, then against the site origin. A
+    # leading "/" makes urljoin discard base_path, so root-relative links are
+    # attached directly to the origin.
     return urljoin(BASE_URL, urljoin(base_path, url))
 
 

--- a/scripts/make_links_absolute.py
+++ b/scripts/make_links_absolute.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Convert relative markdown links to absolute URLs for the deployed site."""
+
+import os
+import re
+
+BASE_URL = "https://skills.qdrant.tech"
+PUBLIC_DIR = "public"
+
+LINK_RE = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
+
+
+def make_absolute(filepath, url, public_dir):
+    if url.startswith(("http://", "https://", "/", "#", "mailto:")):
+        return url
+    file_dir = os.path.relpath(os.path.dirname(filepath), public_dir)
+    if file_dir == ".":
+        abs_path = url
+    else:
+        abs_path = os.path.normpath(os.path.join(file_dir, url))
+    return f"{BASE_URL}/{abs_path}"
+
+
+def run(public_dir):
+    for root, _dirs, files in os.walk(public_dir):
+        for filename in files:
+            if not filename.endswith(".md"):
+                continue
+            filepath = os.path.join(root, filename)
+            with open(filepath) as f:
+                content = f.read()
+            new_content = LINK_RE.sub(
+                lambda m: f"[{m.group(1)}]({make_absolute(filepath, m.group(2), public_dir)})",
+                content,
+            )
+            if new_content != content:
+                with open(filepath, "w") as f:
+                    f.write(new_content)
+
+
+if __name__ == "__main__":
+    run(PUBLIC_DIR)

--- a/scripts/test_make_links_absolute.py
+++ b/scripts/test_make_links_absolute.py
@@ -38,9 +38,13 @@ class TestMakeAbsolute(unittest.TestCase):
         original = "http://example.com/docs"
         self.assertEqual(make_absolute("public/foo/SKILL.md", original, "public"), original)
 
-    def test_root_relative_link_unchanged(self):
-        original = "/md/documentation/something/"
-        self.assertEqual(make_absolute("public/foo/SKILL.md", original, "public"), original)
+    def test_root_relative_link_absolutized(self):
+        url = make_absolute("public/foo/SKILL.md", "/md/documentation/something/", "public")
+        self.assertEqual(url, f"{BASE_URL}/md/documentation/something/")
+
+    def test_root_relative_link_preserves_query(self):
+        url = make_absolute("public/foo/SKILL.md", "/md/collections/?s=aliases", "public")
+        self.assertEqual(url, f"{BASE_URL}/md/collections/?s=aliases")
 
     def test_anchor_unchanged(self):
         original = "#section-heading"
@@ -87,11 +91,13 @@ class TestRun(unittest.TestCase):
         run(self.tmp)
         self.assertEqual(self.read("qdrant-scaling/SKILL.md"), content)
 
-    def test_root_relative_links_not_changed(self):
-        content = "See [Docs](/md/documentation/something/) for info.\n"
-        self.write("foo/SKILL.md", content)
+    def test_root_relative_links_absolutized(self):
+        self.write("foo/SKILL.md", "See [Docs](/md/documentation/something/) for info.\n")
         run(self.tmp)
-        self.assertEqual(self.read("foo/SKILL.md"), content)
+        self.assertIn(
+            f"[Docs]({BASE_URL}/md/documentation/something/)",
+            self.read("foo/SKILL.md"),
+        )
 
     def test_mixed_links_in_one_file(self):
         self.write(
@@ -102,7 +108,7 @@ class TestRun(unittest.TestCase):
         result = self.read("foo/SKILL.md")
         self.assertIn(f"[Relative]({BASE_URL}/foo/bar/SKILL.md)", result)
         self.assertIn("[Absolute](https://example.com)", result)
-        self.assertIn("[Root](/md/x)", result)
+        self.assertIn(f"[Root]({BASE_URL}/md/x)", result)
 
     def test_non_md_file_untouched(self):
         self.write("foo/config.json", '{"link": "bar/baz.md"}\n')

--- a/scripts/test_make_links_absolute.py
+++ b/scripts/test_make_links_absolute.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Tests for make_links_absolute.py"""
+
+import os
+import tempfile
+import unittest
+
+from make_links_absolute import BASE_URL, make_absolute, run
+
+
+class TestMakeAbsolute(unittest.TestCase):
+    def test_root_level_relative_link(self):
+        url = make_absolute("public/index.md", "qdrant-scaling/SKILL.md", "public")
+        self.assertEqual(url, f"{BASE_URL}/qdrant-scaling/SKILL.md")
+
+    def test_nested_relative_link(self):
+        url = make_absolute(
+            "public/qdrant-scaling/SKILL.md", "scaling-data-volume/SKILL.md", "public"
+        )
+        self.assertEqual(url, f"{BASE_URL}/qdrant-scaling/scaling-data-volume/SKILL.md")
+
+    def test_parent_traversal(self):
+        url = make_absolute(
+            "public/qdrant-scaling/minimize-latency/SKILL.md",
+            "../scaling-data-volume/vertical-scaling/SKILL.md",
+            "public",
+        )
+        self.assertEqual(
+            url,
+            f"{BASE_URL}/qdrant-scaling/scaling-data-volume/vertical-scaling/SKILL.md",
+        )
+
+    def test_https_link_unchanged(self):
+        original = "https://example.com/docs"
+        self.assertEqual(make_absolute("public/foo/SKILL.md", original, "public"), original)
+
+    def test_http_link_unchanged(self):
+        original = "http://example.com/docs"
+        self.assertEqual(make_absolute("public/foo/SKILL.md", original, "public"), original)
+
+    def test_root_relative_link_unchanged(self):
+        original = "/md/documentation/something/"
+        self.assertEqual(make_absolute("public/foo/SKILL.md", original, "public"), original)
+
+    def test_anchor_unchanged(self):
+        original = "#section-heading"
+        self.assertEqual(make_absolute("public/foo/SKILL.md", original, "public"), original)
+
+    def test_mailto_unchanged(self):
+        original = "mailto:support@qdrant.tech"
+        self.assertEqual(make_absolute("public/foo/SKILL.md", original, "public"), original)
+
+
+class TestRun(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp)
+
+    def write(self, rel_path, content):
+        path = os.path.join(self.tmp, rel_path)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            f.write(content)
+        return path
+
+    def read(self, rel_path):
+        with open(os.path.join(self.tmp, rel_path)) as f:
+            return f.read()
+
+    def test_relative_links_converted(self):
+        self.write(
+            "qdrant-scaling/SKILL.md",
+            "See [Data Volume](scaling-data-volume/SKILL.md) for details.\n",
+        )
+        run(self.tmp)
+        self.assertIn(
+            f"[Data Volume]({BASE_URL}/qdrant-scaling/scaling-data-volume/SKILL.md)",
+            self.read("qdrant-scaling/SKILL.md"),
+        )
+
+    def test_absolute_links_not_changed(self):
+        content = "See [Docs](https://qdrant.tech/docs) for info.\n"
+        self.write("qdrant-scaling/SKILL.md", content)
+        run(self.tmp)
+        self.assertEqual(self.read("qdrant-scaling/SKILL.md"), content)
+
+    def test_root_relative_links_not_changed(self):
+        content = "See [Docs](/md/documentation/something/) for info.\n"
+        self.write("foo/SKILL.md", content)
+        run(self.tmp)
+        self.assertEqual(self.read("foo/SKILL.md"), content)
+
+    def test_mixed_links_in_one_file(self):
+        self.write(
+            "foo/SKILL.md",
+            "[Relative](bar/SKILL.md) and [Absolute](https://example.com) and [Root](/md/x).\n",
+        )
+        run(self.tmp)
+        result = self.read("foo/SKILL.md")
+        self.assertIn(f"[Relative]({BASE_URL}/foo/bar/SKILL.md)", result)
+        self.assertIn("[Absolute](https://example.com)", result)
+        self.assertIn("[Root](/md/x)", result)
+
+    def test_non_md_file_untouched(self):
+        self.write("foo/config.json", '{"link": "bar/baz.md"}\n')
+        run(self.tmp)
+        self.assertEqual(self.read("foo/config.json"), '{"link": "bar/baz.md"}\n')
+
+    def test_parent_traversal_in_nested_file(self):
+        self.write(
+            "qdrant-scaling/minimize-latency/SKILL.md",
+            "See [Vertical](../scaling-data-volume/vertical-scaling/SKILL.md).\n",
+        )
+        run(self.tmp)
+        self.assertIn(
+            f"[Vertical]({BASE_URL}/qdrant-scaling/scaling-data-volume/vertical-scaling/SKILL.md)",
+            self.read("qdrant-scaling/minimize-latency/SKILL.md"),
+        )
+
+    def test_index_at_root_level(self):
+        self.write(
+            "index.md",
+            "- [Scaling](qdrant-scaling/SKILL.md)\n- [Monitoring](qdrant-monitoring/SKILL.md)\n",
+        )
+        run(self.tmp)
+        result = self.read("index.md")
+        self.assertIn(f"[Scaling]({BASE_URL}/qdrant-scaling/SKILL.md)", result)
+        self.assertIn(f"[Monitoring]({BASE_URL}/qdrant-monitoring/SKILL.md)", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this PR does

Relative inter-skill links (for example, `scaling-data-volume/SKILL.md`) can be misleading when agents fetch skills from the deployed site because there's no base URL context. This PR adds a build step that rewrites them to absolute `https://skills.qdrant.tech/...` URLs. The source files are untouched, so links keep working in the GitHub UI and locally.

### Changes

- scripts/make_links_absolute.py — scans all markdown files in `public/` after the build copy and rewrites relative markdown links to absolute URLs, handling nested paths and `../` traversal
- build.sh — calls the new script after the existing `sed` step
- scripts/test_make_links_absolute.py — 15 unit and integration tests covering all link types and edge cases
- CONTRIBUTING.md — documents how to run both the new tests and the existing skill validator


## Type

- [ ] new skill
- [ ] skill improvement
- [ ] bug fix
- [x] repo hygiene