### PR TITLE
Build links from Netlify deploy domain with proper URL joining

### DIFF
--- a/scripts/generate_sitemap.sh
+++ b/scripts/generate_sitemap.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE_URL="${SITE_URL:-${DEPLOY_PRIME_URL:-${URL:-https://skills.qdrant.tech}}}"
+# On production, URL is the custom domain (skills.qdrant.tech); DEPLOY_PRIME_URL
+# there is the branch permalink (main--qdrant-skills.netlify.app). On previews
+# and branch deploys, prefer DEPLOY_PRIME_URL so links match the viewed deploy.
+if [ "${CONTEXT:-}" = "production" ]; then
+  BASE_URL="${SITE_URL:-${URL:-https://skills.qdrant.tech}}"
+else
+  BASE_URL="${SITE_URL:-${DEPLOY_PRIME_URL:-${URL:-https://skills.qdrant.tech}}}"
+fi
 BASE_URL="${BASE_URL%/}"
 PUBLIC_DIR="${1:-public}"
 OUTPUT="${PUBLIC_DIR}/sitemap.xml"

--- a/scripts/make_links_absolute.py
+++ b/scripts/make_links_absolute.py
@@ -5,14 +5,24 @@ import os
 import re
 from urllib.parse import urljoin, urlsplit
 
-# On Netlify, DEPLOY_PRIME_URL / URL are injected with the deploy's real domain
-# (including branch deploys and deploy previews). Fall back to the production
-# domain for local builds.
-BASE_URL = (
-    os.environ.get("DEPLOY_PRIME_URL")
-    or os.environ.get("URL")
-    or "https://skills.qdrant.tech"
-).rstrip("/")
+def _site_url():
+    """Resolve the site's base URL from Netlify's build environment.
+
+    On production we want the custom domain, which Netlify exposes via URL —
+    DEPLOY_PRIME_URL there is the branch permalink (e.g.
+    https://main--qdrant-skills.netlify.app), not skills.qdrant.tech. On deploy
+    previews and branch deploys we prefer DEPLOY_PRIME_URL so links stay self
+    consistent with the deploy being viewed. Fall back to the production domain
+    for local builds.
+    """
+    if os.environ.get("CONTEXT") == "production":
+        url = os.environ.get("URL")
+    else:
+        url = os.environ.get("DEPLOY_PRIME_URL") or os.environ.get("URL")
+    return (url or "https://skills.qdrant.tech").rstrip("/")
+
+
+BASE_URL = _site_url()
 PUBLIC_DIR = "public"
 
 LINK_RE = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')


### PR DESCRIPTION
## Summary

Makes the deployed markdown links use the **actual current deploy domain** that Netlify provides, instead of a hard-coded one, and replaces ad-hoc string concatenation with proper URL functions.

- **Domain from Netlify env, context-aware** — resolve `BASE_URL` from Netlify's build environment instead of hard-coding it:
  - On **production**, use `URL` (the custom domain, `skills.qdrant.tech`). `DEPLOY_PRIME_URL` on production is the branch permalink (`main--qdrant-skills.netlify.app`), so it must not be preferred there.
  - On **deploy previews / branch deploys**, prefer `DEPLOY_PRIME_URL` so links stay self-consistent with the deploy being viewed.
  - Fall back to `https://skills.qdrant.tech` for local builds.
  - Same fallback chain applied in `generate_sitemap.sh`.
- **Proper URL building** — `make_absolute` now uses `urllib.parse.urljoin`/`urlsplit`, which correctly resolves relative paths and preserves fragments and query strings.
- **Absolutize root-relative links** — `build.sh` strips the `search.qdrant.tech` domain off `/md/` links, leaving them root-relative; these are now re-absolutized to the site domain (Netlify's `/md/*` redirect routes them back to search). Only in-page anchors (`#…`) and scheme-carrying links (`http`, `https`, `mailto`) are left untouched.

## Testing

- `python3 -m pytest scripts/test_make_links_absolute.py` — 16 pass (added/updated coverage for query-string preservation and root-relative absolutization).
- Verified `_site_url()` resolution across `production`, `deploy-preview`, and local (no-env) contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)