### PR TITLE
Add second batch of test prompts to eval

### DIFF
--- a/evals/test-prompts/qdrant-edge.json
+++ b/evals/test-prompts/qdrant-edge.json
@@ -1,0 +1,52 @@
+{
+  "name": "qdrant-edge",
+  "product_area": "edge",
+  "skill_url": "https://github.com/qdrant/skills/blob/main/skills/qdrant-edge/SKILL.md",
+  "prompt": "I'm building an offline-capable Python app on Qdrant Edge (robot, intermittent wifi). Three problems. (1) I bulk-upserted 50k points but keyword search returns almost nothing right after. (2) I want to keep the shard fresh from our Qdrant Cloud collection and also get local edits back up to it. (3) For hybrid search I'm about to pip install a BM25 lib and write my own RRF. What am I getting wrong?",
+  "rubric": [
+    {
+      "type": "must",
+      "text": "The empty keyword results come from Edge having no background optimizer: call optimize after bulk writes to build the sparse/BM25 index and reclaim deletes — nothing is indexed until then."
+    },
+    {
+      "type": "must",
+      "text": "There's no built-in .sync(); pull via the dual-shard pattern (a mutable local-write shard plus an immutable shard restored from a server snapshot, queried together and refreshed on a schedule), downloading the snapshot yourself and applying it with unpack_snapshot/update_from_snapshot."
+    },
+    {
+      "type": "must",
+      "text": "Push is your own dual-write: enqueue each local upsert to a background worker that upserts to the server and buffers while offline."
+    },
+    {
+      "type": "must",
+      "text": "Don't add a BM25 library — BM25 is built into Edge (Bm25/Bm25Config, embed_document/embed_query) and is wire-compatible with server BM25."
+    },
+    {
+      "type": "must",
+      "text": "Keep the custom RRF: Edge queries one vector field per request (using) and doesn't fuse at query time, so combining rankings in application code is correct."
+    },
+    {
+      "type": "bonus",
+      "text": "Refresh incrementally with a partial snapshot from snapshot_manifest, not a full snapshot each cycle."
+    },
+    {
+      "type": "bonus",
+      "text": "Dense embeddings aren't in Edge — generate them on device with the separate fastembed package."
+    },
+    {
+      "type": "bonus",
+      "text": "Edge is beta — pin the version, since the API drifts."
+    },
+    {
+      "type": "avoid",
+      "text": "Blames the empty keyword search on BM25 setup or re-indexing instead of the missing optimize."
+    },
+    {
+      "type": "avoid",
+      "text": "Expects a built-in bidirectional .sync()/push, or untars/merges snapshot segments by hand."
+    },
+    {
+      "type": "avoid",
+      "text": "Drops the custom fusion because \"Edge handles hybrid,\" or swaps embed_document/embed_query."
+    }
+  ]
+}

--- a/evals/test-prompts/qdrant-hybrid-search-combining.json
+++ b/evals/test-prompts/qdrant-hybrid-search-combining.json
@@ -21,7 +21,7 @@
       "text": "Frames the reranker option as late-interaction / multivector fusion (or using a vector as the combiner): most precise but highest compute, for when top-K precision justifies the cost"
     },
     {
-      "type": "bonus",
+      "type": "must",
       "text": "Notes weighted RRF can let one retriever dominate, but weights must be tuned per dataset/score distribution, not guessed ('vibe' weights)"
     },
     {

--- a/evals/test-prompts/qdrant-hybrid-search-combining.json
+++ b/evals/test-prompts/qdrant-hybrid-search-combining.json
@@ -1,0 +1,40 @@
+{
+  "name": "qdrant-hybrid-search-combining",
+  "product_area": "hybrid search",
+  "skill_url": "https://skills.qdrant.tech/qdrant-search-quality/search-strategies/hybrid-search/combining-searches/SKILL.md",
+  "prompt": "We run dense and sparse (BM25) prefetches in a single query, and each one alone returns sensible candidates, but the merged ranking is worse than either - the two score scales are completely different and the fusion feels arbitrary. We can't decide between rank-based fusion, normalizing and fusing on scores, or adding a reranker. How should we choose?",
+  "rubric": [
+    {
+      "type": "must",
+      "text": "Because the two score scales are incomparable, recommends starting with RRF (rank-based fusion that ignores score magnitude) as a sensible default"
+    },
+    {
+      "type": "must",
+      "text": "Explains DBSF as the score-based alternative that normalizes each prefetch's score distribution (mean +/- 3 std) before fusing - the 'normalize and fuse on scores' option"
+    },
+    {
+      "type": "must",
+      "text": "Warns explicitly against a naive linear/weighted combination of the raw incomparable scores - the likely reason the merged ranking is worse than either alone"
+    },
+    {
+      "type": "must",
+      "text": "Frames the reranker option as late-interaction / multivector fusion (or using a vector as the combiner): most precise but highest compute, for when top-K precision justifies the cost"
+    },
+    {
+      "type": "bonus",
+      "text": "Notes weighted RRF can let one retriever dominate, but weights must be tuned per dataset/score distribution, not guessed ('vibe' weights)"
+    },
+    {
+      "type": "bonus",
+      "text": "Mentions custom fusion via a formula query (combine score + payload with decay/normalization) for bespoke control"
+    },
+    {
+      "type": "avoid",
+      "text": "Picks a fusion method without running comparative experiments on their own data"
+    },
+    {
+      "type": "avoid",
+      "text": "Recommends late-interaction reranking without evaluating cheaper analogues (e.g. MUVERA) first"
+    }
+  ]
+}

--- a/evals/test-prompts/qdrant-indexing-performance-optimization.json
+++ b/evals/test-prompts/qdrant-indexing-performance-optimization.json
@@ -1,0 +1,40 @@
+{
+  "name": "qdrant-indexing-performance-optimization",
+  "product_area": "performance optimization",
+  "skill_url": "https://skills.qdrant.tech/qdrant-performance-optimization/indexing-performance-optimization/SKILL.md",
+  "prompt": "Our initial load of 250M vectors is taking days, and after upload finishes the collection spends hours with uneven search performance while indexes catch up. We're using small upsert batches and creating payload indexes as fields become available. How can we make ingestion and index building faster?",
+  "rubric": [
+    {
+      "type": "must",
+      "text": "Identifies the small upsert batches as a client-side bottleneck and recommends larger batches (64-256 points/request) plus 2-4 parallel upload streams"
+    },
+    {
+      "type": "must",
+      "text": "Explains the post-load uneven search is expected: HNSW isn't built until segments exceed the indexing threshold (brute-force until then) and the optimizer is still catching up - not a bug"
+    },
+    {
+      "type": "must",
+      "text": "Recommends disabling HNSW during the bulk load (raise indexing_threshold_kb, restore after) to speed the initial load"
+    },
+    {
+      "type": "must",
+      "text": "Flags the payload-index timing problem: create payload indexes BEFORE the HNSW build, not 'as fields become available' after - adding them after HNSW breaks/forces rebuild of the filterable vector index"
+    },
+    {
+      "type": "bonus",
+      "text": "Suggests more shards (3-12), since each shard has an independent update worker, to parallelize server-side ingestion"
+    },
+    {
+      "type": "bonus",
+      "text": "Mentions checking the optimizations endpoint and CPU vs disk I/O (HNSW is CPU-bound, merging I/O-bound, HDD not viable), plus HNSW build knobs (m, ef_construct 100-200, GPU) if build time dominates"
+    },
+    {
+      "type": "avoid",
+      "text": "Recommends uploading one point at a time, or using m=0 on an existing collection"
+    },
+    {
+      "type": "avoid",
+      "text": "Treats the temporary post-load slow search as a defect rather than expected pre-index behavior"
+    }
+  ]
+}

--- a/evals/test-prompts/qdrant-memory-usage-optimization.json
+++ b/evals/test-prompts/qdrant-memory-usage-optimization.json
@@ -1,0 +1,40 @@
+{
+  "name": "qdrant-memory-usage-optimization",
+  "product_area": "performance optimization",
+  "skill_url": "https://skills.qdrant.tech/qdrant-performance-optimization/memory-usage-optimization/SKILL.md",
+  "prompt": "Our Qdrant node has 128 GB RAM, but memory looks full most of the time and occasionally crosses into OOM risk during optimizations. The collection has 70M 1024-d vectors, several payload indexes, and quantization enabled. How do we tell what must stay in RAM and reduce the footprint safely?",
+  "rubric": [
+    {
+      "type": "must",
+      "text": "Distinguishes resident memory (RSSAnon: ID tracker, quantized vectors with always_ram, payload indexes) from OS page cache (original vectors, releasable); notes page cache filling RAM is normal while resident >80% is the real problem, checked via /metrics"
+    },
+    {
+      "type": "must",
+      "text": "Attributes the OOM-during-optimization risk to insufficient headroom: optimized segments are fully loaded into RAM during optimization, so leave headroom (and a smaller max_segment_size reduces the headroom needed)"
+    },
+    {
+      "type": "must",
+      "text": "Since quantization is already enabled, recommends further footprint levers: original vectors / HNSW / payload indexes on disk, float16 or int8 datatypes (2x/4x reduction), or MRL to keep only small vectors in RAM"
+    },
+    {
+      "type": "bonus",
+      "text": "Notes payload indexes and the HNSW graph also consume resident memory and must be counted in the estimate, not just raw vectors"
+    },
+    {
+      "type": "bonus",
+      "text": "Mentions async_scorer (io_uring, Linux 5.11+) and moving sparse/text payload to disk to keep on-disk performance acceptable"
+    },
+    {
+      "type": "bonus",
+      "text": "Suggests confirming quantized vectors are the copy kept in RAM (always_ram) while originals stay on disk / page cache"
+    },
+    {
+      "type": "avoid",
+      "text": "Concludes a memory leak because page cache fills available RAM"
+    },
+    {
+      "type": "avoid",
+      "text": "Only recommends adding RAM / a bigger node and ignores the explicit footprint-reduction ask"
+    }
+  ]
+}

--- a/evals/test-prompts/qdrant-model-migration.json
+++ b/evals/test-prompts/qdrant-model-migration.json
@@ -1,0 +1,40 @@
+{
+  "name": "qdrant-model-migration",
+  "product_area": "model migration",
+  "skill_url": "https://skills.qdrant.tech/qdrant-model-migration/SKILL.md",
+  "prompt": "We have a production collection with 180M vectors from OpenAI `text-embedding-ada-002` and want to move to `text-embedding-3-large` while keeping search online. The new vectors have different dimensions, and we'd like to A/B test quality before cutting over. What migration plan should we use?",
+  "rubric": [
+    {
+      "type": "must",
+      "text": "Confirms the model change requires full re-embedding into a NEW vector space (ada-002 1536-d and 3-large 3072-d are incompatible; old vectors can't be reused or mixed)"
+    },
+    {
+      "type": "must",
+      "text": "Recommends the side-by-side pattern for the requested A/B test: store both models as named vectors and query using the old vs new vector to compare quality before committing"
+    },
+    {
+      "type": "must",
+      "text": "Uses a collection alias so the app points at the alias and you can atomically swap to the new model once satisfied (zero downtime); notes the version dependency (v1.18+ can add a named vector to the existing collection; v1.17- needs a new collection with both vectors defined upfront)"
+    },
+    {
+      "type": "must",
+      "text": "Warns to verify search quality before deleting old vectors/collection, and to update the query-side embedding model in application code at cutover"
+    },
+    {
+      "type": "bonus",
+      "text": "Addresses 180M-scale re-embed throughput: scroll old data with with_vectors=false, re-embed in batches (64-256 points, 2-4 parallel streams), idempotent upsert (update_mode: insert), disable HNSW during bulk load (raise indexing_threshold, restore after)"
+    },
+    {
+      "type": "bonus",
+      "text": "Flags that an alias swap only redirects queries - payloads must be migrated/re-uploaded separately"
+    },
+    {
+      "type": "avoid",
+      "text": "Suggests reusing or mixing the old ada-002 vectors with the new ones, or that re-embedding can be skipped here"
+    },
+    {
+      "type": "avoid",
+      "text": "Assumes a named vector can be added to an existing collection without checking server version (fails on v1.17 or earlier)"
+    }
+  ]
+}

--- a/evals/test-prompts/qdrant-monitoring.json
+++ b/evals/test-prompts/qdrant-monitoring.json
@@ -1,0 +1,32 @@
+{
+  "name": "qdrant-monitoring",
+  "product_area": "monitoring",
+  "skill_url": "https://skills.qdrant.tech/qdrant-monitoring/SKILL.md",
+  "prompt": "We've run a self-hosted cluster for about six months with basically no observability - no dashboards, no alerts. Lately we've had a couple of unexplained slow spells and one node restarted on its own overnight. We want to both get proper visibility in place and get to the bottom of what's been happening. Where do we start?",
+  "rubric": [
+    {
+      "type": "must",
+      "text": "Recognizes this is BOTH tracks - stand up observability AND diagnose the existing incidents - and separates the two workstreams"
+    },
+    {
+      "type": "must",
+      "text": "For visibility: set up Prometheus scraping of /metrics, Grafana dashboards, health probes (/healthz, /livez, /readyz), and baseline alerts so issues surface before users notice"
+    },
+    {
+      "type": "must",
+      "text": "For the incidents: use metrics/telemetry to diagnose the slow spells and the node restart (optimizer status, memory-growth trend, slow-request metrics) rather than guessing"
+    },
+    {
+      "type": "bonus",
+      "text": "Points to the specific debugging path (optimizer stuck / memory growth / slow requests) as the next step once metrics are in place"
+    },
+    {
+      "type": "bonus",
+      "text": "Establishes a 'healthy' baseline so future deviations like the overnight restart become detectable"
+    },
+    {
+      "type": "avoid",
+      "text": "Jumps straight to a single fix without first putting observability in place to see what's happening"
+    }
+  ]
+}

--- a/evals/test-prompts/qdrant-performance-optimization.json
+++ b/evals/test-prompts/qdrant-performance-optimization.json
@@ -1,0 +1,32 @@
+{
+  "name": "qdrant-performance-optimization",
+  "product_area": "performance optimization",
+  "skill_url": "https://skills.qdrant.tech/qdrant-performance-optimization/SKILL.md",
+  "prompt": "We're doing a performance and cost review before committing to a bigger cloud bill. Bulk re-imports feel slow, RAM sits high on the nodes, and a chunk of our queries are laggier than we'd like. We want to understand the full set of levers across ingestion, memory, and query speed before deciding where to invest. How should we approach this?",
+  "rubric": [
+    {
+      "type": "must",
+      "text": "Frames performance as three areas and maps the symptoms: slow bulk imports -> indexing performance; high RAM -> memory usage; laggy queries -> search speed"
+    },
+    {
+      "type": "must",
+      "text": "Explains search speed splits into latency (single query) vs throughput (QPS), so the query lag must be characterized before tuning"
+    },
+    {
+      "type": "must",
+      "text": "Recommends prioritizing/sequencing which area to tackle first rather than tuning everything at once (fits the 'decide where to invest' ask)"
+    },
+    {
+      "type": "bonus",
+      "text": "Points to the specific sub-areas (indexing-performance, memory-usage, search-speed) for the detailed levers"
+    },
+    {
+      "type": "bonus",
+      "text": "Notes background optimization can couple the areas (indexing competing with search), so measure before/after"
+    },
+    {
+      "type": "avoid",
+      "text": "Collapses into one sub-area and prescribes a single fix, ignoring the cross-cutting review the user asked for"
+    }
+  ]
+}

--- a/evals/test-prompts/qdrant-search-speed-optimization.json
+++ b/evals/test-prompts/qdrant-search-speed-optimization.json
@@ -1,0 +1,36 @@
+{
+  "name": "qdrant-search-speed-optimization",
+  "product_area": "performance optimization",
+  "skill_url": "https://skills.qdrant.tech/qdrant-performance-optimization/search-speed-optimization/SKILL.md",
+  "prompt": "Single-query search latency on our product catalog has crept up over the last month as the collection grew, even though traffic is flat. We return a fair amount of stored metadata with every hit, and sometimes the same query is slow once and fast right after. We want to find the actual bottleneck and speed queries back up - where should we look?",
+  "rubric": [
+    {
+      "type": "must",
+      "text": "Reads 'slow once, fast right after' as the memory-pressure signature: re-run the same query - a much faster second run means the working set no longer fits in RAM, consistent with latency creeping up as the collection grew"
+    },
+    {
+      "type": "must",
+      "text": "Tests whether payload retrieval is the bottleneck by re-running with with_payload:false (and with_vectors:false), given a lot of metadata is returned per hit"
+    },
+    {
+      "type": "must",
+      "text": "Offers latency fixes tied to the diagnosis: in-memory (scalar) quantization with always_ram so the working set fits, HNSW parameter tuning, and returning less payload per hit"
+    },
+    {
+      "type": "bonus",
+      "text": "Suggests removing filters one by one, if any are involved, to isolate a specific filter as the cause"
+    },
+    {
+      "type": "bonus",
+      "text": "Mentions oversampling + rescore for high-dimensional vectors and io_uring for disk-heavy Linux workloads as further levers"
+    },
+    {
+      "type": "avoid",
+      "text": "Sets always_ram=false or puts HNSW on disk for this latency-sensitive case (disk thrashing)"
+    },
+    {
+      "type": "avoid",
+      "text": "Blames Qdrant or scales out before checking the memory-pressure and payload diagnostics, or treats flat-traffic latency as a throughput/QPS problem"
+    }
+  ]
+}

--- a/evals/test-prompts/qdrant-search-strategies.json
+++ b/evals/test-prompts/qdrant-search-strategies.json
@@ -1,0 +1,40 @@
+{
+  "name": "qdrant-search-strategies",
+  "product_area": "search quality",
+  "skill_url": "https://skills.qdrant.tech/qdrant-search-quality/search-strategies/SKILL.md",
+  "prompt": "Our exact vector search looks reasonable, but product search still feels weak: some queries need exact part-number matches, some return near-duplicate items, and some relevant items are found only far down the list. Which retrieval strategy should we try for each problem?",
+  "rubric": [
+    {
+      "type": "must",
+      "text": "Maps the exact part-number match failures to hybrid search (add a lexical/sparse signal alongside dense) - the keyword-match branch"
+    },
+    {
+      "type": "must",
+      "text": "Maps the near-duplicate/redundant results to MMR (diversity parameter, v1.15+) to diversify the top results"
+    },
+    {
+      "type": "must",
+      "text": "Maps 'relevant items found only far down the list' (good recall, poor precision) to reranking / multistage queries (late-interaction or cross-encoder rerankers), or relevance feedback if reranking a large pool is too costly"
+    },
+    {
+      "type": "must",
+      "text": "Treats each symptom as a separate strategy choice (the 'which strategy for each problem' ask) rather than one blanket fix"
+    },
+    {
+      "type": "bonus",
+      "text": "Notes the prerequisite: confirm the embedding model and HNSW config are sound (verify pure vector-search quality) before layering strategies"
+    },
+    {
+      "type": "bonus",
+      "text": "Recommends evaluating each strategy's impact on the pipeline rather than assuming it helps"
+    },
+    {
+      "type": "avoid",
+      "text": "Recommends a single catch-all strategy (e.g. 'just add hybrid search') for all three distinct problems"
+    },
+    {
+      "type": "avoid",
+      "text": "Adds strategies without first verifying base vector-search quality"
+    }
+  ]
+}

--- a/evals/test-prompts/qdrant-tenant-scaling.json
+++ b/evals/test-prompts/qdrant-tenant-scaling.json
@@ -1,0 +1,40 @@
+{
+  "name": "qdrant-tenant-scaling",
+  "product_area": "scaling",
+  "skill_url": "https://skills.qdrant.tech/qdrant-scaling/scaling-data-volume/tenant-scaling/SKILL.md",
+  "prompt": "We run a SaaS app with about 35,000 customers in Qdrant. Today each customer has its own collection, and we're hitting operational limits with many tiny tenants plus a few very large ones. How should we redesign this so tenant queries stay isolated and performance doesn't collapse?",
+  "rubric": [
+    {
+      "type": "must",
+      "text": "Says to abandon collection-per-tenant (doesn't scale past a few hundred; ~1000 collection limit) and move to a single shared collection partitioned by a tenant-id payload key"
+    },
+    {
+      "type": "must",
+      "text": "Recommends a payload index on the tenant field with is_tenant=true for partitioning/isolation and read performance"
+    },
+    {
+      "type": "must",
+      "text": "Addresses the uneven tenant sizes with tiered multitenancy: promote the few very large tenants to dedicated shards while keeping the many small tenants on shared shards"
+    },
+    {
+      "type": "must",
+      "text": "For ~35k tenants on a multi-node cluster, recommends custom sharding (assign tenants to shards by tenant-id hash) to localize each tenant's queries to specific nodes instead of broadcasting to all"
+    },
+    {
+      "type": "bonus",
+      "text": "Uses payload_m to build per-tenant HNSW subgraphs instead of a global HNSW index for the multi-tenant collection"
+    },
+    {
+      "type": "bonus",
+      "text": "Notes true per-tenant isolation via separate collections is only for compliance/encryption needs - the exception, not the default"
+    },
+    {
+      "type": "avoid",
+      "text": "Keeps or recommends collection-per-tenant as the scalable design (without a compliance reason)"
+    },
+    {
+      "type": "avoid",
+      "text": "Omits is_tenant=true on the tenant index (kills sequential-read performance) or builds a global HNSW for the multi-tenant collection"
+    }
+  ]
+}


### PR DESCRIPTION
## What this PR does

Related to https://github.com/qdrant/skills/pull/98

This PR adds a second set of 10 test prompts to the evals folder that can be used to test and evaluate skills.


## Type

<!-- check one -->
- [ ] new skill
- [ ] skill improvement
- [ ] bug fix
- [x] repo hygiene
