### PR TITLE
Scope `qdrant-performance-optimization` to proactive tuning

### DIFF
--- a/skills/qdrant-performance-optimization/SKILL.md
+++ b/skills/qdrant-performance-optimization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qdrant-performance-optimization
-description: "Different techniques to optimize the performance of Qdrant, including indexing strategies, query optimization, and hardware considerations. Use when you want to improve the speed and efficiency of your Qdrant deployment."
+description: "Navigation hub linking sub-skills for proactive Qdrant tuning: search speed, indexing performance, and memory usage optimization. Use when planning configuration or capacity changes to improve speed and efficiency. For diagnosing an active production slowdown or analyzing live metrics, use qdrant-monitoring instead."
 allowed-tools:
   - Read
   - Grep

--- a/skills/qdrant-performance-optimization/memory-usage-optimization/SKILL.md
+++ b/skills/qdrant-performance-optimization/memory-usage-optimization/SKILL.md
@@ -53,7 +53,7 @@ Here are the main techniques to achieve that:
 
 - Use float16 or int8 datatypes to reduce memory usage of vectors by 2x or 4x respectively, with some tradeoff in precision. Read more about vector datatypes in [documentation](https://skills.qdrant.tech/md/documentation/manage-data/vectors/?s=datatypes)
 
-- Leverage Matryoshka Representation Learning (MRL) to store only small vectors in RAM while keeping large vectors on disk. Examples of how to use MRL with Qdrant Cloud inference: [MRL docs](https://skills.qdrant.tech/md/documentation/inference/?s=reduce-vector-dimensionality-with-matryoshka-models)
+- Leverage Matryoshka Representation Learning (MRL) to store only small vectors in RAM while keeping large vectors on disk. Examples of how to use MRL with Qdrant Cloud inference: [MRL docs](https://skills.qdrant.tech/md/documentation/inference/matryoshka-models/?s=reduce-vector-dimensionality-with-matryoshka-models)
 
 - For multi-tenant deployments with small tenants, vectors might be stored on disk because the same tenant's data is stored together [Multitenancy docs](https://skills.qdrant.tech/md/documentation/manage-data/multitenancy/?s=calibrate-performance)
 

--- a/skills/qdrant-performance-optimization/search-speed-optimization/SKILL.md
+++ b/skills/qdrant-performance-optimization/search-speed-optimization/SKILL.md
@@ -27,7 +27,7 @@ Use when: individual queries take too long regardless of load.
 
 - Tune HNSW parameters: [Fine-tuning search](https://skills.qdrant.tech/md/documentation/ops-optimization/optimize/?s=fine-tuning-search-parameters)
 - Enable in-memory quantization: [Scalar quantization](https://skills.qdrant.tech/md/documentation/manage-data/quantization/?s=scalar-quantization)
-- Reduce Vector Dimensionality with Matryoshka Models: [Matryoshka Models](https://skills.qdrant.tech/md/documentation/inference/?s=reduce-vector-dimensionality-with-matryoshka-models)
+- Reduce Vector Dimensionality with Matryoshka Models: [Matryoshka Models](https://skills.qdrant.tech/md/documentation/inference/matryoshka-models/?s=reduce-vector-dimensionality-with-matryoshka-models)
 - Use oversampling + rescore for high-dimensional vectors [Search with quantization](https://skills.qdrant.tech/md/documentation/manage-data/quantization/?s=searching-with-quantization)
 - Enable io_uring for disk-heavy workloads on Linux [io_uring](https://qdrant.tech/articles/io_uring/)
 


### PR DESCRIPTION
## What this PR does


Related to https://github.com/qdrant/skills/issues/70

The `qdrant-performance-optimization` description was generic enough that agents loaded it alongside `qdrant-monitoring` for reactive diagnosis prompts. This PR tightens the description:

- Signals it's a navigation hub linking sub-skills.
- Scopes the "use when" to **proactive** tuning (planning config/capacity).
- Cross-references `qdrant-monitoring` for active production slowdowns.

Verified in a fresh-container harness against the full local skill set:

- **Reactive prompt** ("p99 latency spiked over the weekend, no deploys"): agent picked `qdrant-monitoring` only and explicitly skips `qdrant-performance-optimization`, citing the new cross-reference.
- **Proactive prompt** ("planning a 10M-vector deployment, choose config upfront"): agent picked `qdrant-performance-optimization` as primary  and explicitly rejects `qdrant-monitoring`.

Both runs confirm the new description works.

## Type

- [ ] new skill
- [x] skill improvement
- [ ] bug fix
- [ ] repo hygiene

## Checklist

<!-- for new/improved skills, check all that apply -->
- [ ] `python3 scripts/validate_skills.py` passes
- [ ] skill answers "when?" or "why?", not "how?"
- [ ] skill navigates to docs, does not duplicate or replace them
- [ ] description has `Use when` with 5+ trigger phrases
- [ ] leaf skills omit `allowed-tools`, hub skills declare them
- [ ] ends with `## What NOT to Do` section
- [ ] no code blocks except minimal snippets when absolutely required (reference the docs instead)
- [ ] all doc links go to `skills.qdrant.tech/md/documentation/`
- [ ] tested with a realistic prompt (paste below or link to eval)

## Test prompt

<!-- paste a realistic user question you tested this skill against, and summarize what the agent responded. skip for non-skill PRs. -->

Prompt 1.

```
Production Qdrant search latency just spiked from 80ms to 400ms p99 over the weekend with no deploys. I need to figure out what changed and restore performance.

Do two things:

1. State which Qdrant-related skill(s) you decided to load to answer this, and very briefly why you picked them.
2. Outline how you would diagnose the slowdown.
```

Prompt 2.

```
I am planning a new Qdrant deployment for a 10M-vector collection (768-dim, cosine, ~10k QPS target) on a single 32GB host. Nothing is in production yet — I want to choose the right configuration upfront for fast search and reasonable memory use.

Do two things:

1. State which Qdrant-related skill(s) you decided to load to answer this, and very briefly why you picked them.
2. Outline a configuration approach.
```
