### PR TITLE
Change API docs links to skills proxy

### DIFF
--- a/skills/qdrant-clients-sdk/SKILL.md
+++ b/skills/qdrant-clients-sdk/SKILL.md
@@ -24,7 +24,7 @@ Qdrant has the following officially supported client SDKs:
 
 All interaction with Qdrant can happen through the REST API or gRPC API. We recommend using the REST API if you are using Qdrant for the first time or working on a prototype.
 
-* REST API - [OpenAPI Reference](https://api.qdrant.tech/api-reference) - [GitHub](https://github.com/qdrant/qdrant/blob/master/docs/redoc/master/openapi.json)
+* REST API - [OpenAPI Reference](https://skills.qdrant.tech/api-reference.md) - [GitHub](https://github.com/qdrant/qdrant/blob/master/docs/redoc/master/openapi.json)
 * gRPC API - [gRPC protobuf definitions](https://github.com/qdrant/qdrant/tree/master/lib/api/src/grpc/proto)
 
 ## Code examples

--- a/skills/qdrant-search-quality/search-strategies/relevance-feedback/SKILL.md
+++ b/skills/qdrant-search-quality/search-strategies/relevance-feedback/SKILL.md
@@ -12,7 +12,7 @@ First, understand how the RF works, read the ENTIRE section. Then define your go
 
 ## How It Works
 
-The [Qdrant Query Point API with a type RelevanceFeedbackQuery](https://api.qdrant.tech/api-reference/search/query-points) takes:
+The [Qdrant Query Point API with a type RelevanceFeedbackQuery](https://skills.qdrant.tech/api-reference/search/query-points.md) takes:
 
 - a query (`target`)
 - a small list of seed documents (`feedback`) with relevance scores (often 4–5 seeds are enough)


### PR DESCRIPTION
## What this PR does

This PR updates two SKILL.md links that pointed to the HTML version of the API reference to instead use the .md endpoint and route through skills.qdrant.tech.


## Type

<!-- check one -->
- [ ] new skill
- [ ] skill improvement
- [ ] bug fix
- [x] repo hygiene
