### PR TITLE
Update qdrant model migration skill related to support to create and delete named vectors

### DIFF
--- a/skills/qdrant-model-migration/SKILL.md
+++ b/skills/qdrant-model-migration/SKILL.md
@@ -5,7 +5,7 @@ description: "Guides embedding model migration in Qdrant without downtime. Use w
 
 # What to Do When Changing Embedding Models
 
-Vectors from different models are incompatible. You cannot mix old and new embeddings in the same vector space. All named vectors must be defined at collection creation time. Both migration strategies below require creating a new collection.
+Vectors from different models are incompatible. You cannot mix old and new embeddings in the same vector space. On v1.18+, you can add or delete named vector fields on an existing collection — migration no longer always requires a new collection. On v1.17 or earlier, all named vectors must be defined at collection creation time.
 
 - Understand collection aliases before choosing a strategy [Collection aliases](https://skills.qdrant.tech/md/documentation/manage-data/collections/?s=collection-aliases)
 
@@ -66,11 +66,13 @@ If you anticipate future model migrations, define both vector fields upfront at 
 
 Use when: adding sparse/BM25 vectors to an existing dense-only collection. Most common migration pattern.
 
-You cannot add sparse vectors to an existing dense-only collection. Must recreate:
+You cannot add sparse vectors to an existing collection that uses a default (unnamed) dense vector. Must recreate:
 
 - Create new collection with both dense and sparse vector configs defined
 - Re-embed all data with both dense and sparse models
 - Migrate payloads, swap alias
+
+If the collection already uses named dense vectors and is on v1.18+, add the sparse vector field directly without recreating [Update vector schema](https://skills.qdrant.tech/md/documentation/manage-data/collections/?s=update-vector-schema).
 
 Sparse vectors at chunk level have different TF-IDF characteristics than document level. Test retrieval quality after migration, especially for non-English text without stop-word removal.
 


### PR DESCRIPTION
Closes #53

## What this PR does

Update qdrant model migration skill related to support to create and delete named vectors

## Type

<!-- check one -->
- [ ] new skill
- [X] skill improvement
- [ ] bug fix
- [ ] repo hygiene

## Checklist

<!-- for new/improved skills, check all that apply -->
- [X] `python3 scripts/validate_skills.py` passes
- [X] skill answers "when?" or "why?", not "how?"
- [X] skill navigates to docs, does not duplicate or replace them
- [X] description has `Use when` with 5+ trigger phrases
- [X] leaf skills omit `allowed-tools`, hub skills declare them
- [X] ends with `## What NOT to Do` section
- [X] no code blocks except minimal snippets when absolutely required (reference the docs instead)
- [X] all doc links go to `skills.qdrant.tech/md/documentation/`
- [x] tested with a realistic prompt (paste below or link to eval)

## Test prompt

```
I'm on Qdrant v1.18 and my collection already uses named vectors (text_dense). I want to switch from all-MiniLM-L6-v2 to text-embedding-3-small with zero downtime. Do I need to create a new collection?
---
● Skill(qdrant-model-migration)
  ⎿  Successfully loaded skill

● No, you don't need a new collection. Since you're on v1.18+ with named vectors, you can do this in-place:

  1. Add the new vector field to your existing collection

  text-embedding-3-small outputs 1536 dimensions vs. 384 for all-MiniLM-L6-v2, so add a new named vector with the correct config:

  client.update_collection(
      collection_name="your_collection",
      vectors_config={
          "text_dense_v2": models.VectorParamsDiff(
              size=1536,
              distance=models.Distance.COSINE,
          )
      }
  )

  2. Backfill in the background with UpdateVectors

  Scroll through all points and re-embed with the new model, writing into text_dense_v2:

  from openai import OpenAI

  openai_client = OpenAI()
  offset = None

  while True:

  while True:
      points, offset = client.scroll(
          collection_name="your_collection",
          with_payload=True,
          with_vectors=False,  # don't fetch old vectors
          limit=64,
          offset=offset,
      )
      if not points:
          break

      texts = [p.payload["text"] for p in points]  # adjust to your payload key
      embeddings = openai_client.embeddings.create(
          model="text-embedding-3-small", input=texts
      ).data

      client.update_vectors(
          collection_name="your_collection",
          points=[
              models.PointVectors(id=p.id, vector={"text_dense_v2": e.embedding})
              for p, e in zip(points, embeddings)
          ],
      )

  During backfill, your app keeps serving queries using text_dense (old model). New writes should populate both vector fields.

  3. Verify quality, then clean up

  Once backfill is complete and you've validated search quality (run your eval set against text_dense_v2), delete the old field:

  client.delete_collection_vectors(
      collection_name="your_collection",
      vectors=["text_dense"],  # frees the memory/disk
  )

  Then update your application to query with using="text_dense_v2" (or rename it if you want to avoid the code change — though a rename requires a recreate).

  One important note: remember to update your query-time embedding call in your app code to use text-embedding-3-small when you switch the using parameter — mismatched query/index embeddings are a common gotcha.
```
