### PR TITLE
[infra] Set docs team as code owner for `skills/`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/skills/ @szabosteve @documentation-team
+* @szabosteve @documentation-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-* @thierrypdamiba
-
 /skills/ @szabosteve @documentation-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @thierrypdamiba
+
+/skills/ @szabosteve @documentation-team


### PR DESCRIPTION
## What this PR does

This PR changes the code owners for the `skills` folder.


## Type

<!-- check one -->
- [ ] new skill
- [ ] skill improvement
- [ ] bug fix
- [x] repo hygiene