### PR TITLE
Update skills for version 1.19

### DIFF
--- a/skills/qdrant-monitoring/debugging/SKILL.md
+++ b/skills/qdrant-monitoring/debugging/SKILL.md
@@ -29,7 +29,7 @@ Use when: memory exceeds expectations, node crashes with OOM, or memory keeps gr
 - If resident memory (RSSAnon) exceeds 80% of total RAM, investigate
 - Check `/telemetry` for per-collection breakdown of point counts and vector configurations
 - Estimate expected memory: `num_vectors * dimensions * 4 bytes * 1.5` for vectors, plus payload and index overhead [Capacity planning](https://skills.qdrant.tech/md/documentation/capacity-planning/)
-- Common causes of unexpected growth: quantized vectors with `always_ram=true`, too many payload indexes, large `max_segment_size` during optimization
+- Common causes of unexpected growth: quantized vectors pinned in RAM (`memory: pinned` on Qdrant 1.19 or newer, `always_ram: true` on 1.18 or older), too many payload indexes, large `max_segment_size` during optimization
 
 
 ## Queries Are Slow

--- a/skills/qdrant-performance-optimization/memory-usage-optimization/SKILL.md
+++ b/skills/qdrant-performance-optimization/memory-usage-optimization/SKILL.md
@@ -7,9 +7,9 @@ description: "Diagnoses and reduces Qdrant memory usage. Use when someone report
 
 Qdrant operates with two types of memory:
 
-- Resident memory (aka RSSAnon) - memory used for internal data structures like the ID tracker, plus components that must stay in RAM, such as quantized vectors when `always_ram=true` and payload indexes.
+- Resident memory (aka RSSAnon) - memory used for internal data structures like the ID tracker, plus components that stay fully in RAM. On Qdrant 1.19 or newer this is controlled per-component with `memory: pinned` (e.g. quantized vectors, payload indexes); on 1.18 or older the equivalent is `always_ram: true`.
 
-- OS page cache - memory used for caching disk reads, which can be released when needed. Original vectors are normally stored in page cache, so the service won't crash if RAM is full, but performance may degrade.
+- OS page cache - memory used for caching disk reads, which can be released when needed. Original vectors are normally stored in page cache, so the service won't crash if RAM is full, but performance may degrade. On Qdrant 1.19 or newer this corresponds to `memory: cached` (pre-warmed into page cache at startup) or `memory: cold` (lazy disk reads, not pre-warmed); on 1.18 or older it's controlled via the `on_disk` boolean on vectors, HNSW config, sparse vector index, and payload index. See [Memory Tiers docs](https://skills.qdrant.tech/md/documentation/ops-configuration/memory-tiers/) (available on 1.19+).
 
 It is normal for the OS page cache to occupy all available RAM, but if resident memory is above 80% of total RAM, it is a sign of a problem.
 
@@ -36,7 +36,7 @@ The larger `max_segment_size` is, the more headroom is needed.
 
 ### When to put HNSW index on disk
 
-Putting frequently used components (such as HNSW index) on disk might cause significant performance degradation.
+Putting frequently used components (such as HNSW index) on disk might cause significant performance degradation. On Qdrant 1.19 or newer this is set with `memory: cold` in `hnsw_config`; on 1.18 or older with `hnsw_config.on_disk: true`.
 There are some scenarios, however, when it can be a good option:
 
 - Deployments with low latency disks - local NVMe or similar.
@@ -51,7 +51,7 @@ Here are the main techniques to achieve that:
 
 - Use quantization to store only compressed vectors in RAM [Quantization docs](https://skills.qdrant.tech/md/documentation/manage-data/quantization/)
 
-- Use float16 or int8 datatypes to reduce memory usage of vectors by 2x or 4x respectively, with some tradeoff in precision. Read more about vector datatypes in [documentation](https://skills.qdrant.tech/md/documentation/manage-data/vectors/?s=datatypes)
+- Use float16 or int8 datatypes to reduce memory usage of vectors by 2x or 4x respectively, with some tradeoff in precision. On Qdrant 1.19 or newer, the `turbo4` datatype (TurboQuant-based, 4 bits/dimension, dense vectors only) reduces memory by ~8x, and can be paired with 1-bit quantization for cheaper rescoring than pairing 1-bit quantization with full-precision vectors. Read more about vector datatypes in [documentation](https://skills.qdrant.tech/md/documentation/manage-data/vectors/?s=datatypes)
 
 - Leverage Matryoshka Representation Learning (MRL) to store only small vectors in RAM while keeping large vectors on disk. Examples of how to use MRL with Qdrant Cloud inference: [MRL docs](https://skills.qdrant.tech/md/documentation/inference/matryoshka-models/?s=reduce-vector-dimensionality-with-matryoshka-models)
 
@@ -62,6 +62,6 @@ Here are the main techniques to achieve that:
 - For low RAM environments, consider `async_scorer` config, which enables support of `io_uring` for parallel disk access, which can significantly improve performance of on-disk storage. Read more about `async_scorer` in [the article](https://skills.qdrant.tech/md/articles/io_uring/) (only available on Linux with kernel 5.11+)
 
 - Consider storing Sparse Vectors and text payload on disk, as they are usually more disk-friendly than dense vectors.
-- Configure payload indexes to be stored on disk [docs](https://skills.qdrant.tech/md/documentation/manage-data/indexing/?s=on-disk-payload-index)
-- Configure sparse vectors to be stored on disk [docs](https://skills.qdrant.tech/md/documentation/manage-data/indexing/?s=sparse-vector-index)
+- Configure payload indexes to be stored on disk: `memory: cold` on Qdrant 1.19 or newer, `on_disk: true` on 1.18 or older [docs](https://skills.qdrant.tech/md/documentation/manage-data/indexing/?s=on-disk-payload-index)
+- Configure sparse vectors to be stored on disk: `memory: cold` on the sparse vector index on Qdrant 1.19 or newer (defaults to `pinned`), `on_disk: true` on 1.18 or older [docs](https://skills.qdrant.tech/md/documentation/manage-data/indexing/?s=sparse-vector-index)
 

--- a/skills/qdrant-performance-optimization/search-speed-optimization/SKILL.md
+++ b/skills/qdrant-performance-optimization/search-speed-optimization/SKILL.md
@@ -70,7 +70,7 @@ Learn more [here](https://skills.qdrant.tech/md/documentation/search/low-latency
 
 ## What NOT to Do
 
-- Set `always_ram=false` on quantization (disk thrashing on every search)
+- Set quantization to not stay in RAM (disk thrashing on every search): avoid `memory: cold`/`cached` on Qdrant 1.19 or newer, `always_ram: false` on 1.18 or older
 - Put HNSW on disk for latency-sensitive production (only for cold storage)
 - Increase segment count for throughput (opposite: fewer = better)
 - Create payload indexes on every field (wastes memory)

--- a/skills/qdrant-scaling/minimize-latency/SKILL.md
+++ b/skills/qdrant-scaling/minimize-latency/SKILL.md
@@ -12,7 +12,7 @@ Low latency optimization is aimed at utilising maximum resource saturation for a
 ## Performance Tuning for Lower Latency
 
 - Increase segment count to match CPU cores (`default_segment_number: 16`) [Minimizing latency](https://skills.qdrant.tech/md/documentation/ops-optimization/optimize/?s=minimizing-latency)
-- Keep quantized vectors and HNSW in RAM (`always_ram=true`)
+- Keep quantized vectors and HNSW in RAM: `memory: pinned` on Qdrant 1.19 or newer, `always_ram: true` on 1.18 or older
 - Reduce `hnsw_ef` at query time (trade recall for speed) [Search params](https://skills.qdrant.tech/md/documentation/ops-optimization/optimize/?s=fine-tuning-search-parameters)
 - Use local NVMe, avoid network-attached storage
 
@@ -22,7 +22,7 @@ RAM is the most critical resource for latency. If working set exceeds available 
 
 - Vertical scale RAM first. Critical if working set >80%.
 - Use quantization: scalar (4x reduction) or binary (16x reduction) [Quantization](https://skills.qdrant.tech/md/documentation/manage-data/quantization/)
-- Move payload indexes to disk if filtering is infrequent [On-disk payload index](https://skills.qdrant.tech/md/documentation/manage-data/indexing/?s=on-disk-payload-index)
+- Move payload indexes to disk if filtering is infrequent: `memory: cold` on Qdrant 1.19 or newer, `on_disk: true` on 1.18 or older [On-disk payload index](https://skills.qdrant.tech/md/documentation/manage-data/indexing/?s=on-disk-payload-index)
 - Set `optimizer_cpu_budget` to limit background optimization CPUs
 - Schedule indexing: set high `indexing_threshold` during peak hours
 

--- a/skills/qdrant-scaling/scaling-data-volume/sliding-time-window/SKILL.md
+++ b/skills/qdrant-scaling/scaling-data-volume/sliding-time-window/SKILL.md
@@ -56,7 +56,7 @@ Use when: data arrives continuously without clear time boundaries, or you want t
 Use when: recent data needs fast in-RAM search, older data should remain searchable at lower performance.
 
 - **Shard rotation:** place current shard key on fast-storage nodes, move older shard keys to cheaper nodes via shard placement. All queries still go through a single collection.
-- **Collection rotation:** keep current collection in RAM (`always_ram: true`), move older collections to mmap/on-disk vectors. [Quantization](https://skills.qdrant.tech/md/documentation/manage-data/quantization/)
+- **Collection rotation:** keep current collection in RAM (`memory: pinned` on Qdrant 1.19 or newer, `always_ram: true` on 1.18 or older), move older collections to mmap/on-disk vectors (`memory: cold` on 1.19 or newer, `on_disk: true` on 1.18 or older). [Quantization](https://skills.qdrant.tech/md/documentation/manage-data/quantization/)
 
 
 ## What NOT to Do

--- a/skills/qdrant-scaling/scaling-data-volume/vertical-scaling/SKILL.md
+++ b/skills/qdrant-scaling/scaling-data-volume/vertical-scaling/SKILL.md
@@ -41,6 +41,7 @@ RAM is the most critical resource for Qdrant performance. Use these guidelines t
 - Exact estimation of RAM usage is difficult; use this simple approximate formula: `num_vectors * dimensions * 4 bytes * 1.5` for full-precision vectors in RAM
 - With scalar quantization: divide by 4 (INT8 reduces each float32 to 1 byte) [Quantization](https://skills.qdrant.tech/md/documentation/manage-data/quantization/)
 - With binary quantization: divide by 32 [Binary quantization](https://skills.qdrant.tech/md/documentation/manage-data/quantization/?s=binary-quantization)
+- On Qdrant 1.19 or newer, the `turbo4` datatype (dense vectors only) divides by ~8 on its own, without needing separate quantization [Vector datatypes](https://skills.qdrant.tech/md/documentation/manage-data/vectors/?s=datatypes)
 - Add overhead for HNSW index (~20-30% of vector data), payload indexes, and WAL
 - Reserve 20% headroom for optimizer operations and OS cache
 - Monitor actual usage via Grafana/Prometheus before and after resizing [Monitoring](../../../qdrant-monitoring/SKILL.md)

--- a/skills/qdrant-scaling/scaling-qps/SKILL.md
+++ b/skills/qdrant-scaling/scaling-qps/SKILL.md
@@ -14,7 +14,7 @@ High throughput favors fewer, larger segments so each query touches less overhea
 ## Performance Tuning for Higher RPS
 
 - Use fewer, larger segments (`default_segment_number: 2`) [Maximizing throughput](https://skills.qdrant.tech/md/documentation/ops-optimization/optimize/?s=maximizing-throughput)
-- Enable quantization with `always_ram=true` to reduce disk IO [Quantization](https://skills.qdrant.tech/md/documentation/manage-data/quantization/)
+- Enable quantization pinned in RAM to reduce disk IO: `memory: pinned` on Qdrant 1.19 or newer, `always_ram: true` on 1.18 or older [Quantization](https://skills.qdrant.tech/md/documentation/manage-data/quantization/)
 - Use batch search API to amortize overhead [Batch search](https://skills.qdrant.tech/md/documentation/search/search/?s=batch-search-api)
 
 ## Minimize impact of Update Workloads

--- a/skills/qdrant-search-quality/search-strategies/hybrid-search/SKILL.md
+++ b/skills/qdrant-search-quality/search-strategies/hybrid-search/SKILL.md
@@ -29,7 +29,7 @@ Use when: different tenants share one collection and you need to understand hybr
 
 If user wants to isolate/share hybrid search pipelines between tenants, consider that:
 
-- Indexes (sparse, payload and dense) and [IDF modifier](https://skills.qdrant.tech/md/documentation/manage-data/indexing/?s=idf-modifier) for sparse vectors are computed independently **per shard**, not per **tenant**.
+- Indexes (sparse, payload and dense) and [IDF modifier](https://skills.qdrant.tech/md/documentation/manage-data/indexing/?s=idf-modifier) for sparse vectors are computed independently **per shard**, not per **tenant**, by default — payload-based tenant partitioning alone does not isolate IDF statistics. On Qdrant 1.19 or newer, the `idf` search param can scope IDF statistics to a payload-filtered corpus (requires a payload index on the filtered field), giving each tenant properly isolated BM25 scoring instead of shard-wide statistics.
 - Prefetch runs independently per shard to retrieve #limit results, so for collection-level prefetches if collection has several shards, Qdrant will always prefetch under the hood #limit * #shard results. Final results are merged based on scores.
 - In nested prefetches (deeper than 1 level), methods described in "Combining Searches" might be done on a shard level first, then per-shards results once again will be merged based on scores.
 

--- a/skills/qdrant-search-quality/search-strategies/hybrid-search/search-types/SKILL.md
+++ b/skills/qdrant-search-quality/search-strategies/hybrid-search/search-types/SKILL.md
@@ -34,7 +34,7 @@ What to remember when using sparse vectors for lexical search:
 What to remember when using Qdrant BM25 and miniCOIL (based on BM25):
 - `avg_len` in formula is not computed server-side, it is a user responsibility and passed as a parameter. Calibrate per field — defaults assume document-length text; short fields (titles, tags) need a much smaller value or BM25 scoring is skewed (`avg_len=256` against a 10-word title overweights term frequency).
 - BM25 might be not good for small chunks of text, as BM25 algorithm was initially created for search on long documents; consider adjusting document statistics in sparse vectors (TF & IDF, k, b).
-- Qdrant BM25 vectors are configured per language, so consider customizing stop words, stemming & tokenization when users documents mix several languages or carefully configure vectors per point when they are monolingual.
+- Qdrant BM25 vectors are configured per language, so consider customizing stop words, stemming & tokenization when users documents mix several languages or carefully configure vectors per point when they are monolingual. To disable text processing entirely for language-neutral content: on Qdrant 1.19 or newer, use `stemmer: {"type": "none"}` plus an empty `stopwords` set explicitly (both are disabled by default); on 1.18 or older, use `language: none` (deprecated as of 1.19).
 
 More on [Sparse Vectors for Text Search](https://skills.qdrant.tech/md/course/essentials/day-3/sparse-retrieval-demo/)
 


### PR DESCRIPTION
## What this PR does

Updates the skills for version 1.19: 

- **Memory tiers (1.19+)**: `memory-usage-optimization`, `vertical-scaling`, `minimize-latency`, `monitoring/debugging`, `scaling-qps`, `sliding-time-window`, and `search-speed-optimization` now phrase RAM/disk placement version-conditionally (`memory: pinned/cached/cold` on 1.19+, `always_ram`/`on_disk` on 1.18 or older), plus the `turbo4` datatype note.
- **BM25/IDF**: `hybrid-search` now notes the 1.19+ `idf` param for per-tenant IDF isolation; `hybrid-search/search-types` notes the 1.19+ explicit `stemmer`/`stopwords` config replacing deprecated `language: none`.

## Type

<!-- check one -->
- [ ] new skill
- [x] skill improvement
- [ ] bug fix
- [ ] repo hygiene

## Checklist

<!-- for new/improved skills, check all that apply -->
- [ ] `python3 scripts/validate_skills.py` passes
- [ ] skill answers "when?" or "why?", not "how?"
- [ ] skill navigates to docs, does not duplicate or replace them
- [ ] description has `Use when` with 5+ trigger phrases
- [ ] leaf skills omit `allowed-tools`, hub skills declare them
- [ ] ends with `## What NOT to Do` section
- [ ] no code blocks except minimal snippets when absolutely required (reference the docs instead)
- [ ] all doc links go to `skills.qdrant.tech/md/documentation/`
- [ ] tested with a realistic prompt (paste below or link to eval)

## Test prompt

<!-- paste a realistic user question you tested this skill against, and summarize what the agent responded. skip for non-skill PRs. -->

```
<prompt here>
```
