### PR TITLE
Proxy /snippets/* to search.qdrant.tech via Netlify rewrite

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -31,6 +31,12 @@
   status = 200
   force = true
 
+[[redirects]]
+  from = "/snippets/*"
+  to = "https://search.qdrant.tech/snippets/:splat"
+  status = 200
+  force = true
+
 [[headers]]
   for = "/*.md"
   [headers.values]


### PR DESCRIPTION
## What this PR does

This PR adds a Netlify proxy rewrite for `/snippets/*` → `search.qdrant.tech/snippets/*`.

## Type

<!-- check one -->
- [ ] new skill
- [ ] skill improvement
- [ ] bug fix
- [x] repo hygiene