### PR TITLE
Switch to Sonnet for the nightly link fixer

### DIFF
--- a/.github/workflows/nightly-link-fix.yml
+++ b/.github/workflows/nightly-link-fix.yml
@@ -76,6 +76,7 @@ jobs:
           base_branch: main
           branch_prefix: "fix-broken-links/"
           claude_args: |
+            --model claude-sonnet-5
             --max-turns 40
             --allowedTools "Read,Grep,Glob,Edit,Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(git add:*),Bash(git checkout -b:*),Bash(git commit:*),Bash(git push:*),Bash(gh pr create:*),Bash(gh issue create:*)"
           prompt: |


### PR DESCRIPTION
Switches the nightly link fixer to Sonnet instead of Opus. This should be much cheaper (~40% cheaper per token), and Sonnet also tends to be more concise/fewer turns for straightforward mechanical tasks, so real-world savings are usually better than the raw price ratio suggests. 