### PR TITLE
docs: add symptom-to-sub-skill maps to navigation hubs

### DIFF
--- a/skills/qdrant-monitoring/SKILL.md
+++ b/skills/qdrant-monitoring/SKILL.md
@@ -9,6 +9,18 @@ allowed-tools:
 
 # Qdrant Monitoring
 
+## Symptom to Sub-skill Map
+
+| Symptom | Sub-skill |
+|---|---|
+| Want to set up Prometheus, Grafana, or health checks | [Monitoring Setup](setup/SKILL.md) |
+| Need to know which metrics to track | [Monitoring Setup](setup/SKILL.md) |
+| Setting up alerting or log centralization | [Monitoring Setup](setup/SKILL.md) |
+| Optimizer stuck or running forever | [Debugging with Metrics](debugging/SKILL.md) |
+| Memory keeps growing in production | [Debugging with Metrics](debugging/SKILL.md) |
+| Requests are slow and I need to find out why | [Debugging with Metrics](debugging/SKILL.md) |
+| Diagnosing an active production issue with metrics | [Debugging with Metrics](debugging/SKILL.md) |
+
 Qdrant monitoring allows tracking performance and health of your deployment, and identifying issues before they become outages. First determine whether you need to set up monitoring or diagnose an active issue.
 
 - Understand available metrics [Monitoring docs](https://skills.qdrant.tech/md/documentation/ops-monitoring/monitoring/)

--- a/skills/qdrant-performance-optimization/SKILL.md
+++ b/skills/qdrant-performance-optimization/SKILL.md
@@ -10,6 +10,20 @@ allowed-tools:
 
 # Qdrant Performance Optimization
 
+## Symptom to Sub-skill Map
+
+| Symptom | Sub-skill |
+|---|---|
+| Filtered queries much slower than unfiltered | [Search Speed Optimization](search-speed-optimization/SKILL.md) |
+| Low QPS, cannot handle the query load | [Search Speed Optimization](search-speed-optimization/SKILL.md) |
+| Individual queries take too long to return | [Search Speed Optimization](search-speed-optimization/SKILL.md) |
+| Index build or vector upload takes too long | [Indexing Performance Optimization](indexing-performance-optimization/SKILL.md) |
+| Collection stays yellow, optimizer runs for a long time | [Indexing Performance Optimization](indexing-performance-optimization/SKILL.md) |
+| Bulk upsert of vectors is slow | [Indexing Performance Optimization](indexing-performance-optimization/SKILL.md) |
+| RAM usage too high or out-of-memory crashes | [Memory Usage Optimization](memory-usage-optimization/SKILL.md) |
+| Want to fit a larger dataset on the same hardware | [Memory Usage Optimization](memory-usage-optimization/SKILL.md) |
+| Reducing cost by moving data to disk | [Memory Usage Optimization](memory-usage-optimization/SKILL.md) |
+
 There are different aspects of Qdrant performance, this document serves as a navigation hub for different aspects of performance optimization in Qdrant.
 
 

--- a/skills/qdrant-scaling/SKILL.md
+++ b/skills/qdrant-scaling/SKILL.md
@@ -9,6 +9,19 @@ allowed-tools:
 
 # Qdrant Scaling
 
+## Symptom to Sub-skill Map
+
+| Symptom | Sub-skill |
+|---|---|
+| Data does not fit on a single node | [Scaling Data Volume](scaling-data-volume/SKILL.md) |
+| Running out of disk or memory as the dataset grows | [Scaling Data Volume](scaling-data-volume/SKILL.md) |
+| Need to shard the collection across more nodes | [Scaling Data Volume](scaling-data-volume/SKILL.md) |
+| Cannot handle enough parallel queries | [Scaling for Query Throughput](scaling-qps/SKILL.md) |
+| Need higher QPS | [Scaling for Query Throughput](scaling-qps/SKILL.md) |
+| A single query is too slow | [Scaling for Query Latency](minimize-latency/SKILL.md) |
+| Need to cut the tail latency of individual requests | [Scaling for Query Latency](minimize-latency/SKILL.md) |
+| Queries return very large result sets and slow down | [Scaling for Query Volume](scaling-query-volume/SKILL.md) |
+
 First determine what you're scaling for:
 
 - data volume

--- a/skills/qdrant-search-quality/SKILL.md
+++ b/skills/qdrant-search-quality/SKILL.md
@@ -9,6 +9,20 @@ allowed-tools:
 
 # Qdrant Search Quality
 
+## Symptom to Sub-skill Map
+
+| Symptom | Sub-skill |
+|---|---|
+| Search results are bad or irrelevant | [Diagnosis and Tuning](diagnosis/SKILL.md) |
+| Low recall, expected results are missing | [Diagnosis and Tuning](diagnosis/SKILL.md) |
+| Low precision, too many wrong matches | [Diagnosis and Tuning](diagnosis/SKILL.md) |
+| Quality dropped after quantization or a model change | [Diagnosis and Tuning](diagnosis/SKILL.md) |
+| Not sure if the model, the data, or Qdrant is at fault | [Diagnosis and Tuning](diagnosis/SKILL.md) |
+| Want to measure recall or build a golden set | [Diagnosis and Tuning](diagnosis/SKILL.md) |
+| Need to combine keyword and semantic search | [Search Strategies](search-strategies/SKILL.md) |
+| Want hybrid search, reranking, or score fusion | [Search Strategies](search-strategies/SKILL.md) |
+| Improving results with relevance feedback or recommendations | [Search Strategies](search-strategies/SKILL.md) |
+
 First determine whether the problem is the embedding model, Qdrant configuration, or the query strategy. Most quality issues come from the model or data, not from Qdrant itself. If search quality is low, inspect how chunks are being passed to Qdrant before tuning any parameters. Splitting mid-sentence can drop quality 30-40%.
 
 - Start by testing with exact search to isolate the problem [Search API](https://skills.qdrant.tech/md/documentation/search/search/?s=search-api)


### PR DESCRIPTION
## What

Adds a scannable "Symptom to Sub-skill Map" table at the top of each Qdrant navigation hub, so an agent can route straight to the correct leaf skill instead of inferring it from topic names and risking a wrong-branch fetch.

Covers four hubs:

- `qdrant-performance-optimization`
- `qdrant-search-quality`
- `qdrant-scaling`
- `qdrant-monitoring`

## Details

Following the requirements in #76 and the example from @szabosteve:

- The table appears before any prose in each hub.
- Symptoms are written in user-facing language, not internal Qdrant terminology.
- Multiple phrasings are covered per sub-skill where the same problem can be described differently.
- Links point to the sub-skill `SKILL.md` files using the repo's relative-link convention. The build step (`scripts/make_links_absolute.py`) rewrites these to absolute `skills.qdrant.tech` URLs on deploy, matching every other link in the repo.

`scripts/validate_skills.py` passes cleanly on all four edited files with no new warnings.

Closes #76.
