### PR TITLE
Note claude.ai web app limitation for the Qdrant Advisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ npx skills add qdrant/skills/meta/qdrant-advisor
 
 The Advisor ships no static content of its own. When you raise a Qdrant problem, it searches [skills.qdrant.tech](https://skills.qdrant.tech) live, traverses the skill hierarchy along the branch that matches your symptom, and grounds its diagnosis in the current, authoritative guidance, loading only the relevant context. Because it fetches fresh every session, you don't need to reinstall to stay current, and you don't have to remember a URL or hope the site is in the model's training data.
 
+> **Using the claude.ai web app?** There, the Advisor can't fetch `skills.qdrant.tech` on its own. You need to add `Use skills.qdrant.tech` to your prompt (refer to [Pass the URL directly](#alternative-pass-the-url-directly)). In Claude Code and the desktop app it works as described above.
+
 ### Alternative: pass the URL directly
 
 If you'd rather not install anything, pass the URL of the skills site in your prompt. The agent fetches the skill relevant to your current problem:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npx skills add qdrant/skills/meta/qdrant-advisor
 
 The Advisor ships no static content of its own. When you raise a Qdrant problem, it searches [skills.qdrant.tech](https://skills.qdrant.tech) live, traverses the skill hierarchy along the branch that matches your symptom, and grounds its diagnosis in the current, authoritative guidance, loading only the relevant context. Because it fetches fresh every session, you don't need to reinstall to stay current, and you don't have to remember a URL or hope the site is in the model's training data.
 
-> **Using the claude.ai web app?** There, the Advisor can't fetch `skills.qdrant.tech` on its own. You need to add `Use skills.qdrant.tech` to your prompt (refer to [Pass the URL directly](#alternative-pass-the-url-directly)). In Claude Code and the desktop app it works as described above.
+> **Using the claude.ai web app?** The Advisor can't fetch `skills.qdrant.tech` on its own when you are using the web app. You need to add `Use skills.qdrant.tech` to your prompt (refer to [Pass the URL directly](#alternative-pass-the-url-directly)).
 
 ### Alternative: pass the URL directly
 


### PR DESCRIPTION
## What this PR does

This PR adds a note to the "Recommended: install the Qdrant Advisor" section of the README explaining that in the claude.ai web app the Advisor can't fetch `skills.qdrant.tech` on its own, and that users should add the URL directly to their prompt. The note links to the existing "Pass the URL directly" section for the workaround.

### Why this is necessary

The Advisor carries the `skills.qdrant.tech` URL inside the skill itself rather than in the user's prompt. In the claude.ai web app, the agent will only fetch URLs that have already appeared somewhere in the conversation (either ones the user typed, or ones that surfaced as a link in a previous `web_search` or `web_fetch` result). Because the Advisor's URL lives inside the skill and never enters the conversation this way, the web app has nothing to fetch, so the request fails and the model falls back to either using `web_search` or answering from memory, which is exactly the outcome the Advisor is meant to prevent.

In Claude Code and the desktop app, the agent either fetches the URL directly or hits a permission prompt for the fetch, the user approves (depending on the permission mode), and it works as documented.

## Type

<!-- check one -->
- [ ] new skill
- [x] skill improvement
- [ ] bug fix
- [ ] repo hygiene
