### PR TITLE
add qdrant-edge skill for building on embedded shards

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qdrant",
-  "description": "Agent skills for Qdrant vector search: scaling, performance optimization, search quality, monitoring, deployment, model migration, version upgrades, and SDK usage",
+  "description": "Agent skills for Qdrant vector search: scaling, performance optimization, search quality, monitoring, deployment, edge, model migration, version upgrades, and SDK usage",
   "version": "1.0.0",
   "author": {
     "name": "Qdrant"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ If you use the installation method, just ask your agent about Qdrant. Skills are
 | qdrant-search-quality | Diagnosing bad results, search strategies, hybrid search |
 | qdrant-monitoring | Metrics, health checks, debugging optimizer and cluster issues |
 | qdrant-deployment-options | Choosing between local, self-hosted, cloud, and hybrid |
+| qdrant-edge | Building on the embedded shard: server sync, on-device BM25, snapshots, reuse vs reimplement |
 | qdrant-model-migration | Switching embedding models without downtime |
 | qdrant-version-upgrade | Safe upgrade paths, compatibility guarantees, rolling upgrades |
 

--- a/skills/index.md
+++ b/skills/index.md
@@ -6,6 +6,7 @@ Agent skills encoding deep Qdrant knowledge for coding agents.
 
 - [qdrant-clients-sdk](qdrant-clients-sdk/SKILL.md) — Client SDKs for Python, TypeScript, Rust, Go, .NET, and Java.
 - [qdrant-deployment-options](qdrant-deployment-options/SKILL.md) — Choosing between local, Docker, self-hosted, Cloud, and embedded deployments.
+- [qdrant-edge](qdrant-edge/SKILL.md) — Building on the embedded in-process shard: server sync, on-device BM25, snapshots, and what to reuse versus implement.
 - [qdrant-model-migration](qdrant-model-migration/SKILL.md) — Switching embedding models without downtime.
 - [qdrant-monitoring](qdrant-monitoring/SKILL.md) — Monitoring, observability, health checks, and debugging production issues.
   - [qdrant-monitoring-setup](qdrant-monitoring/setup/SKILL.md) — Setting up Prometheus, health probes, alerting, and log centralization.

--- a/skills/qdrant-deployment-options/SKILL.md
+++ b/skills/qdrant-deployment-options/SKILL.md
@@ -43,6 +43,7 @@ Use when: network round-trip to a server is unacceptable. Edge devices, in-proce
 - Qdrant EDGE: in-process bindings to Qdrant shard-level functions, no network overhead [Qdrant EDGE](https://skills.qdrant.tech/md/documentation/edge/edge-quickstart/)
 - Same data format as server. Can sync with server via shard snapshots.
 - Single-node feature set only. No distributed mode.
+- Chose EDGE and want to build on it? See the `qdrant-edge` skill (BM25, snapshot sync, app-side fusion).
 
 
 ## What NOT to Do

--- a/skills/qdrant-edge/SKILL.md
+++ b/skills/qdrant-edge/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: qdrant-edge
+description: "Guides building on Qdrant Edge, the embedded in-process shard. Use when someone asks 'how to sync Edge with the server', 'keep a local shard in sync with Qdrant Cloud', 'BM25 or keyword search on Edge', 'hybrid search on Edge', 'embeddings on device', 'Edge snapshots', 'apply a partial snapshot', or is writing custom sync, BM25, or fusion code against qdrant-edge. Also use when deciding what Edge ships built-in versus what you must implement."
+---
+
+# Building on Qdrant Edge
+
+Edge is the Qdrant engine embedded in your process (Python or Rust), not a thin local vector store to wrap. The failure mode is rebuilding what the shard already ships: keyword scoring, snapshot handling, faceting. Before writing any of that, check the shard API. Two things Edge genuinely does NOT give you are a one-call cloud sync and query-time fusion, so knowing which is which keeps you from both reinventing built-ins and expecting capabilities Edge lacks. Edge is single-node and shares the server's data format.
+
+- Start from what a shard is and does [Qdrant Edge](https://skills.qdrant.tech/md/documentation/edge/)
+
+
+## Syncing a Shard With a Qdrant Server
+
+Use when: keeping a local Edge shard in step with a Qdrant Cloud or server collection.
+
+There is no built-in `.sync()`. Sync is a pattern you implement, not one call, so do not invent a protocol or hand-parse snapshot tarballs.
+
+- Follow the documented dual-shard pattern: a `mutable` shard for this device's writes plus an `immutable` shard loaded from a server snapshot, query both, refresh the immutable one on a schedule [Edge synchronization guide](https://skills.qdrant.tech/md/documentation/edge/edge-synchronization-guide/)
+- Apply snapshots with the shard helpers (`snapshot_manifest`, `unpack_snapshot`, `update_from_snapshot`), never custom tar extraction [Synchronization patterns](https://skills.qdrant.tech/md/documentation/edge/edge-data-synchronization-patterns/)
+- Push is your own upserts to the server: the helpers cover the pull side only. Buffer writes while offline and drain the queue on reconnect [Edge synchronization guide](https://skills.qdrant.tech/md/documentation/edge/edge-synchronization-guide/)
+- Seed a fresh shard straight from a snapshot: seeding and refresh share one apply path [Synchronization patterns](https://skills.qdrant.tech/md/documentation/edge/edge-data-synchronization-patterns/)
+
+
+## Keyword and Hybrid Search on Device
+
+Use when: you need exact-term or BM25 matching, alone or alongside vectors.
+
+- BM25 is built into Edge (`Bm25`, `Bm25Config`, `embed_document`, `embed_query`), with the IDF `Modifier` on `EdgeSparseVectorParams`. Do not reimplement term scoring or ship a second BM25 library [Edge BM25](https://skills.qdrant.tech/md/documentation/edge/edge-bm25/)
+- Dense embeddings are NOT in Edge: generate them on device with the separate `fastembed` package [FastEmbed embeddings](https://skills.qdrant.tech/md/documentation/edge/edge-fastembed-embeddings/)
+- Fusion (RRF, DBSF) is NOT consumed by Edge's query path: run the dense and sparse legs separately and combine them in application code. This is the one place hand-rolling is correct, not a smell [Edge quickstart](https://skills.qdrant.tech/md/documentation/edge/edge-quickstart/)
+
+
+## Reaching for a Server-Side Feature
+
+Use when: you are about to aggregate, count, or index in application code.
+
+- Faceting is built in (`facet` with a `FacetRequest`), so do not scroll and tally in Python [Edge quickstart](https://skills.qdrant.tech/md/documentation/edge/edge-quickstart/)
+- Create payload field indexes at setup (`create_field_index`) so filtered queries stay fast [Edge quickstart](https://skills.qdrant.tech/md/documentation/edge/edge-quickstart/)
+- Reclaim space and keep segments healthy with `optimize` and `EdgeOptimizersConfig`, not manual compaction [Edge quickstart](https://skills.qdrant.tech/md/documentation/edge/edge-quickstart/)
+
+
+## What NOT to Do
+
+- Hand-roll snapshot download and tar handling instead of the shard's snapshot helpers
+- Expect a bidirectional `.sync()` or a built-in push path: Edge gives you snapshot apply, you own the upload
+- Ship a custom or third-party BM25 when Edge has one built in
+- Assume Edge consumes Prefetch or Fusion: combine dense and sparse results in application code until the docs state otherwise
+- Reach for Edge when you need distributed or multi-node search: it is single-node [Qdrant Edge](https://skills.qdrant.tech/md/documentation/edge/)
+- Claim support for a language beyond Python and Rust, or an OS or accelerator the Edge docs do not state

--- a/skills/qdrant-edge/SKILL.md
+++ b/skills/qdrant-edge/SKILL.md
@@ -5,21 +5,21 @@ description: "Guides building on Qdrant Edge, the embedded in-process shard. Use
 
 # Building on Qdrant Edge
 
-Edge is the Qdrant engine embedded in your process (Python or Rust), not a thin local vector store to wrap. The failure mode is rebuilding what the shard already ships: keyword scoring, snapshot apply, faceting, counting. Before writing any of that, check the shard API. Two things Edge genuinely does NOT give you are a one-call cloud sync and query-time fusion, so knowing which is which keeps you from both reinventing built-ins and expecting capabilities Edge lacks. Edge is single-node and shares the server's data format.
+Edge is the Qdrant engine embedded in your process (Python or Rust), not a thin local vector store to wrap. The failure mode is rebuilding what the shard already ships: keyword scoring, snapshot apply, faceting, counting. Before writing any of that, check the shard API. Two things Edge does NOT give you are a one-call cloud sync and query-time fusion, so knowing which is which keeps you from both reinventing built-ins and expecting capabilities Edge lacks. Edge is single-node and shares the server's data format.
 
-- Edge is in beta: pin your version, the API drifts between releases [Qdrant Edge](https://skills.qdrant.tech/md/documentation/edge/)
+- Edge is in beta: pin your version, the API drifts between releases [Qdrant Edge](https://skills.qdrant.tech/md/documentation/edge/).
 
 
-## Syncing a Shard With a Qdrant Server
+## Syncing a Shard with a Qdrant Server
 
 Use when: seeding a shard from a server, keeping it fresh, backing it up, or aggregating many devices into one collection.
 
 There is no built-in `.sync()`. Sync is a pattern you assemble from shard helpers plus your own transport, so do not go looking for one call.
 
-- Follow the documented dual-shard pattern: a `mutable` shard for local writes plus an `immutable` shard restored from a server snapshot, query both, refresh on a schedule [Edge synchronization guide](https://skills.qdrant.tech/md/documentation/edge/edge-synchronization-guide/)
-- You write the snapshot download (plain HTTP to the shard snapshot endpoint), then apply it with `unpack_snapshot` and `update_from_snapshot`. Do not untar or merge segments by hand [Synchronization patterns](https://skills.qdrant.tech/md/documentation/edge/edge-data-synchronization-patterns/)
-- Refresh incrementally with a partial snapshot built from `snapshot_manifest`, not a full snapshot every cycle [Synchronization patterns](https://skills.qdrant.tech/md/documentation/edge/edge-data-synchronization-patterns/)
-- Push is your own dual-write: on each local upsert, enqueue the point and let a background worker upsert it to the server, buffering while offline [Synchronization patterns](https://skills.qdrant.tech/md/documentation/edge/edge-data-synchronization-patterns/)
+- Follow the documented dual-shard pattern: a `mutable` shard for local writes plus an `immutable` shard restored from a server snapshot, query both, refresh on a schedule [Edge synchronization guide](https://skills.qdrant.tech/md/documentation/edge/edge-synchronization-guide/).
+- You write the snapshot download (plain HTTP to the shard snapshot endpoint), then apply it with `unpack_snapshot` and `update_from_snapshot`. Do not untar or merge segments by hand [Synchronization patterns](https://skills.qdrant.tech/md/documentation/edge/edge-data-synchronization-patterns/).
+- Refresh incrementally with a partial snapshot built from `snapshot_manifest`, not a full snapshot every cycle [Synchronization patterns](https://skills.qdrant.tech/md/documentation/edge/edge-data-synchronization-patterns/).
+- Push is your own dual-write: on each local upsert, enqueue the point and let a background worker upsert it to the server, buffering while offline [Synchronization patterns](https://skills.qdrant.tech/md/documentation/edge/edge-data-synchronization-patterns/).
 
 
 ## Keyword and Hybrid Search on Device

--- a/skills/qdrant-edge/SKILL.md
+++ b/skills/qdrant-edge/SKILL.md
@@ -1,50 +1,52 @@
 ---
 name: qdrant-edge
-description: "Guides building on Qdrant Edge, the embedded in-process shard. Use when someone asks 'how to sync Edge with the server', 'keep a local shard in sync with Qdrant Cloud', 'BM25 or keyword search on Edge', 'hybrid search on Edge', 'embeddings on device', 'Edge snapshots', 'apply a partial snapshot', or is writing custom sync, BM25, or fusion code against qdrant-edge. Also use when deciding what Edge ships built-in versus what you must implement."
+description: "Guides building on Qdrant Edge, the embedded in-process shard. Use when someone asks 'how to sync Edge with the server', 'keep a local shard in sync with Qdrant Cloud', 'BM25 or keyword search on Edge', 'hybrid search on Edge', 'embeddings on device', 'Edge snapshots', 'apply a partial snapshot', 'why is my Edge search empty after inserts', or is writing custom sync, BM25, or fusion code against qdrant-edge. Also use when deciding what Edge ships built-in versus what you must implement."
 ---
 
 # Building on Qdrant Edge
 
-Edge is the Qdrant engine embedded in your process (Python or Rust), not a thin local vector store to wrap. The failure mode is rebuilding what the shard already ships: keyword scoring, snapshot handling, faceting. Before writing any of that, check the shard API. Two things Edge genuinely does NOT give you are a one-call cloud sync and query-time fusion, so knowing which is which keeps you from both reinventing built-ins and expecting capabilities Edge lacks. Edge is single-node and shares the server's data format.
+Edge is the Qdrant engine embedded in your process (Python or Rust), not a thin local vector store to wrap. The failure mode is rebuilding what the shard already ships: keyword scoring, snapshot apply, faceting, counting. Before writing any of that, check the shard API. Two things Edge genuinely does NOT give you are a one-call cloud sync and query-time fusion, so knowing which is which keeps you from both reinventing built-ins and expecting capabilities Edge lacks. Edge is single-node and shares the server's data format.
 
-- Start from what a shard is and does [Qdrant Edge](https://skills.qdrant.tech/md/documentation/edge/)
+- Edge is in beta: pin your version, the API drifts between releases [Qdrant Edge](https://skills.qdrant.tech/md/documentation/edge/)
 
 
 ## Syncing a Shard With a Qdrant Server
 
-Use when: keeping a local Edge shard in step with a Qdrant Cloud or server collection.
+Use when: seeding a shard from a server, keeping it fresh, backing it up, or aggregating many devices into one collection.
 
-There is no built-in `.sync()`. Sync is a pattern you implement, not one call, so do not invent a protocol or hand-parse snapshot tarballs.
+There is no built-in `.sync()`. Sync is a pattern you assemble from shard helpers plus your own transport, so do not go looking for one call.
 
-- Follow the documented dual-shard pattern: a `mutable` shard for this device's writes plus an `immutable` shard loaded from a server snapshot, query both, refresh the immutable one on a schedule [Edge synchronization guide](https://skills.qdrant.tech/md/documentation/edge/edge-synchronization-guide/)
-- Apply snapshots with the shard helpers (`snapshot_manifest`, `unpack_snapshot`, `update_from_snapshot`), never custom tar extraction [Synchronization patterns](https://skills.qdrant.tech/md/documentation/edge/edge-data-synchronization-patterns/)
-- Push is your own upserts to the server: the helpers cover the pull side only. Buffer writes while offline and drain the queue on reconnect [Edge synchronization guide](https://skills.qdrant.tech/md/documentation/edge/edge-synchronization-guide/)
-- Seed a fresh shard straight from a snapshot: seeding and refresh share one apply path [Synchronization patterns](https://skills.qdrant.tech/md/documentation/edge/edge-data-synchronization-patterns/)
+- Follow the documented dual-shard pattern: a `mutable` shard for local writes plus an `immutable` shard restored from a server snapshot, query both, refresh on a schedule [Edge synchronization guide](https://skills.qdrant.tech/md/documentation/edge/edge-synchronization-guide/)
+- You write the snapshot download (plain HTTP to the shard snapshot endpoint), then apply it with `unpack_snapshot` and `update_from_snapshot`. Do not untar or merge segments by hand [Synchronization patterns](https://skills.qdrant.tech/md/documentation/edge/edge-data-synchronization-patterns/)
+- Refresh incrementally with a partial snapshot built from `snapshot_manifest`, not a full snapshot every cycle [Synchronization patterns](https://skills.qdrant.tech/md/documentation/edge/edge-data-synchronization-patterns/)
+- Push is your own dual-write: on each local upsert, enqueue the point and let a background worker upsert it to the server, buffering while offline [Synchronization patterns](https://skills.qdrant.tech/md/documentation/edge/edge-data-synchronization-patterns/)
 
 
 ## Keyword and Hybrid Search on Device
 
 Use when: you need exact-term or BM25 matching, alone or alongside vectors.
 
-- BM25 is built into Edge (`Bm25`, `Bm25Config`, `embed_document`, `embed_query`), with the IDF `Modifier` on `EdgeSparseVectorParams`. Do not reimplement term scoring or ship a second BM25 library [Edge BM25](https://skills.qdrant.tech/md/documentation/edge/edge-bm25/)
+- BM25 is built into Edge (`Bm25`, `Bm25Config`, `embed_document`, `embed_query`) with the IDF `Modifier` on `EdgeSparseVectorParams`, and is wire-compatible with server BM25: a shard seeded from a server snapshot answers local BM25 queries without re-indexing. Do not ship a second BM25 library [Edge BM25](https://skills.qdrant.tech/md/documentation/edge/edge-bm25/)
 - Dense embeddings are NOT in Edge: generate them on device with the separate `fastembed` package [FastEmbed embeddings](https://skills.qdrant.tech/md/documentation/edge/edge-fastembed-embeddings/)
-- Fusion (RRF, DBSF) is NOT consumed by Edge's query path: run the dense and sparse legs separately and combine them in application code. This is the one place hand-rolling is correct, not a smell [Edge quickstart](https://skills.qdrant.tech/md/documentation/edge/edge-quickstart/)
+- Edge queries one vector field per request (`using`) and does not fuse dense and sparse at query time. Run each leg separately and combine the rankings in application code [Edge quickstart](https://skills.qdrant.tech/md/documentation/edge/edge-quickstart/)
 
 
-## Reaching for a Server-Side Feature
+## Operating the Shard
 
-Use when: you are about to aggregate, count, or index in application code.
+Use when: writes have accumulated, search looks stale after inserts, or a backup is larger than the data.
 
-- Faceting is built in (`facet` with a `FacetRequest`), so do not scroll and tally in Python [Edge quickstart](https://skills.qdrant.tech/md/documentation/edge/edge-quickstart/)
-- Create payload field indexes at setup (`create_field_index`) so filtered queries stay fast [Edge quickstart](https://skills.qdrant.tech/md/documentation/edge/edge-quickstart/)
-- Reclaim space and keep segments healthy with `optimize` and `EdgeOptimizersConfig`, not manual compaction [Edge quickstart](https://skills.qdrant.tech/md/documentation/edge/edge-quickstart/)
+- Edge has NO background optimizer. Call `optimize` after bulk writes: it builds indexes (including the sparse index) and reclaims deleted points. Skip it and that data stays unindexed [Edge quickstart](https://skills.qdrant.tech/md/documentation/edge/edge-quickstart/)
+- Faceting, counting, and enumeration are built in (`facet`, `count`, `scroll`); index the fields you filter or facet with `create_field_index` rather than aggregating in application code [Edge quickstart](https://skills.qdrant.tech/md/documentation/edge/edge-quickstart/)
+- The write-ahead log is pre-allocated to 32 MB and inflates apparent disk and backup size. Shrink it with `wal_options` (Rust), and do not treat raw file size as real usage [Edge quickstart](https://skills.qdrant.tech/md/documentation/edge/edge-quickstart/)
 
 
 ## What NOT to Do
 
-- Hand-roll snapshot download and tar handling instead of the shard's snapshot helpers
-- Expect a bidirectional `.sync()` or a built-in push path: Edge gives you snapshot apply, you own the upload
+- Expect a bidirectional `.sync()` or a built-in push path: Edge gives you snapshot apply, you own the transport and the dual-write
+- Untar or merge snapshot segments by hand instead of using `unpack_snapshot` and `update_from_snapshot`
 - Ship a custom or third-party BM25 when Edge has one built in
-- Assume Edge consumes Prefetch or Fusion: combine dense and sparse results in application code until the docs state otherwise
+- Use `embed_document` for queries or `embed_query` for documents: the weighting differs and results go wrong
+- Assume Edge fuses dense and sparse or consumes Prefetch: combine the rankings in application code
+- Assume a background optimizer like the server's: nothing is indexed or compacted until you call `optimize`
 - Reach for Edge when you need distributed or multi-node search: it is single-node [Qdrant Edge](https://skills.qdrant.tech/md/documentation/edge/)
 - Claim support for a language beyond Python and Rust, or an OS or accelerator the Edge docs do not state


### PR DESCRIPTION
Learnings from building https://github.com/qdrant-labs/memory-fleet

Adds a `qdrant-edge` skill for building on the embedded shard: use the built-in BM25 and the snapshot helpers, follow the documented dual-shard sync pattern, and fuse dense/sparse in application code (Edge has no one-call sync and does not consume query-time fusion).

Fills the gap left by `qdrant-deployment-options`, which covers only choosing Edge, not building on it. Every API name and doc link is verified against the live Edge docs and the skill passes `validate_skills.py`.

## Test prompt

Load the skill, then give a coding agent this prompt. It walks into the main anti-patterns (skipping `optimize()`, hand-rolling BM25 and RRF, custom snapshot sync); a correct answer keeps the app-side RRF while fixing the other two.

> I'm building an offline-capable Python app on Qdrant Edge (robot, intermittent wifi). Three problems. (1) I bulk-upserted 50k points but keyword search returns almost nothing right after. (2) I want to keep the shard fresh from our Qdrant Cloud collection and also get local edits back up to it. (3) For hybrid search I'm about to pip install a BM25 lib and write my own RRF. What am I getting wrong?