### PR TITLE
Add a skill-lift scoring framework

### DIFF
--- a/SCORING.md
+++ b/SCORING.md
@@ -1,0 +1,470 @@
+# Weekly Skill Scoring
+
+This describes how the harness turns test prompts into a weekly score that tells
+us whether a skill actually helps a model, and by how much.
+
+## What We Measure
+
+We do not care about a model's absolute score. We care about **skill lift**: how
+much better a model answers *with* the skill installed than *without* it.
+
+```text
+lift(model) = mean_score(model, with-skill) − mean_score(model, no-skill)
+```
+
+A skill that earns its keep produces positive lift. Lift is reported **per
+model**, because a good skill typically lifts a smaller model (Haiku) far more
+than a larger one (Sonnet) that already knows much of the material from
+pretraining. A skill with near-zero lift on both models is a candidate for
+rewriting or retirement.
+
+Both arms have web search, so lift is measured against a baseline that can reach
+`docs.qdrant.tech` and `skills.qdrant.tech`, not against a bare model. That is
+the honest counterfactual for a real user, and it sets a harder bar: expect
+smaller lift numbers than a no-web baseline would produce.
+
+Low lift therefore has two readings, and they are worth separating before anyone rewrites a skill.
+Either the skill is weak, or the public docs already cover that ground well, in which case merging or retiring the skill is the right call rather than expanding it.
+
+## The Evaluation Matrix
+
+Every prompt is run across a 2×2 matrix, `k` times per cell:
+
+|              | no skill | with skill |
+|--------------|----------|------------|
+| **Sonnet**   | baseline | treatment  |
+| **Haiku**    | baseline | treatment  |
+
+- **Prompts:** every `*.json` under `evals/test-prompts/` **except** those with
+  the `discord-` prefix (26 prompts at time of writing).
+- **`k` (repetitions):** default **2**. Model output is stochastic; one run per
+  cell is too noisy to trust a rubric item that can flip on rerun. Two reps is a
+  deliberate cost-first setting: it still exposes an unstable item (the two reps
+  disagree) and a min–max spread, but gives no generation-level majority vote and
+  only a weak variance estimate. It's planned to raise it once the pipeline is
+  trusted and the first weeks of data justify the extra spend. Scores are averaged
+  over the `k` reps and we also report spread.
+- **Volume:** `26 prompts × 2 models × 2 conditions × 2 reps = 208` runs/week.
+
+The `with skill` arm **explicitly installs** the skill into the container — its
+`SKILL.md` and files are placed under `~/.claude/skills/<name>/` before the run,
+so Claude Code registers it at startup. The `no skill` arm runs the same prompt
+in the same fresh container with nothing installed.
+
+Two things about the skill are recorded per run:
+
+- **Availability** (a hard check). The installed skill must appear in the run's
+  `init` skill list. Because install is explicit rather than best-effort, an
+  absent skill is a real harness failure — a broken install path or image drift,
+  not a model choice — so such a run is **invalid**, excluded from scoring, and
+  reported. This is a cheap tripwire, not a likely event.
+- **Activation** (recorded, never gated). *How* the model reached the skill:
+  `skill_tool` (invoked via progressive disclosure), `file_read` (read the
+  installed `SKILL.md` directly), `web_fetch` (pulled the published copy from
+  `skills.qdrant.tech` instead), or `none`. Because install is guaranteed, a
+  `none` is unambiguous: the skill was present and the model did not reach for it.
+  That is a **trigger miss** — a real signal about the skill's description, not a
+  harness bug — so the run stays in scoring and the miss is flagged. Persistent
+  `none` on a skill is a triggering problem to fix in that skill, not a run to
+  throw away. Recording the source also matters because `web_fetch` means the
+  run's lift came from the published copy, not the local `SKILL.md` under test.
+
+### Tool Parity Across Arms
+
+Both arms get an **identical toolset with web search enabled**, and nothing is
+blocked. Any asymmetry here contaminates lift: a baseline without web access
+inflates it, and a baseline with tools the treatment lacks deflates it. Blocking
+a domain would create a third kind of asymmetry, between the harness and the
+user, and a score measured under conditions no user runs in is not the score we
+want to track.
+
+This interacts with the `dontAsk` mode scored runs use (see Weekly Run). On its
+own `dontAsk` denies exactly the tools scoring depends on — the `Skill` tool and
+web search/fetch — which would silently defeat both skill activation and the
+web-enabled baseline. So both arms are run under `dontAsk` **with an identical
+allow-list**, `Skill,WebSearch,WebFetch,Read,Grep,Glob,Bash`, applied the same
+way to no-skill and with-skill. That is how "identical toolset, web enabled,
+nothing relevant blocked" is delivered while still keeping `dontAsk`'s guarantee
+that a run cannot wander into edits or other out-of-scope actions. The allow-list
+is a measurement parameter: changing it changes what lift means, so it is pinned
+alongside the CLI version and model snapshots. (A denied tool call still surfaces
+in a run's `permission_denials`; the extractor nets those out so a denied attempt
+never counts as activation or a fetch.)
+
+Leaving `skills.qdrant.tech` reachable has consequences worth stating plainly,
+because they change what lift means:
+
+- The `with-skill` arm may read the published copy of a skill as well as the
+  local files under test. A scored run is therefore not a clean measurement of
+  the local `SKILL.md` alone. Keep the local files and the published site in sync,
+  and record the skills commit in the manifest, so that when the two disagree you
+  can see it rather than infer it.
+- The `no-skill` arm can also find `skills.qdrant.tech` and effectively serve
+  itself the skill. That is exactly what a user could do, so it belongs in the
+  baseline, but it means lift measures "skill installed" against "skill
+  discoverable on the open web". That is a harder bar than a bare model, and
+  near-zero lift on a prompt may mean the skill is easy to find rather than
+  unhelpful.
+- Fetched URLs are recorded per run, and this is what makes the previous point
+  tractable. Segment baseline runs by whether they reached `skills.qdrant.tech`:
+  if the same prompt hits it in one rep and not the next, that alone moves the
+  score, and the URL log is how you attribute the variance instead of chasing it.
+  `docs.qdrant.tech` is an input to both arms for the same reason, so a docs
+  change can move scores with no skill change.
+
+### Prompt Sets
+
+The `discord-` prefixed prompts are **reserved, not excluded**. They are real
+user messages, and they are the only prompts we have that nobody wrote with a
+skill in front of them.
+
+Their first role is as a held-out set for measuring generalization: once we start
+editing skills in response to eval failures, the scored prompts stop being able
+to tell real improvement from tuning to the test, and an unoptimized set is the
+only way to recover that signal. They have other likely uses too, including
+paraphrase robustness checks, trigger precision tests, and a source of
+replacements as scored prompts saturate.
+
+None of that works if they get folded into the scored set first. The point at which we need them is the first skill edit motivated by an eval result, not the first run.
+
+## Rubric Format
+
+Each prompt file carries a `prompt` and a `rubric` array. Every rubric item has
+a `type` and a `text`:
+
+```json
+{
+  "prompt": "...user question...",
+  "rubric": [
+    { "type": "must",  "text": "Recommends RRF as the default because score scales are incomparable" },
+    { "type": "bonus", "text": "Mentions custom fusion via a formula query" },
+    { "type": "avoid", "text": "Picks a fusion method without running comparative experiments" }
+  ]
+}
+```
+
+- **`must`** — the answer is expected to contain this. Missing musts are the
+  primary quality failure. (Three to five per prompt.)
+- **`bonus`** — a nice-to-have that shows depth. Never required. (One to three
+  per prompt.)
+- **`avoid`** — the answer must *not* do this. A violation is an active harm (a
+  hallucinated config key, or recommending an expensive approach without the
+  cheap alternative), not a mere omission. (One to three per prompt.)
+
+## Grading: The Judge
+
+Grading is done by an **LLM judge (Opus)**, one verdict per rubric item.
+
+The judge runs under three rules:
+
+1. **Blind.** The judge sees only the prompt, the final answer, and the rubric.
+   It does **not** see the model name or whether the skill was installed,
+   otherwise it anchors. That metadata is stripped before grading and order is shuffled.
+2. **Final answer only.** The judge grades only the last assistant message, not the full
+   transcript. Thinking and tool-call noise are not the deliverable. The
+   transcript is still captured, because the availability check, the activation
+   signal, and the URL log are derived from it.
+3. **Evidence required.** For every "met" or "violated" verdict the judge must
+   quote the supporting span from the answer. Requiring a quote sharply reduces
+   hallucinated "yes, it covered that" grades.
+
+Two reliability additions for the items that matter most:
+
+- **`must` items:** verdicts are **binary**, `met` or `missing`, with no partial
+  credit. Partial is where judge leniency drifts, and it makes week-over-week
+  diffs unreadable.
+- **`avoid` items:** adversarial framing. The judge actively hunts for the violation
+  and marks `clean` only if it genuinely cannot find one. Misses here are expensive.
+
+**Scoring runs a single judge sample per item.** The cell score aggregates
+roughly 200 items across two generation reps, so a single judge's per-item jitter
+is already heavily diluted in the headline lift number; multi-sample voting mostly
+buys per-item stability and a rubric-ambiguity signal, not a better aggregate, and
+musts are the largest judging cost.
+
+That single-sample choice is backed by a **self-agreement** calibration we ran,
+not just assumed. The protocol: grade the same answer three times and count how
+often a single verdict flips.
+
+We ran it on 2026-07-30 against the first available scored transcript —
+`qdrant-minimize-latency`, no-skill arm (3 must / 2 bonus / 2 avoid) —
+graded three times by the Opus judge against quoted evidence. All 7 items came
+back unanimous across the three samples, including 3/3 binary musts,
+clearing the ≥95%-on-musts bar. On that basis one vote stands. This is an initial
+result on a single transcript; we re-run the same calibration across a handful of
+transcripts once the weekly matrix has produced them, and escalate if it turns up
+noise — preferably to two samples with a third only to break a disagreement (≈2×
+cost, not 3×), which resolves to a majority and yields the `contested` flag for
+free. An item whose two samples disagree is flagged `contested` in `scores.csv`;
+items that come back contested week after week are worded ambiguously rather than
+hard, and that flag is the rubric-quality backlog. We revisit the vote count once
+four weeks of data exist, alongside the threshold decisions.
+
+### Per-Item Credit
+
+| type    | verdicts → credit                                  |
+|---------|----------------------------------------------------|
+| `must`  | met `1.0` · missing `0.0`                           |
+| `bonus` | met `1.0` · absent `0.0`                            |
+| `avoid` | violated `1.0` · clean `0.0` (a violation *count*)  |
+
+Note the inverted polarity: for `avoid`, `1.0` is bad. `scores.csv` therefore
+carries both the raw `credit` and a signed `contribution` column, so that summing
+across item types cannot silently produce nonsense.
+
+## Scoring Math
+
+We report **three separate per-prompt metrics** rather than collapsing early,
+because they answer different questions and averaging them hides the important
+one:
+
+```text
+must_coverage    = Σ must_credit  / n_must       ∈ [0,1]   # correctness / completeness (primary)
+bonus_rate       = Σ bonus_credit / n_bonus      ∈ [0,1]   # depth
+avoid_violations = Σ avoid_violated              (count)   # safety / harm
+```
+
+For ranking and dashboards we also compute a single **composite**, with musts
+dominant, bonus as a small bump that can never rescue missing musts, and avoid as
+a real penalty:
+
+```text
+composite = clamp( must_coverage
+                   + 0.10 * bonus_rate
+                   − 0.25 * avoid_violations,
+                   0, 1 )
+```
+
+The composite is for trend lines and ranking only. Because it clamps at zero, it
+stops distinguishing bad answers from worse ones past three violations, which is
+one reason `avoid_violations` is also reported raw and checked separately.
+
+### Aggregation
+
+There is exactly one prompt per skill, so a prompt and a skill are the same unit
+of measurement here. We aggregate in three levels, averaging at each one rather than
+pooling all items:
+
+```text
+item        → 0/1 from the judge
+prompt×rep  → the three metrics, plus composite
+prompt      → mean over its k reps (report min–max as a stability signal)
+cell        → mean over all prompts                 (flat, macro)
+```
+
+The cell score is a **flat per-prompt macro-average**: every prompt (and so every
+skill) counts exactly once, no matter how long its rubric is.
+
+Averaging prompts rather than pooling their items keeps rubric length out of the
+score. Pooling makes a prompt with eight musts count nearly three times a prompt
+with three, which reflects how much someone wrote, not how much the prompt
+matters.
+
+Flat per-prompt weighting is what gives every skill an equal say. Because each
+skill has one prompt, one prompt regressing moves the headline by the same amount
+regardless of which skill it belongs to, so no skill can dominate or hide. That is
+the question the scorecard answers: "is every skill healthy".
+
+### Reading Week-Over-Week Movement
+
+The `k` reps only capture generation variance — they say nothing about the fact
+that 26 prompts are a small sample of all possible Qdrant questions, and rubric
+items cluster (a skill that fails to trigger loses all its musts at once). So a
+cell score is noisier than its item count suggests.
+
+Two quantities on the scorecard turn that caution into a rule, and they measure
+different noise:
+
+- **Within-week SE** (shown every week from week one as `lift ± SE`, with a
+  `95% CI ≠ 0?` flag). This is the paired per-prompt standard error,
+  `stdev(dᵢ)/√n` over the scored prompts, where `dᵢ` is a prompt's
+  (`with_skill_value`-`no_skill_value`) lift. It answers the single-week question:
+  is a skill's lift distinguishable from zero at all, or is it just which questions
+  we happened to ask? A `no` flag means don't act on that lift yet. It captures
+  sampling noise only, not drift.
+- **Between-week σ** (the empirical spread of prior weeks' lift). This captures
+  what the within-week SE cannot measure: drift in the model build, docs, or judge
+  between runs. It needs prior weeks to exist, so the week-over-week delta reads
+  `Will be computed after four runs.` until then.
+
+The practical rule combines them: **don't act on a week-over-week movement smaller
+than `max(t·SE_Δ, between-week σ)`** — a real move must clear both this week's
+sampling error (`SE_Δ = √(SE_now² + SE_prev²)`) and the observed drift. Until four
+weeks of data exist, lean on the within-week SE and treat small deltas as noise by
+default, investigating only large or sustained moves — a sustained trend is not the
+same as random bounce, and the threshold is built for the latter.
+
+## Thresholds And Gating
+
+The framework is deliberately **ungated for now**, with one exception. Setting
+thresholds before we know the distribution produces either an ungrounded gate or
+constant false alarms, so the first weeks are for observation.
+
+One thing is a hard check from week one, because it needs no baseline data to
+interpret:
+
+- The availability check on every `with-skill` run: the installed skill must
+  appear in the run's `init` skill list, or the run is invalid and excluded.
+  Activation (`skill_tool`/`file_read`/`web_fetch`/`none`) is recorded but never
+  gated — a `none` is a trigger miss to surface, not a failure to exclude.
+
+`avoid` violations, including fabricated identifiers, are **penalized but not
+gated**. A fabrication is the most damaging thing an answer can do, so gating on
+it is tempting, but we have no trustworthy way to detect it yet: unlike a rubric
+item, the judge is not handed the text to check against and would have to know
+what is real in Qdrant, so a fabrication gate would fail good runs on false flags.
+A gate we cannot trust is worse than none, so fabrications ride the graded `−0.25`
+avoid penalty until a reliable detector exists. Revisit this when one does.
+
+Revisit after four weeks and set thresholds on `must_coverage` and lift from the
+variance we actually observe. Until then the scorecard is a report, so record that
+deferral here with its date rather than leaving the absence of gates implicit.
+
+## Weekly Run
+
+```bash
+# 0. Preflight: confirm every prompt's skill_url resolves to a real skill on disk.
+scripts/scoring/validate-prompts.sh
+
+# 1. Generate: run the full 2×2×k matrix over the scored (non-discord) prompts.
+#    Writes runs + a base manifest to evals/weekly/<UTC-date>/.
+scripts/scoring/run-eval-matrix.sh --models sonnet,haiku --reps 2
+
+# 2. Extract signals: enrich the manifest (availability, activation, cost, budget).
+scripts/scoring/extract-run-signals.sh --out-dir evals/weekly/<date>
+
+# 3. Judge: grade every valid run's final answer against its rubric (Opus, blind).
+scripts/scoring/judge-runs.sh --out-dir evals/weekly/<date>
+
+# 4. Summarize: aggregate to the per-model lift + efficiency scorecard.
+scripts/scoring/summarize-eval.py evals/weekly/<date>
+```
+
+Scored runs use `--permission-mode dontAsk` (the run cannot wander off-task; any
+out-of-scope tool call is denied and the run continues) rather than
+`bypassPermissions`, together with a shared tool allow-list
+(`Skill,WebSearch,WebFetch,Read,Grep,Glob,Bash`) so the tools scoring needs are
+available in both arms — refer to Tool Parity Across Arms for why this pairing is
+required, not optional.
+
+Each run also carries a per-run spend cap (`--max-budget-usd`, default **$2**), a
+runaway backstop set well above the normal per-run cost (cents), not a routine
+limiter. A run that hits it stops truncated; it is marked `budget_hit`, excluded
+from scoring and the cost mean, and reported as budget-capped — because a
+truncated answer would grade unfairly low and its cost is a floor, not the real
+figure. Keep the cap high enough that legitimate runs never hit it; if several do,
+raise it rather than let clipped runs contaminate the numbers.
+
+Confirm the skill-install step and `--permission-mode dontAsk` work on the pinned
+CLI version before the first scored run — verify an installed skill actually shows
+up in the `init` skill list, **and that the allow-listed tools are not denied**
+(check a run's `permission_denials` is empty for `Skill`/`WebFetch`/`WebSearch`) —
+and pin that version, the allow-list, the model snapshot strings, and the skills
+commit in the manifest. An install that silently no-ops, or a flag the CLI ignores,
+fails as zero lift rather than as an error.
+
+## Outputs
+
+For a plain-language glossary of every number in `scorecard.md` and `scores.csv`
+— what each field means, in a sentence or two — see
+[`interpret-stats.md`](interpret-stats.md).
+
+Under `evals/weekly/<date>/`:
+
+- **`manifest.csv`** — one row per run: `prompt, skill_family, skill_leaf, model,
+  condition, rep, run_id, exit_code, skills_sha, timestamp, skill_available,
+  skill_activation, reached_leaf, fetched_site, fetched_count, model_snapshot,
+  cli_version, total_cost_usd, num_turns, result_subtype, budget_hit`. The runner
+  writes the first ten (base) columns; `extract-run-signals.sh` derives the rest
+  from each transcript. `budget_hit` is `1` when the run hit the per-run spend cap
+  (`result_subtype = error_max_budget_usd`): such a run is truncated, so it is
+  excluded from scoring and the cost mean and reported as budget-capped.
+  `skill_family` is the installed/availability unit and `skill_leaf` the prompt's
+  target SKILL.md (so `reached_leaf` records whether progressive disclosure
+  actually fired); `fetched_site`/`fetched_count` replace a raw URL list and count
+  reaches to `skills.qdrant.tech`, net of denied attempts; `total_cost_usd` and
+  `num_turns` are the per-run efficiency signals, straight from the result event.
+- **`scores.csv`** — one row per graded rubric item: `prompt, skill, model,
+  condition, rep, item_type, item_text, verdict, credit, contribution,
+  contested, evidence_quote`. This is the raw grade ledger; everything else is
+  derived from it.
+- **`scorecard.md`** — the human-facing weekly report:
+  - top line: **lift per model** (Sonnet, Haiku), the must-coverage lift shown as
+    **`lift ± SE`** with a **95% CI ≠ 0?** flag, each paired with a **cost delta**
+    and **turns delta** (with-skill minus no-skill). The `± SE` is one *within-week*
+    standard error of the paired per-prompt must-coverage lift (`stdev(dᵢ)/√n`,
+    `dᵢ = must_cov_with(i) − must_cov_no(i)`): it measures this week's sampling
+    uncertainty — the finite prompt set plus folded-in rep/judge noise — and
+    **not** between-week drift. The flag reports whether the `t·SE` 95% interval
+    excludes zero; `no` means the lift is not distinguishable from zero this week,
+    so don't act on it. Available from week one (needs no history). Alongside it,
+    **`Δbonus`** and **`Δavoid`** (with-skill minus no-skill) appear only when
+    nonzero. The blended `composite` is deliberately **not** lifted in the headline:
+    differencing a clamped 0–1 score misleads (a treatment already at the 1.0
+    ceiling loses bonus credit the baseline still counts), so `must_coverage` lift
+    plus the raw `Δbonus`/`Δavoid` carry the quality signal; `composite` stays a
+    per-cell ranking score only.
+  - **week-over-week lift delta** vs the previous run. The don't-act threshold is
+    **`max(t·SE_Δ, between-week σ)`** — a movement must clear *both* the two weeks'
+    combined sampling error (`SE_Δ = √(SE_now² + SE_prev²)`) *and* the observed
+    week-to-week drift (`σ` of prior weekly lifts). Until four runs of history
+    exist it reads `Will be computed after four runs.` — the between-week σ needs
+    prior runs to exist (the within-week SE is already shown). Backed by a
+    persistent, idempotent `scorecard-history.csv` (one upserted row per run,
+    carrying each run's lift and its SE).
+  - per-cell table: `must_coverage`, `bonus_rate`, `avoid_violations`, composite,
+    plus mean `cost` and mean `num_turns`.
+  - per-prompt table (one row per prompt/skill), so a regression is traceable to a specific skill
+  - **activation / trigger-miss summary** — per-prompt activation breakdown and
+    `reached_leaf` rate on the with-skill arm, with headline counts of *trigger
+    misses* (`activation=none`: skill present but never reached, so a low lift is a
+    triggering bug to fix in the skill's description, not a content bug) and
+    *web_fetch-sourced* runs (lift came from the published copy, not the local
+    `SKILL.md` under test). A prompt that never triggers is flagged.
+  - **lift caveat — baseline self-served** — how many `no-skill` runs fetched
+    `skills.qdrant.tech`, and which prompts; for those, lift is measured against a
+    baseline that reached the published skill on its own, so it understates value.
+  - **`avoid` violation detail** — the actual violated items with model, condition,
+    and the evidence quote, not just a count, because fabrications are the most
+    damaging failures and deserve names.
+  - **coverage** — `graded X of Y` runs, and every dropped run listed with its
+    reason (invalid install / errored / no gradeable answer). A partial run must
+    not read as a clean one (refer to the No silent caps guardrail).
+  - contested-item and harness-failure counts.
+  - **provenance** — exact resolved model snapshot string per model label, CLI
+    version(s), skills commit(s), and the UTC run window (the only correlate for a
+    silent build swap behind a floating alias); mismatches are flagged.
+
+  **Efficiency companion (cost & turns).** Lift measures answer quality; it is
+  near-zero for a strong model that already knows the material. A skill can still
+  earn its keep by reaching the right answer *sooner* — fewer turns, fewer web
+  round-trips, lower cost — so the scorecard reports a per-model **cost delta** and
+  **turns delta** beside lift, and mean cost/turns per prompt. The delta is signed
+  and cuts both ways: a skill may lower cost (less flailing/searching) or raise it
+  (progressive-disclosure reads plus the skill's own context footprint), and both
+  are informative when read next to lift — a flat lift with a negative cost delta
+  is a skill worth keeping. Three rules keep it honest: it is a **within-model**
+  comparison only (cost is model-priced, like lift); **budget-capped or errored
+  runs are excluded** from the cost mean (their cost is a truncated floor, not the
+  real figure); and `num_turns` is the cleaner "sooner" signal because, unlike
+  cost, it is not inflated by the skill's context size. Reported, never gated.
+
+## Guardrails
+
+- **The judge is the linchpin.** Before trusting any number, dry-run the judge on
+  a handful of existing `runs/` transcripts and confirm its grades match a
+  human's. If the judge and a human disagree, the framework is measuring noise.
+- **Rubrics need an owner other than the skill author.** A rubric written from
+  `SKILL.md` measures conformity to the skill, including where the skill is
+  wrong.
+- **Baseline is not zero.** Sonnet and Haiku already know real material from
+  pretraining and both arms can read the docs, so `no-skill` scores will be
+  well above zero. That is expected: the signal is the lift, not the baseline.
+- **Fabrications are the most damaging `avoid` violations.** A hallucinated
+  endpoint, metric, or config key is a harm, penalized through the graded `−0.25`
+  avoid term rather than gated, because we have no trustworthy way to detect
+  fabrication reliably yet (refer to Thresholds And Gating).
+- **No silent caps.** If a week's run drops prompts (timeouts, budget, invalid
+  runs), the scorecard states which and how many. A partial run must not read as
+  a clean one.
+  

--- a/SCORING.md
+++ b/SCORING.md
@@ -374,11 +374,15 @@ Under `evals/weekly/<date>/`:
 - **`manifest.csv`** — one row per run: `prompt, skill_family, skill_leaf, model,
   condition, rep, run_id, exit_code, skills_sha, timestamp, skill_available,
   skill_activation, reached_leaf, fetched_site, fetched_count, model_snapshot,
-  cli_version, total_cost_usd, num_turns, result_subtype, budget_hit`. The runner
-  writes the first ten (base) columns; `extract-run-signals.sh` derives the rest
-  from each transcript. `budget_hit` is `1` when the run hit the per-run spend cap
-  (`result_subtype = error_max_budget_usd`): such a run is truncated, so it is
-  excluded from scoring and the cost mean and reported as budget-capped.
+  cli_version, total_cost_usd, num_turns, result_subtype, budget_hit, signals_ok`.
+  The runner writes the first ten (base) columns; `extract-run-signals.sh` derives
+  the rest from each transcript. `budget_hit` is `1` when the run hit the per-run
+  spend cap (`result_subtype = error_max_budget_usd`): such a run is truncated, so
+  it is excluded from scoring and the cost mean and reported as budget-capped.
+  `signals_ok` is `0` when the transcript did not parse into the expected shape (a
+  format break, not a real `activation=none`): the run's activation/fetch fields
+  are then untrustworthy and the run is surfaced in Run health for investigation
+  rather than silently read as a trigger miss.
   `skill_family` is the installed/availability unit and `skill_leaf` the prompt's
   target SKILL.md (so `reached_leaf` records whether progressive disclosure
   actually fired); `fetched_site`/`fetched_count` replace a raw URL list and count

--- a/interpret-stats.md
+++ b/interpret-stats.md
@@ -1,0 +1,110 @@
+# Interpreting the Scorecard and `scores.csv`
+
+A plain-language glossary of every number the weekly run reports. Companion to `SCORING.md`, which explains the method; this file just says what each field means.
+
+## TL;DR
+
+The scorecard answers three questions for each skill, **per model** (a skill lifts a small model more than a large one):
+
+1. **Does the skill improve the answer?**: *lift* (quality with the skill minus
+   without).
+2. **Does it also get there cheaper/sooner?**: *cost delta* and *turns delta*.
+3. **Can we trust the number?**: *± SE* and the *week-over-week noise floor* (is it real or sampling noise), *activation* (was the skill actually used), *coverage* (what was dropped), and *provenance* (exactly what produced it).
+
+Quality is on a 0–1 scale (read as a percentage). Nothing is gated — it is a report.
+
+---
+
+## Scorecard
+
+### Lift per model
+
+- `model`: which model.
+- `must_coverage no→with`: share of required points covered, baseline → with-skill.
+- `must lift ± SE`: the improvement, ± one within-week standard error (this week's sampling uncertainty, not drift).
+- `95% CI != 0?`: is the lift distinguishable from zero this week? `no` = don't act on it yet.
+- `Δbonus` / `Δavoid`: change in bonus depth / avoid-violation count with the skill; each column appears only when nonzero. (Composite is not lifted here — differencing the clamped score misleads; see per-cell `composite` for ranking.)
+- `Δcost ($)`: dollars per run added/saved by the skill; negative = cheaper.
+- `Δturns`: conversation messages added/saved; negative = fewer. Counts all messages (model turns + tool-result messages), not just the model's own turns.
+
+### Week-over-week lift delta
+
+- placeholder: reads `Will be computed after four runs.` until four runs of history exist.
+- `must lift (prev → now)`: last run's lift → this run's.
+- `Δ`: the change between them.
+- `t·SE_Δ (within)`: how big a change this week's sampling noise alone could explain.
+- `σ (between)`: observed week-to-week bounce from prior runs (drift + prompt resampling).
+- `threshold`: `max` of the two; the don't-act line.
+- `actionable?`: is `|Δ|` above the threshold? `no (within noise)` = ignore it.
+
+### Per-cell metrics
+
+One row per model × condition (a "cell").
+
+- `must_cov`: must-coverage; primary quality.
+- `bonus_rate`: share of nice-to-have points hit; depth.
+- `avoid_viol`: average count of harmful things done; `0` = none.
+- `composite`: blended score (must_coverage + 0.10 × bonus_rate − 0.25 × avoid_violations, then clamped 0–1)
+- `mean cost`: average $/run.
+- `mean turns`: average conversation messages/run (model turns + tool results).
+- `n`: prompts in the cell.
+
+### Per-prompt
+
+Traces a regression to a specific skill.
+
+- `must no→with`: this prompt's must-coverage, baseline → with-skill.
+- `must lift`: this prompt's improvement.
+- `comp no→with`: this prompt's composite, baseline → with-skill.
+
+### Activation / trigger misses
+
+- `with-skill runs`: count.
+- `trigger misses`: with-skill runs where the skill was present but never reached. A low lift here is a triggering (description) bug, not a content bug.
+- `web_fetch-sourced`: runs whose lift came from the published site, not the local `SKILL.md` under test.
+- `activations (with-skill)`: how the skill was reached and how often: `skill_tool` (progressive disclosure), `file_read` (read the file), `web_fetch` (published copy), `none`.
+- `reached leaf`: runs that read the prompt's exact target `SKILL.md`; whether progressive disclosure actually fired.
+
+### Lift caveat — baseline self-served
+
+- `no-skill runs that fetched skills.qdrant.tech`: baselines that reached the published skill on their own. Their lift is understated (the baseline effectively had the skill).
+
+### `avoid` violations
+
+- One row per actual violation, with `model`, `condition`, the violated item, and the quoted `evidence`. Fabrications live here; the most damaging failures, given names not just a count.
+
+### Coverage
+
+- `runs graded`: how many of the attempted runs were actually scored (`X of Y`).
+- `dropped`: runs excluded, each with a reason (`budget-capped (truncated)` / `invalid: skill unavailable` / `errored` / `no gradeable answer`). Stops a partial week from reading as a clean one.
+
+### Run health
+
+- `contested items`: items where two judge samples disagreed; the rubric-ambiguity backlog.
+- `ungraded items`: items the judge returned no parseable verdict for.
+- `budget-capped runs`: runs that hit the per-run $ cap and were truncated; excluded from scoring and the cost mean.
+- `runs excluded from the cost mean`: errored/capped runs left out of the cost average (their cost is a truncated floor).
+
+### Provenance
+
+- `exact snapshot string`: the model build each label resolved to (for example, `claude-haiku-4-5-20251001`).
+- `CLI version(s)`: Claude Code version(s) the runs used.
+- `skills commit(s)`: the skills-tree commit under test.
+- `run window (UTC)`: when the runs happened; the only correlate for a silent build swap behind a floating alias.
+
+---
+
+## `scores.csv` (raw grade ledger — one row per graded rubric item)
+
+- `prompt`: the test prompt (one per skill).
+- `skill`: the installed skill family.
+- `model`: model label.
+- `condition`: `no-skill` or `with-skill`.
+- `rep`: repetition index.
+- `item_type`: `must` (required), `bonus` (nice-to-have), `avoid` (must not do).
+- `item_text`: the rubric item being graded.
+- `verdict`: `met`/`missing` (must), `met`/`absent` (bonus), `violated`/`clean` (avoid); `PARSE_ERROR` if the judge output could not be parsed.
+- `credit`: `0` or `1`. Note inverted polarity for `avoid`: `1` = violated = bad.
+- `contribution`: signed credit (`avoid` is negative), so summing across item types cannot silently produce nonsense.
+- `contested`: set when two judge samples disagreed on this item.
+- `evidence_quote`: the span the judge quoted from the answer to justify a `met`/`violated` verdict.

--- a/interpret-stats.md
+++ b/interpret-stats.md
@@ -83,6 +83,7 @@ Traces a regression to a specific skill.
 - `contested items`: items where two judge samples disagreed; the rubric-ambiguity backlog.
 - `ungraded items`: items the judge returned no parseable verdict for.
 - `budget-capped runs`: runs that hit the per-run $ cap and were truncated; excluded from scoring and the cost mean.
+- `runs with unreliable signals`: runs whose transcript did not parse to the expected shape (`signals_ok=0`) — a format break, so their activation/fetch numbers are suspect and flagged for investigation rather than read as a trigger miss.
 - `runs excluded from the cost mean`: errored/capped runs left out of the cost average (their cost is a truncated floor).
 
 ### Provenance

--- a/scripts/scoring/extract-run-signals.sh
+++ b/scripts/scoring/extract-run-signals.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Enrich a weekly manifest with the per-run signals derived from each captured
+# transcript, producing the manifest.csv schema SCORING.md describes.
+#
+# Reads the base manifest written by run-eval-matrix.sh (first 10 columns) and,
+# for each run's stdout.txt (stream-json), adds:
+#
+#   skill_available   1 if the run's init skill list contains the mapped family.
+#                     For with-skill runs, 0 is a hard harness failure (the run
+#                     is invalid and excluded downstream). For no-skill runs it
+#                     is expected 0 and just recorded.
+#   skill_activation  how the model reached the skill, by priority:
+#                       skill_tool  invoked the Skill tool for the family
+#                       file_read   read an installed family SKILL.md
+#                       web_fetch   pulled skills.qdrant.tech instead
+#                       none        never reached it (a trigger miss, not a bug)
+#   reached_leaf      1 if it read the prompt's specific target leaf SKILL.md
+#                     (progressive disclosure actually fired), else 0.
+#   fetched_site      1 if it fetched skills.qdrant.tech at all.
+#   fetched_count     number of skills.qdrant.tech fetches (WebFetch or curl).
+#   model_snapshot    the exact model string from init (e.g. claude-haiku-...).
+#   cli_version       claude_code_version from init.
+#
+# Idempotent: re-reads only the 10 base columns, so it can be run repeatedly.
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+OUT_DIR=""
+MANIFEST=""
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/scoring/extract-run-signals.sh --out-dir DIR [--manifest FILE]
+
+Enriches DIR/manifest.csv in place with per-run signals from the transcripts
+under DIR. Run after run-eval-matrix.sh.
+
+Options:
+  --out-dir DIR    Weekly dir containing manifest.csv and the run subdirs.
+  --manifest FILE  Manifest path (default: <out-dir>/manifest.csv).
+  -h, --help       Show this help.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out-dir) OUT_DIR="${2:?}"; shift 2 ;;
+    --manifest) MANIFEST="${2:?}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 64 ;;
+  esac
+done
+
+[[ -n "$OUT_DIR" ]] || { echo "--out-dir is required" >&2; usage >&2; exit 64; }
+[[ -z "$MANIFEST" ]] && MANIFEST="$OUT_DIR/manifest.csv"
+[[ -f "$MANIFEST" ]] || { echo "Manifest not found: $MANIFEST" >&2; exit 66; }
+
+OUT_HEADER="prompt,skill_family,skill_leaf,model,condition,rep,run_id,exit_code,skills_sha,timestamp,skill_available,skill_activation,reached_leaf,fetched_site,fetched_count,model_snapshot,cli_version,total_cost_usd,num_turns,result_subtype,budget_hit"
+
+tmp="$(mktemp)"
+echo "$OUT_HEADER" > "$tmp"
+
+# grep -c can exit 1 on no match under set -e; this wrapper always returns a count.
+count() { grep -cE "$1" "$2" 2>/dev/null || true; }
+
+tail -n +2 "$MANIFEST" | while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  base="$(printf '%s' "$line" | cut -d, -f1-10)"
+  IFS=, read -r prompt family leaf model condition rep run_id exit_code skills_sha timestamp <<< "$base"
+
+  stdout="$OUT_DIR/$run_id/stdout.txt"
+
+  skill_available=0
+  activation="none"
+  reached_leaf=0
+  fetched_site=0
+  fetched_count=0
+  model_snapshot=""
+  cli_version=""
+  total_cost_usd=""
+  num_turns=""
+  result_subtype=""
+  budget_hit=0
+
+  if [[ -f "$stdout" ]]; then
+    init="$(grep -m1 '"subtype":"init"' "$stdout" || true)"
+    if [[ -n "$init" ]]; then
+      model_snapshot="$(printf '%s' "$init" | jq -r '.model // ""' 2>/dev/null || echo "")"
+      cli_version="$(printf '%s' "$init" | jq -r '.claude_code_version // ""' 2>/dev/null || echo "")"
+      if printf '%s' "$init" | jq -e --arg f "$family" '(.skills // []) | index($f) != null' >/dev/null 2>&1; then
+        skill_available=1
+      fi
+    fi
+
+    # Per-run cost/effort and denials all come from the terminal result event.
+    # Cost + turns are the efficiency companions to lift: a skill can be worth it
+    # by reaching the answer sooner/cheaper even when quality lift is small.
+    result_ev="$(grep '"type":"result"' "$stdout" 2>/dev/null | tail -1)"
+    total_cost_usd="$(printf '%s' "$result_ev" | jq -r '.total_cost_usd // ""' 2>/dev/null || echo "")"
+    num_turns="$(printf '%s' "$result_ev" | jq -r '.num_turns // ""' 2>/dev/null || echo "")"
+    result_subtype="$(printf '%s' "$result_ev" | jq -r '.subtype // ""' 2>/dev/null || echo "")"
+    # A run that hit the per-run spend cap: definitive markers from the result event.
+    terminal_reason="$(printf '%s' "$result_ev" | jq -r '.terminal_reason // ""' 2>/dev/null || echo "")"
+    if [[ "$result_subtype" == "error_max_budget_usd" || "$terminal_reason" == "budget_exhausted" ]]; then
+      budget_hit=1
+    fi
+    # A tool the model *attempted* but that dontAsk denied is not a real reach.
+    # Net out permission_denials so a denied Skill/WebFetch is not read as activation.
+    denials="$(printf '%s' "$result_ev" | jq -c '.permission_denials // []' 2>/dev/null || echo '[]')"
+    skill_denied="$(printf '%s' "$denials" | jq '[.[]|select(.tool_name=="Skill")]|length' 2>/dev/null || echo 0)"
+    wf_site_denied="$(printf '%s' "$denials" | jq '[.[]|select(.tool_name=="WebFetch")|select((.tool_input.url // "")|test("skills\\.qdrant\\.tech"))]|length' 2>/dev/null || echo 0)"
+    bash_site_denied="$(printf '%s' "$denials" | jq '[.[]|select(.tool_name=="Bash")|select((.tool_input.command // "")|test("skills\\.qdrant\\.tech"))]|length' 2>/dev/null || echo 0)"
+
+    # Activation signals (grep over the stream, tolerant of exact JSON shape).
+    skill_tool="$(grep -E '"name":"Skill"' "$stdout" 2>/dev/null | grep -c "$family" || true)"
+    read_family="$(grep -E '"name":"Read"' "$stdout" 2>/dev/null | grep -E "skills/$family/[^\"]*SKILL\.md" | grep -c . || true)"
+    read_leaf="$(grep -E '"name":"Read"' "$stdout" 2>/dev/null | grep -Fc "skills/$leaf" || true)"
+
+    wf="$(count '"name":"WebFetch"[^}]*skills\.qdrant\.tech' "$stdout")"
+    curlf="$(count '"name":"Bash"[^}]*skills\.qdrant\.tech' "$stdout")"
+
+    # Subtract denied attempts (floor at 0).
+    skill_tool=$(( skill_tool - skill_denied )); (( skill_tool < 0 )) && skill_tool=0
+    fetched_count=$(( (wf - wf_site_denied) + (curlf - bash_site_denied) ))
+    (( fetched_count < 0 )) && fetched_count=0
+
+    [[ "$read_leaf" -gt 0 ]] && reached_leaf=1
+    [[ "$fetched_count" -gt 0 ]] && fetched_site=1
+
+    if [[ "$skill_tool" -gt 0 ]]; then
+      activation="skill_tool"
+    elif [[ "$read_family" -gt 0 ]]; then
+      activation="file_read"
+    elif [[ "$fetched_count" -gt 0 ]]; then
+      activation="web_fetch"
+    else
+      activation="none"
+    fi
+  else
+    model_snapshot="MISSING_TRANSCRIPT"
+  fi
+
+  printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+    "$base" "$skill_available" "$activation" "$reached_leaf" \
+    "$fetched_site" "$fetched_count" "$model_snapshot" "$cli_version" \
+    "$total_cost_usd" "$num_turns" "$result_subtype" "$budget_hit" >> "$tmp"
+done
+
+mv "$tmp" "$MANIFEST"
+echo "Enriched manifest: $MANIFEST"
+
+# Surface invalid with-skill runs (availability check failed) — the one hard gate.
+invalid="$(awk -F, 'NR>1 && $5=="with-skill" && $11==0 {print $7}' "$MANIFEST")"
+if [[ -n "$invalid" ]]; then
+  echo "WARNING: with-skill runs where the skill was NOT available (invalid, exclude from scoring):" >&2
+  printf '  %s\n' $invalid >&2
+fi
+
+# Budget-capped runs: truncated, excluded from scoring and the cost mean. ($21 = budget_hit)
+capped="$(awk -F, 'NR>1 && $21==1 {print $7}' "$MANIFEST")"
+if [[ -n "$capped" ]]; then
+  echo "NOTE: budget-capped runs (hit the per-run \$ cap, truncated, excluded):" >&2
+  printf '  %s\n' $capped >&2
+fi

--- a/scripts/scoring/extract-run-signals.sh
+++ b/scripts/scoring/extract-run-signals.sh
@@ -57,13 +57,10 @@ done
 [[ -z "$MANIFEST" ]] && MANIFEST="$OUT_DIR/manifest.csv"
 [[ -f "$MANIFEST" ]] || { echo "Manifest not found: $MANIFEST" >&2; exit 66; }
 
-OUT_HEADER="prompt,skill_family,skill_leaf,model,condition,rep,run_id,exit_code,skills_sha,timestamp,skill_available,skill_activation,reached_leaf,fetched_site,fetched_count,model_snapshot,cli_version,total_cost_usd,num_turns,result_subtype,budget_hit"
+OUT_HEADER="prompt,skill_family,skill_leaf,model,condition,rep,run_id,exit_code,skills_sha,timestamp,skill_available,skill_activation,reached_leaf,fetched_site,fetched_count,model_snapshot,cli_version,total_cost_usd,num_turns,result_subtype,budget_hit,signals_ok"
 
 tmp="$(mktemp)"
 echo "$OUT_HEADER" > "$tmp"
-
-# grep -c can exit 1 on no match under set -e; this wrapper always returns a count.
-count() { grep -cE "$1" "$2" 2>/dev/null || true; }
 
 tail -n +2 "$MANIFEST" | while IFS= read -r line; do
   [[ -z "$line" ]] && continue
@@ -83,6 +80,7 @@ tail -n +2 "$MANIFEST" | while IFS= read -r line; do
   num_turns=""
   result_subtype=""
   budget_hit=0
+  signals_ok=1
 
   if [[ -f "$stdout" ]]; then
     init="$(grep -m1 '"subtype":"init"' "$stdout" || true)"
@@ -113,13 +111,26 @@ tail -n +2 "$MANIFEST" | while IFS= read -r line; do
     wf_site_denied="$(printf '%s' "$denials" | jq '[.[]|select(.tool_name=="WebFetch")|select((.tool_input.url // "")|test("skills\\.qdrant\\.tech"))]|length' 2>/dev/null || echo 0)"
     bash_site_denied="$(printf '%s' "$denials" | jq '[.[]|select(.tool_name=="Bash")|select((.tool_input.command // "")|test("skills\\.qdrant\\.tech"))]|length' 2>/dev/null || echo 0)"
 
-    # Activation signals (grep over the stream, tolerant of exact JSON shape).
-    skill_tool="$(grep -E '"name":"Skill"' "$stdout" 2>/dev/null | grep -c "$family" || true)"
-    read_family="$(grep -E '"name":"Read"' "$stdout" 2>/dev/null | grep -E "skills/$family/[^\"]*SKILL\.md" | grep -c . || true)"
-    read_leaf="$(grep -E '"name":"Read"' "$stdout" 2>/dev/null | grep -Fc "skills/$leaf" || true)"
-
-    wf="$(count '"name":"WebFetch"[^}]*skills\.qdrant\.tech' "$stdout")"
-    curlf="$(count '"name":"Bash"[^}]*skills\.qdrant\.tech' "$stdout")"
+    # Activation/fetch signals: structural jq over the whole stream (robust to
+    # whitespace and key-order changes, unlike string-matching). tool_use objects
+    # are found by recursive descent so a re-nesting of the event schema survives.
+    # If the slurp fails to parse, or init/result are absent, the transcript is not
+    # the shape we expect: set signals_ok=0 and surface it, rather than silently
+    # scoring activation=none (the No silent caps guardrail).
+    sig="$(jq -rs --arg fam "$family" --arg leaf "$leaf" '
+      [ .. | objects | select(.type? == "tool_use") ] as $t
+      | [ ([$t[]|select(.name=="Skill")   |select((((.input.skill // .input.command) // "")|tostring)|contains($fam))]|length),
+          ([$t[]|select(.name=="Read")    |select(((.input.file_path) // "")|test("skills/"+$fam+"/.*SKILL\\.md"))]|length),
+          ([$t[]|select(.name=="Read")    |select(((.input.file_path) // "")|contains("skills/"+$leaf))]|length),
+          ([$t[]|select(.name=="WebFetch")|select(((.input.url) // "")|contains("skills.qdrant.tech"))]|length),
+          ([$t[]|select(.name=="Bash")    |select(((.input.command) // "")|contains("skills.qdrant.tech"))]|length)
+        ] | @tsv' "$stdout" 2>/dev/null)"
+    if [[ -n "$sig" && -n "$init" && -n "$result_ev" ]]; then
+      IFS=$'\t' read -r skill_tool read_family read_leaf wf curlf <<< "$sig"
+    else
+      signals_ok=0
+      skill_tool=0; read_family=0; read_leaf=0; wf=0; curlf=0
+    fi
 
     # Subtract denied attempts (floor at 0).
     skill_tool=$(( skill_tool - skill_denied )); (( skill_tool < 0 )) && skill_tool=0
@@ -140,12 +151,13 @@ tail -n +2 "$MANIFEST" | while IFS= read -r line; do
     fi
   else
     model_snapshot="MISSING_TRANSCRIPT"
+    signals_ok=0
   fi
 
-  printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+  printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
     "$base" "$skill_available" "$activation" "$reached_leaf" \
     "$fetched_site" "$fetched_count" "$model_snapshot" "$cli_version" \
-    "$total_cost_usd" "$num_turns" "$result_subtype" "$budget_hit" >> "$tmp"
+    "$total_cost_usd" "$num_turns" "$result_subtype" "$budget_hit" "$signals_ok" >> "$tmp"
 done
 
 mv "$tmp" "$MANIFEST"
@@ -163,4 +175,15 @@ capped="$(awk -F, 'NR>1 && $21==1 {print $7}' "$MANIFEST")"
 if [[ -n "$capped" ]]; then
   echo "NOTE: budget-capped runs (hit the per-run \$ cap, truncated, excluded):" >&2
   printf '  %s\n' $capped >&2
+fi
+
+# Signals tripwire: a transcript we could not parse into the expected shape. Its
+# activation/fetch numbers are NOT trustworthy (a format break, not a real
+# activation=none) — surface it rather than let it read as a silent trigger miss.
+# ($22 = signals_ok)
+bad_signals="$(awk -F, 'NR>1 && $22==0 {print $7}' "$MANIFEST")"
+if [[ -n "$bad_signals" ]]; then
+  echo "WARNING: runs whose transcript did not parse to the expected shape" >&2
+  echo "         (signals_ok=0 — activation/fetch numbers unreliable, investigate the format):" >&2
+  printf '  %s\n' $bad_signals >&2
 fi

--- a/scripts/scoring/judge-runs.sh
+++ b/scripts/scoring/judge-runs.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Grade every valid run in a weekly dir into scores.csv (the raw grade ledger).
+#
+# Reads the enriched manifest (from extract-run-signals.sh — auto-run if the
+# signal columns are missing), then for each run invokes the blind judge on its
+# final answer. Runs excluded from scoring, with reasons surfaced:
+#   - with-skill runs where the skill was not available (invalid harness state)
+#   - runs with a nonzero exit_code (failed/aborted — no trustworthy answer)
+#   - runs with no gradeable final answer
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+OUT_DIR=""
+JUDGE_MODEL="opus"
+SCORES=""
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/scoring/judge-runs.sh --out-dir DIR [--judge-model M] [--scores FILE]
+
+Grades every valid run under DIR into DIR/scores.csv (blind Opus judge).
+
+Options:
+  --out-dir DIR       Weekly dir with manifest.csv and run subdirs.
+  --judge-model M     Grader model. Default: opus
+  --scores FILE       Output ledger. Default: <out-dir>/scores.csv
+  -h, --help          Show this help.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out-dir) OUT_DIR="${2:?}"; shift 2 ;;
+    --judge-model) JUDGE_MODEL="${2:?}"; shift 2 ;;
+    --scores) SCORES="${2:?}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 64 ;;
+  esac
+done
+
+[[ -n "$OUT_DIR" ]] || { echo "--out-dir is required" >&2; usage >&2; exit 64; }
+MANIFEST="$OUT_DIR/manifest.csv"
+[[ -f "$MANIFEST" ]] || { echo "Manifest not found: $MANIFEST" >&2; exit 66; }
+[[ -z "$SCORES" ]] && SCORES="$OUT_DIR/scores.csv"
+
+# Ensure the manifest carries the signal columns; enrich in place if not.
+if ! head -1 "$MANIFEST" | grep -q 'skill_available'; then
+  echo "Manifest not enriched yet; running extract-run-signals.sh ..." >&2
+  "$SCRIPT_DIR/extract-run-signals.sh" --out-dir "$OUT_DIR" >&2
+fi
+
+# Column indices (1-based) in the enriched manifest.
+col() { head -1 "$MANIFEST" | tr ',' '\n' | grep -nx "$1" | cut -d: -f1; }
+C_PROMPT=$(col prompt); C_FAMILY=$(col skill_family); C_MODEL=$(col model)
+C_COND=$(col condition); C_REP=$(col rep); C_RUNID=$(col run_id)
+C_EXIT=$(col exit_code); C_AVAIL=$(col skill_available); C_BUDGET=$(col budget_hit)
+
+rm -f "$SCORES"
+graded=0; skip_invalid=0; skip_error=0; skip_noanswer=0
+
+tail -n +2 "$MANIFEST" | while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  get() { printf '%s' "$line" | cut -d, -f"$1"; }
+  prompt=$(get "$C_PROMPT"); family=$(get "$C_FAMILY"); model=$(get "$C_MODEL")
+  cond=$(get "$C_COND"); rep=$(get "$C_REP"); run_id=$(get "$C_RUNID")
+  exit_code=$(get "$C_EXIT"); avail=$(get "$C_AVAIL")
+  run_dir="$OUT_DIR/$run_id"
+
+  budget=""; [[ -n "${C_BUDGET:-}" ]] && budget=$(get "$C_BUDGET")
+  if [[ "$budget" == "1" ]]; then
+    echo "  skip (budget-capped: truncated) $run_id" >&2; skip_error=$((skip_error+1)); continue
+  fi
+  if [[ "$cond" == "with-skill" && "$avail" != "1" ]]; then
+    echo "  skip (invalid: skill unavailable) $run_id" >&2; skip_invalid=$((skip_invalid+1)); continue
+  fi
+  if [[ "$exit_code" != "0" ]]; then
+    echo "  skip (exit=$exit_code) $run_id" >&2; skip_error=$((skip_error+1)); continue
+  fi
+  if [[ ! -f "$run_dir/test-prompt.json" ]]; then
+    echo "  skip (no test-prompt.json) $run_id" >&2; skip_noanswer=$((skip_noanswer+1)); continue
+  fi
+
+  echo "  judging $model/$cond/rep$rep  $prompt" >&2
+  if python3 "$SCRIPT_DIR/judge.py" "$run_dir" \
+      --judge-model "$JUDGE_MODEL" \
+      --skill "$family" --condition "$cond" --rep "$rep" --model-label "$model" \
+      --out "$SCORES" >&2; then
+    graded=$((graded+1))
+  else
+    echo "  !! judge failed on $run_id" >&2; skip_noanswer=$((skip_noanswer+1))
+  fi
+done
+
+# The while loop runs in a subshell (pipe), so recompute the tallies for the summary.
+echo
+echo "Scores ledger: $SCORES"
+if [[ -f "$SCORES" ]]; then
+  n_rows=$(( $(wc -l < "$SCORES") - 1 ))
+  n_runs=$(tail -n +2 "$SCORES" | cut -d, -f1,3,4,5 | sort -u | wc -l | tr -d ' ')
+  echo "Graded $n_rows rubric items across $n_runs runs."
+else
+  echo "No runs graded." >&2
+fi

--- a/scripts/scoring/judge.py
+++ b/scripts/scoring/judge.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""Blind LLM judge for the weekly skill scoring framework.
+
+Grades one run's *final answer only* against its rubric, one verdict per item,
+under the three SCORING.md rules:
+
+  1. Blind          - the judge sees only prompt, final answer, and rubric.
+                      Model name and skill/no-skill condition are never included.
+  2. Final answer   - grade the last assistant message (the deliverable), not the
+                      transcript's thinking/tool noise.
+  3. Evidence       - every `met`/`violated` verdict must quote a span from the
+                      answer; requiring a quote curbs hallucinated "yes" grades.
+
+Per-type verdict vocabulary and credit (SCORING.md "Per-Item Credit"):
+
+    must   met | missing        met=1.0 missing=0.0   contribution = +credit
+    bonus  met | absent         met=1.0 absent=0.0    contribution = +credit
+    avoid  violated | clean     viol=1.0 clean=0.0     contribution = -credit
+
+`avoid` polarity is inverted: credit 1.0 means the answer did the bad thing, so
+its contribution is negative. The composite weights (0.10 bonus, 0.25 avoid) are
+applied later by the summarizer, not here -- this stays the raw signed ledger.
+
+The model call is a pluggable backend so the scoring logic is testable without an
+API call. Backends:
+  - claude CLI (default): `claude -p --model <m> --output-format json`
+  - canned: read a pre-captured judge JSON (offline tests / replays)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+# --- verdict / credit model -------------------------------------------------
+
+# type -> (positive_verdict, negative_verdict, contribution_sign)
+VERDICTS = {
+    "must": ("met", "missing", +1.0),
+    "bonus": ("met", "absent", +1.0),
+    "avoid": ("violated", "clean", -1.0),
+}
+
+
+def score_item(item_type: str, verdict: str) -> tuple[float, float, bool]:
+    """Return (credit, contribution, valid). credit is always the raw 0/1;
+    contribution carries polarity so cross-type sums stay sane."""
+    spec = VERDICTS.get(item_type)
+    if spec is None:
+        return 0.0, 0.0, False
+    positive, negative, sign = spec
+    if verdict == positive:
+        return 1.0, 1.0 * sign, True
+    if verdict == negative:
+        return 0.0, 0.0, True
+    return 0.0, 0.0, False  # unrecognized verdict for this type
+
+
+# --- final-answer extraction ------------------------------------------------
+
+
+def extract_final_answer(run_dir: Path) -> str:
+    """Pull the final assistant message from a stream-json stdout.txt.
+
+    Prefers the terminal `result` event's `.result` (the CLI's canonical final
+    answer). Falls back to the last assistant text block if that is missing or
+    empty (some early/aborted runs emit an empty result)."""
+    stdout = run_dir / "stdout.txt"
+    if not stdout.exists():
+        raise FileNotFoundError(f"no stdout.txt in {run_dir}")
+
+    result_text = ""
+    last_assistant = ""
+    for line in stdout.read_text(errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(ev, dict):
+            continue
+        if ev.get("type") == "result" and isinstance(ev.get("result"), str):
+            result_text = ev["result"]
+        elif ev.get("type") == "assistant":
+            msg = ev.get("message", {})
+            for block in msg.get("content", []) or []:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    last_assistant = block.get("text", "") or last_assistant
+    answer = result_text.strip() or last_assistant.strip()
+    return answer
+
+
+# --- grading prompt ---------------------------------------------------------
+
+GRADING_PREAMBLE = """\
+You are a strict, blind grader for answers to a technical question about the \
+Qdrant vector database. You are given the user's PROMPT, a candidate ANSWER, \
+and a RUBRIC. Grade each rubric item independently and return JSON only.
+
+Rules:
+- Judge ONLY the ANSWER text below. Do not use outside knowledge to fill gaps \
+the answer leaves; if the answer does not say it, it is not there.
+- For every "met" or "violated" verdict you MUST quote the exact span from the \
+ANSWER that supports it, verbatim, in the "evidence" field. If you cannot quote \
+it, it is not met. Keep each quote short — at most ~15 words; a phrase is enough.
+- Grade each item by its type:
+  * "must": verdict "met" if the ANSWER clearly satisfies the item, else \
+"missing". Binary — no partial credit.
+  * "bonus": verdict "met" if present, else "absent".
+  * "avoid": this is a bad behavior. Actively hunt for it. verdict "violated" \
+only if you can quote the answer doing it; otherwise "clean". When genuinely \
+unsure, prefer "clean" — but do not overlook a clear violation.
+
+Return a single JSON object, no prose, no code fences:
+{"verdicts": [{"index": <1-based item number>, "verdict": "<verdict>", \
+"evidence": "<verbatim quote from the answer, or empty for missing/absent/clean>"}]}
+Return exactly one verdict object per rubric item, in order."""
+
+
+def render_prompt(prompt: str, answer: str, rubric: list[dict]) -> str:
+    rubric_lines = []
+    for i, item in enumerate(rubric, 1):
+        rubric_lines.append(f'{i}. [{item["type"]}] {item["text"]}')
+    return (
+        f"{GRADING_PREAMBLE}\n\n"
+        f"PROMPT:\n{prompt.strip()}\n\n"
+        f"ANSWER:\n<<<ANSWER\n{answer.strip()}\nANSWER\n\n"
+        f"RUBRIC:\n" + "\n".join(rubric_lines) + "\n"
+    )
+
+
+# --- judge-output parsing ---------------------------------------------------
+
+
+def _extract_json_object(text: str) -> Optional[dict]:
+    """Best-effort: find the first {...} JSON object in text, tolerating code
+    fences or stray prose around it."""
+    text = text.strip()
+    # Strip a leading ```json / ``` fence if present.
+    if text.startswith("```"):
+        text = text.split("\n", 1)[-1]
+        if text.rstrip().endswith("```"):
+            text = text.rstrip()[:-3]
+    # Try direct parse first.
+    try:
+        obj = json.loads(text)
+        if isinstance(obj, dict):
+            return obj
+        if isinstance(obj, list):
+            return {"verdicts": obj}
+    except json.JSONDecodeError:
+        pass
+    # Fall back to slicing between the outermost braces.
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end > start:
+        try:
+            obj = json.loads(text[start : end + 1])
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def _salvage_verdicts(text: str) -> dict[int, dict]:
+    """Scan text for individual well-formed {..."index"...} objects using
+    incremental JSON decoding. Robust to a truncated tail (the last, incomplete
+    object is skipped while every complete one before it is kept) and to prose or
+    code fences around the JSON."""
+    dec = json.JSONDecoder()
+    out: dict[int, dict] = {}
+    i, n = 0, len(text)
+    while i < n:
+        if text[i] == "{":
+            try:
+                obj, end = dec.raw_decode(text, i)
+            except json.JSONDecodeError:
+                i += 1
+                continue
+            if isinstance(obj, dict) and isinstance(obj.get("index"), int) and "verdict" in obj:
+                out[obj["index"]] = obj
+            i = end
+            continue
+        i += 1
+    return out
+
+
+def parse_verdicts(judge_text: str, rubric: list[dict]) -> list[dict]:
+    """Align the judge's verdicts to the rubric by 1-based index. Missing or
+    unparseable items are marked verdict '' (invalid) so nothing is silently
+    scored as passing."""
+    obj = _extract_json_object(judge_text) or {}
+    raw = obj.get("verdicts", []) if isinstance(obj, dict) else []
+    by_index: dict[int, dict] = {}
+    for v in raw:
+        if isinstance(v, dict) and isinstance(v.get("index"), int):
+            by_index[v["index"]] = v
+    # If the whole-object parse came up short (e.g. truncated tail, fenced, or
+    # prose-wrapped), salvage any individual verdict objects it missed.
+    if len(by_index) < len(rubric):
+        for idx, v in _salvage_verdicts(judge_text).items():
+            by_index.setdefault(idx, v)
+
+    rows = []
+    for i, item in enumerate(rubric, 1):
+        v = by_index.get(i, {})
+        verdict = (v.get("verdict") or "").strip().lower()
+        evidence = (v.get("evidence") or "").strip()
+        credit, contribution, valid = score_item(item["type"], verdict)
+        rows.append(
+            {
+                "item_type": item["type"],
+                "item_text": item["text"],
+                "verdict": verdict if valid else (verdict or "PARSE_ERROR"),
+                "credit": credit,
+                "contribution": contribution,
+                "valid": valid,
+                "evidence_quote": evidence,
+            }
+        )
+    return rows
+
+
+# --- backends ---------------------------------------------------------------
+
+JudgeFn = Callable[[str], str]
+
+
+def load_env_key(repo_root: Path) -> None:
+    """Populate ANTHROPIC_API_KEY from a .env if not already in the environment.
+    Checks the repo root and the embedded harness's .env (skill-test/.env). CI
+    passes the key as an env var, so this is only a local-run convenience."""
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        return
+    for env in (repo_root / ".env", repo_root / "skill-test" / ".env"):
+        if not env.exists():
+            continue
+        for line in env.read_text().splitlines():
+            line = line.strip()
+            if line.startswith("ANTHROPIC_API_KEY="):
+                val = line.split("=", 1)[1].strip().strip("'\"")
+                if val:
+                    os.environ["ANTHROPIC_API_KEY"] = val
+                return
+
+
+def claude_cli_backend(model: str, repo_root: Path) -> JudgeFn:
+    load_env_key(repo_root)
+
+    def run(prompt: str) -> str:
+        proc = subprocess.run(
+            [
+                "claude", "-p",
+                "--model", model,
+                "--output-format", "json",
+                "--max-turns", "1",
+                "--permission-mode", "dontAsk",
+            ],
+            input=prompt,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(f"claude judge failed: {proc.stderr[:300]}")
+        # The CLI's json envelope carries the assistant text in `.result`.
+        try:
+            env = json.loads(proc.stdout)
+            return env.get("result", "") if isinstance(env, dict) else proc.stdout
+        except json.JSONDecodeError:
+            return proc.stdout
+
+    return run
+
+
+def canned_backend(path: Path) -> JudgeFn:
+    text = path.read_text()
+    return lambda _prompt: text
+
+
+# --- grading one run --------------------------------------------------------
+
+
+@dataclass
+class RunMeta:
+    prompt_name: str
+    skill: str
+    model: str
+    condition: str
+    rep: str
+
+
+def grade_run(run_dir: Path, backend: JudgeFn, meta: RunMeta) -> list[dict]:
+    tp_path = run_dir / "test-prompt.json"
+    if not tp_path.exists():
+        raise FileNotFoundError(f"no test-prompt.json in {run_dir}")
+    tp = json.loads(tp_path.read_text())
+    prompt = tp["prompt"]
+    rubric = tp["rubric"]
+
+    answer = extract_final_answer(run_dir)
+    if not answer:
+        raise ValueError(f"empty final answer in {run_dir} — cannot grade")
+
+    judge_text = backend(render_prompt(prompt, answer, rubric))
+    verdicts = parse_verdicts(judge_text, rubric)
+
+    rows = []
+    for item in verdicts:
+        rows.append(
+            {
+                "prompt": meta.prompt_name,
+                "skill": meta.skill,
+                "model": meta.model,
+                "condition": meta.condition,
+                "rep": meta.rep,
+                "contested": "",  # reserved for multi-sample voting
+                **item,
+            }
+        )
+    return rows
+
+
+CSV_COLUMNS = [
+    "prompt", "skill", "model", "condition", "rep",
+    "item_type", "item_text", "verdict", "credit", "contribution",
+    "contested", "evidence_quote",
+]
+
+
+def rows_to_csv(rows: list[dict]) -> str:
+    import csv
+    import io
+
+    buf = io.StringIO()
+    w = csv.DictWriter(buf, fieldnames=CSV_COLUMNS, extrasaction="ignore")
+    w.writeheader()
+    for r in rows:
+        w.writerow(r)
+    return buf.getvalue()
+
+
+# --- calibration ------------------------------------------------------------
+
+
+def calibrate(run_dir: Path, backend: JudgeFn, meta: RunMeta, repeat: int) -> None:
+    """Grade the same run `repeat` times and report per-item verdict agreement —
+    SCORING.md's judge self-agreement check. High agreement (esp. on binary
+    musts) means one vote stands; noisy items are flagged for a second sample."""
+    tp = json.loads((run_dir / "test-prompt.json").read_text())
+    rubric = tp["rubric"]
+    prompt = tp["prompt"]
+    answer = extract_final_answer(run_dir)
+
+    samples = []
+    for k in range(repeat):
+        verdicts = parse_verdicts(backend(render_prompt(prompt, answer, rubric)), rubric)
+        samples.append([v["verdict"] for v in verdicts])
+        print(f"  sample {k + 1}/{repeat} graded", file=sys.stderr)
+
+    print(f"\nSelf-agreement over {repeat} samples ({run_dir.name}):\n")
+    print(f"{'#':>2}  {'type':<6} {'agree':<7} verdicts")
+    n_unanimous = 0
+    must_unanimous = 0
+    n_must = 0
+    for i, item in enumerate(rubric):
+        col = [s[i] for s in samples]
+        unanimous = len(set(col)) == 1
+        n_unanimous += unanimous
+        if item["type"] == "must":
+            n_must += 1
+            must_unanimous += unanimous
+        mark = "UNANIM" if unanimous else "SPLIT"
+        print(f"{i + 1:>2}  {item['type']:<6} {mark:<7} {col}")
+    print(
+        f"\nunanimous items: {n_unanimous}/{len(rubric)}"
+        f"  |  unanimous musts: {must_unanimous}/{n_must}"
+    )
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def infer_meta(run_dir: Path, args) -> RunMeta:
+    model = args.model_label or ""
+    if not model:
+        md = run_dir / "metadata.json"
+        if md.exists():
+            model = json.loads(md.read_text()).get("model", "") or ""
+    # skill defaults to the test-prompt name (one prompt per skill); the matrix
+    # runner can pass the resolved family explicitly via --skill.
+    tp = run_dir / "test-prompt.json"
+    name = ""
+    if tp.exists():
+        name = json.loads(tp.read_text()).get("name", "") or run_dir.name
+    return RunMeta(
+        prompt_name=name or run_dir.name,
+        skill=args.skill or name or run_dir.name,
+        model=model or "unknown",
+        condition=args.condition,
+        rep=args.rep,
+    )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Blind LLM judge for one run.")
+    p.add_argument("run_dir", type=Path, help="runs/<id>/ with test-prompt.json + stdout.txt")
+    p.add_argument("--judge-model", default="opus", help="grader model (default: opus)")
+    p.add_argument("--canned", type=Path, help="read judge output from a file instead of calling the model")
+    p.add_argument("--repeat", type=int, default=0, help="calibration: grade N times and report self-agreement")
+    p.add_argument("--skill", default="", help="skill/family label for the CSV (default: prompt name)")
+    p.add_argument("--condition", default="NA", help="no-skill | with-skill (for the CSV)")
+    p.add_argument("--rep", default="NA", help="generation rep index (for the CSV)")
+    p.add_argument("--model-label", default="", help="generation model label for the CSV (default: metadata.json)")
+    p.add_argument("--out", type=Path, help="append CSV rows here (writes header if new); default stdout")
+    args = p.parse_args()
+
+    run_dir = args.run_dir
+    if not (run_dir / "test-prompt.json").exists():
+        print(f"error: {run_dir} has no test-prompt.json (not a scored run)", file=sys.stderr)
+        return 2
+
+    repo_root = Path(__file__).resolve().parents[2]
+    if args.canned:
+        backend = canned_backend(args.canned)
+    else:
+        backend = claude_cli_backend(args.judge_model, repo_root)
+
+    meta = infer_meta(run_dir, args)
+
+    if args.repeat and args.repeat > 1:
+        calibrate(run_dir, backend, meta, args.repeat)
+        return 0
+
+    rows = grade_run(run_dir, backend, meta)
+
+    invalid = [r for r in rows if not r["valid"]]
+    if invalid:
+        print(f"warning: {len(invalid)} item(s) failed to parse a valid verdict", file=sys.stderr)
+
+    csv_text = rows_to_csv(rows)
+    if args.out:
+        new = not args.out.exists()
+        with args.out.open("a") as f:
+            f.write(csv_text if new else csv_text.split("\n", 1)[1])
+        print(f"wrote {len(rows)} rows -> {args.out}", file=sys.stderr)
+    else:
+        sys.stdout.write(csv_text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/scoring/resolve-skill.sh
+++ b/scripts/scoring/resolve-skill.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Shared skill resolver for the weekly scoring framework.
+#
+# Maps a test-prompt's skill_url to the two units scoring needs:
+#   family   = first path segment  -> install/staging target + availability key
+#   leaf_rel = full path under skills/ -> activation target + provenance
+#
+# The mapping is a pure string parse of skill_url; nothing here touches disk.
+# Filesystem existence is checked by validate-prompts.sh, which sources this.
+#
+# Source it to get resolve_skill(), or run directly on one URL:
+#   scripts/scoring/resolve-skill.sh https://skills.qdrant.tech/qdrant-scaling/minimize-latency/SKILL.md
+#   -> qdrant-scaling<TAB>qdrant-scaling/minimize-latency/SKILL.md
+set -Eeuo pipefail
+
+# Every skill_url is expected to live on the published site. A URL that does not
+# start with this prefix (e.g. a stray GitHub blob link) is a resolution failure,
+# not something to silently coerce.
+SKILL_URL_PREFIX="https://skills.qdrant.tech/"
+
+# resolve_skill URL
+# On success: prints "family<TAB>leaf_rel", returns 0.
+# On a non-matching host: prints nothing, returns 1.
+resolve_skill() {
+  local url="$1"
+  local path="${url#"$SKILL_URL_PREFIX"}"
+  if [[ "$path" == "$url" ]]; then
+    return 1 # url did not start with the expected host prefix
+  fi
+  local family="${path%%/*}"
+  printf '%s\t%s\n' "$family" "$path"
+}
+
+# Direct execution: resolve a single URL for quick inspection.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  if [[ $# -ne 1 ]]; then
+    echo "Usage: resolve-skill.sh SKILL_URL" >&2
+    exit 64
+  fi
+  if ! resolve_skill "$1"; then
+    echo "Unrecognized skill_url host (expected ${SKILL_URL_PREFIX}...): $1" >&2
+    exit 65
+  fi
+fi

--- a/scripts/scoring/run-eval-matrix.sh
+++ b/scripts/scoring/run-eval-matrix.sh
@@ -78,9 +78,11 @@ while [[ $# -gt 0 ]]; do
     --skills-root) SKILLS_ROOT="${2:?}"; shift 2 ;;
     --out-dir) OUT_DIR="${2:?}"; shift 2 ;;
     --permission-mode) PERMISSION_MODE="${2:?}"; shift 2 ;;
-    --allowed-tools) ALLOWED_TOOLS="${2:?}"; shift 2 ;;
+    # `${2?...}` (no colon) accepts an explicit "" (disables the feature, per the
+    # usage text) but still errors when the value is genuinely missing.
+    --allowed-tools) ALLOWED_TOOLS="${2?--allowed-tools needs a value (use \"\" to disable)}"; shift 2 ;;
     --max-turns) MAX_TURNS="${2:?}"; shift 2 ;;
-    --max-budget-usd) MAX_BUDGET_USD="${2:?}"; shift 2 ;;
+    --max-budget-usd) MAX_BUDGET_USD="${2?--max-budget-usd needs a value (use \"\" to disable)}"; shift 2 ;;
     --limit) LIMIT="${2:?}"; shift 2 ;;
     --dry-run) DRY_RUN="1"; shift ;;
     -h|--help) usage; exit 0 ;;

--- a/scripts/scoring/run-eval-matrix.sh
+++ b/scripts/scoring/run-eval-matrix.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Weekly scoring matrix: run every scored test-prompt across models x conditions
+# x reps, capturing each run under a dated weekly dir and recording a base
+# manifest row. Signals (availability/activation/fetches) are added afterwards by
+# extract-run-signals.sh, which reads this manifest and the captured transcripts.
+#
+#   models      default sonnet,haiku
+#   conditions  no-skill (nothing installed) and with-skill (isolated family)
+#   reps        default 2 (see SCORING.md: cost-first, raise later)
+#
+# The with-skill arm installs ONLY the one top-level skill family the prompt maps
+# to, so lift is attributable to that skill. It stages the family into a temp dir
+# and mounts that, so the container's per-child install path registers it under
+# its real name (not "mounted-skill") — which is what the availability check and
+# activation detection key on.
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=resolve-skill.sh
+source "$SCRIPT_DIR/resolve-skill.sh"
+
+MODELS="sonnet,haiku"
+CONDITIONS="no-skill,with-skill"
+REPS="2"
+PROMPTS_DIR="${PROMPTS_DIR:-$REPO_ROOT/evals/test-prompts}"
+SKILLS_ROOT="${SKILLS_ROOT:-$REPO_ROOT/skills}"
+HARNESS="${HARNESS:-$REPO_ROOT/skill-test/scripts/run-claude-test.sh}"
+OUT_DIR=""
+PERMISSION_MODE="dontAsk"
+# Under dontAsk the run cannot wander off-task, but the tools scoring depends on
+# (the Skill tool, web search/fetch) are denied unless pre-approved. Allow the
+# same set in BOTH arms so lift is measured with web enabled and the skill
+# usable, exactly as SCORING.md's tool-parity section requires. Comma-separated
+# (single token) so it is not confused with the prompt positional.
+ALLOWED_TOOLS="Skill,WebSearch,WebFetch,Read,Grep,Glob,Bash"
+MAX_TURNS="20"
+# Per-run spend cap (a runaway backstop, not a routine limiter). A run that hits
+# it stops truncated and is excluded from scoring/cost and marked budget-capped.
+MAX_BUDGET_USD="2.00"
+DRY_RUN="0"
+LIMIT="0"
+DATE_TAG="$(date -u +%Y%m%d)"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/scoring/run-eval-matrix.sh [options]
+
+Runs the 2x2xk scoring matrix over the scored (non-discord) test-prompts.
+
+Options:
+  --models LIST         Comma list of models. Default: sonnet,haiku
+  --conditions LIST     Comma list of no-skill,with-skill. Default: both
+  --reps N              Repetitions per cell. Default: 2
+  --prompts-dir DIR     Test-prompt JSONs. Default: ../skills/evals/test-prompts
+  --skills-root DIR     Skills root for staging. Default: ../skills/skills
+  --out-dir DIR         Weekly output dir. Default: runs/weekly/<UTC-date>
+  --permission-mode M   Passed to the harness. Default: dontAsk
+  --allowed-tools LIST  Comma-separated tools pre-approved in BOTH arms under
+                        dontAsk. Default: Skill,WebSearch,WebFetch,Read,Grep,Glob,Bash
+                        Empty string disables the allow-list.
+  --max-turns N         Passed to the harness. Default: 20
+  --max-budget-usd USD  Per-run spend cap (runaway backstop). Default: 2.00
+                        Empty string disables the cap.
+  --limit N             Only the first N scored prompts (smoke). Default: all
+  --dry-run             Print the plan and manifest path; run nothing.
+  -h, --help            Show this help.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --models) MODELS="${2:?}"; shift 2 ;;
+    --conditions) CONDITIONS="${2:?}"; shift 2 ;;
+    --reps) REPS="${2:?}"; shift 2 ;;
+    --prompts-dir) PROMPTS_DIR="${2:?}"; shift 2 ;;
+    --skills-root) SKILLS_ROOT="${2:?}"; shift 2 ;;
+    --out-dir) OUT_DIR="${2:?}"; shift 2 ;;
+    --permission-mode) PERMISSION_MODE="${2:?}"; shift 2 ;;
+    --allowed-tools) ALLOWED_TOOLS="${2:?}"; shift 2 ;;
+    --max-turns) MAX_TURNS="${2:?}"; shift 2 ;;
+    --max-budget-usd) MAX_BUDGET_USD="${2:?}"; shift 2 ;;
+    --limit) LIMIT="${2:?}"; shift 2 ;;
+    --dry-run) DRY_RUN="1"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 64 ;;
+  esac
+done
+
+[[ -d "$PROMPTS_DIR" ]] || { echo "Prompts dir not found: $PROMPTS_DIR" >&2; exit 66; }
+[[ -d "$SKILLS_ROOT" ]] || { echo "Skills root not found: $SKILLS_ROOT" >&2; exit 66; }
+
+if [[ -z "$OUT_DIR" ]]; then
+  OUT_DIR="$REPO_ROOT/evals/weekly/$DATE_TAG"
+fi
+MANIFEST="$OUT_DIR/manifest.csv"
+
+IFS=',' read -r -a MODEL_ARR <<< "$MODELS"
+IFS=',' read -r -a COND_ARR <<< "$CONDITIONS"
+
+for c in "${COND_ARR[@]}"; do
+  case "$c" in
+    no-skill|with-skill) ;;
+    *) echo "Invalid condition: $c (want no-skill or with-skill)" >&2; exit 64 ;;
+  esac
+done
+
+# Collect scored prompts (skip discord-), sorted. (Portable to bash 3.2 — no mapfile.)
+PROMPTS=()
+while IFS= read -r _pf; do
+  [[ -n "$_pf" ]] && PROMPTS+=("$_pf")
+done < <(find "$PROMPTS_DIR" -maxdepth 1 -name '*.json' ! -name 'discord-*' | sort)
+if [[ "$LIMIT" -gt 0 && "${#PROMPTS[@]}" -gt "$LIMIT" ]]; then
+  PROMPTS=("${PROMPTS[@]:0:$LIMIT}")
+fi
+
+n_prompts="${#PROMPTS[@]}"
+total=$((n_prompts * ${#MODEL_ARR[@]} * ${#COND_ARR[@]} * REPS))
+
+# Skills commit for provenance (records what the with-skill arm actually mounted).
+skills_sha="unknown"
+if command -v git >/dev/null 2>&1; then
+  skills_sha="$(git -C "$SKILLS_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+fi
+
+echo "Weekly scoring matrix"
+echo "  out-dir:    $OUT_DIR"
+echo "  models:     ${MODEL_ARR[*]}"
+echo "  conditions: ${COND_ARR[*]}"
+echo "  reps:       $REPS"
+echo "  prompts:    $n_prompts scored"
+echo "  skills_sha: $skills_sha"
+echo "  total runs: $total"
+echo "  mode:       $PERMISSION_MODE  max-turns: $MAX_TURNS  budget: ${MAX_BUDGET_USD:-none}"
+echo "  allowed:    ${ALLOWED_TOOLS:-<none>}"
+echo
+
+if [[ "$DRY_RUN" != "1" ]]; then
+  mkdir -p "$OUT_DIR"
+  if [[ ! -f "$MANIFEST" ]]; then
+    echo "prompt,skill_family,skill_leaf,model,condition,rep,run_id,exit_code,skills_sha,timestamp" > "$MANIFEST"
+  fi
+fi
+
+run_one() {
+  local prompt_file="$1" model="$2" condition="$3" rep="$4"
+  local name url resolved family leaf
+  name="$(jq -r '.name // empty' "$prompt_file")"
+  [[ -n "$name" ]] || name="$(basename "$prompt_file" .json)"
+  url="$(jq -r '.skill_url // empty' "$prompt_file")"
+
+  if ! resolved="$(resolve_skill "$url")"; then
+    echo "  !! skip $name: unresolvable skill_url ($url)" >&2
+    return 1
+  fi
+  family="${resolved%%$'\t'*}"
+  leaf="${resolved#*$'\t'}"
+
+  local args=(
+    --model "$model"
+    --permission-mode "$PERMISSION_MODE"
+    --max-turns "$MAX_TURNS"
+    --runs-dir "$OUT_DIR"
+    --no-render
+  )
+  # Trailing `--` ends the variadic --allowedTools list so the container's prompt
+  # positional (claude ... "$prompt") is not swallowed as a tool name.
+  [[ -n "$ALLOWED_TOOLS" ]] && args+=(--extra-args "--allowedTools $ALLOWED_TOOLS --")
+  [[ -n "$MAX_BUDGET_USD" ]] && args+=(--max-budget-usd "$MAX_BUDGET_USD")
+
+  local stage=""
+  if [[ "$condition" == "with-skill" ]]; then
+    stage="$(mktemp -d)"
+    # Copy the whole family subtree under its real name so progressive-disclosure
+    # relative links resolve and the container installs it as ~/.claude/skills/<family>.
+    cp -R "$SKILLS_ROOT/$family" "$stage/$family"
+    args+=(--skills-dir "$stage")
+  fi
+
+  local ts run_id exit_code tmplog
+  ts="$(date -u +%Y%m%dT%H%M%SZ)"
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    printf '  DRY  %-42s %-7s %-11s rep=%s  install=%s\n' \
+      "$name" "$model" "$condition" "$rep" \
+      "$([[ "$condition" == with-skill ]] && echo "$family" || echo none)"
+    [[ -n "$stage" ]] && rm -rf "$stage"
+    return 0
+  fi
+
+  tmplog="$(mktemp)"
+  set +e
+  "$HARNESS" "${args[@]}" "$prompt_file" >"$tmplog" 2>&1
+  exit_code=$?
+  set -e
+
+  run_id="$(grep -o 'Starting Claude Code test: [^ ]*' "$tmplog" | tail -1 | awk '{print $NF}')"
+  [[ -n "$run_id" ]] || run_id="MISSING-$ts"
+  rm -f "$tmplog"
+  [[ -n "$stage" ]] && rm -rf "$stage"
+
+  echo "$name,$family,$leaf,$model,$condition,$rep,$run_id,$exit_code,$skills_sha,$ts" >> "$MANIFEST"
+  printf '  ok   %-42s %-7s %-11s rep=%s  run_id=%s exit=%s\n' \
+    "$name" "$model" "$condition" "$rep" "$run_id" "$exit_code"
+}
+
+for prompt_file in "${PROMPTS[@]}"; do
+  for model in "${MODEL_ARR[@]}"; do
+    for condition in "${COND_ARR[@]}"; do
+      for ((rep = 1; rep <= REPS; rep++)); do
+        run_one "$prompt_file" "$model" "$condition" "$rep" || true
+      done
+    done
+  done
+done
+
+echo
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo "Dry run: $total runs planned. Manifest would be: $MANIFEST"
+else
+  echo "Matrix complete. Manifest: $MANIFEST"
+  echo "Next: scripts/scoring/extract-run-signals.sh --out-dir \"$OUT_DIR\""
+fi

--- a/scripts/scoring/summarize-eval.py
+++ b/scripts/scoring/summarize-eval.py
@@ -520,10 +520,13 @@ def build_scorecard(weekdir, prompt_q, cell_q, cell_cost, contested, ungraded,
 
     # run health
     budget_capped = sum(1 for r in manifest if r.get("budget_hit") == "1")
+    signals_bad = sum(1 for r in manifest if r.get("signals_ok") == "0")
     L.append("## Run health\n")
     L.append(f"- contested items: {contested}")
     L.append(f"- ungraded items (parse/verdict errors): {ungraded}")
     L.append(f"- budget-capped runs (hit the per-run $ cap, truncated, excluded): {budget_capped}")
+    L.append(f"- runs with unreliable signals (signals_ok=0 — transcript did not parse "
+             f"to the expected shape; activation/fetch numbers suspect, investigate): {signals_bad}")
     L.append(f"- runs excluded from the cost mean (errored/capped/no-cost): {cost_excluded}")
     L.append("")
 

--- a/scripts/scoring/summarize-eval.py
+++ b/scripts/scoring/summarize-eval.py
@@ -1,0 +1,601 @@
+#!/usr/bin/env python3
+"""Aggregate a weekly run into the lift + efficiency scorecard.
+
+Reads scores.csv (graded item ledger) and manifest.csv (per-run signals incl.
+cost/turns/activation) from a weekly dir, aggregates in the SCORING.md order
+
+    item  ->  prompt x rep  ->  prompt  ->  cell (model x condition)
+
+as a flat per-prompt macro-average, and writes scorecard.md with:
+  - lift per model (must_coverage + composite) + cost/turns delta
+  - week-over-week lift delta (placeholder until four runs of history exist)
+  - per-cell and per-prompt tables
+  - activation / trigger-miss summary (why a lift is what it is)
+  - lift caveats: baseline runs that self-served the skill via the site
+  - avoid-violation detail (the most damaging failures, with evidence)
+  - coverage: how many prompts scored, and every dropped run with its reason
+  - run health + provenance (exact model strings, versions, run window)
+
+Quality comes from scores.csv; cost/turns/activation from manifest.csv. Deltas
+are within-model only; nothing here gates.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+from collections import Counter, defaultdict
+from pathlib import Path
+from statistics import mean, pstdev, stdev
+
+MODELS_ORDER = ["sonnet", "haiku"]
+CONDITIONS = ["no-skill", "with-skill"]
+UNGRADED = {"", "PARSE_ERROR"}
+WOW_MIN_RUNS = 4  # need this many runs of history before a WoW delta is meaningful
+
+
+def clamp(x, lo, hi):
+    return max(lo, min(hi, x))
+
+
+def fmt(x, nd=3):
+    return "n/a" if x is None else f"{x:.{nd}f}"
+
+
+def signed(x, nd=3):
+    return "n/a" if x is None else f"{x:+.{nd}f}"
+
+
+def md_table(headers, rows):
+    """Render a GitHub-markdown table with padded, aligned columns so it is
+    readable as raw text (and still renders normally). Cells are plain strings —
+    avoid markdown emphasis (**bold**) inside them, which would misalign the raw
+    view. Returns a list of lines."""
+    rows = [[str(c) for c in r] for r in rows]
+    widths = [len(h) for h in headers]
+    for r in rows:
+        for i, c in enumerate(r):
+            widths[i] = max(widths[i], len(c))
+
+    def line(cells):
+        return "| " + " | ".join(c.ljust(widths[i]) for i, c in enumerate(cells)) + " |"
+
+    out = [line(headers), "| " + " | ".join("-" * w for w in widths) + " |"]
+    out += [line(r) for r in rows]
+    return out
+
+
+# --- load ------------------------------------------------------------------
+
+
+def load_csv(path: Path):
+    with path.open() as f:
+        return list(csv.DictReader(f))
+
+
+# --- quality aggregation ---------------------------------------------------
+
+
+def rep_metrics(items):
+    must = [float(i["credit"]) for i in items if i["item_type"] == "must"]
+    bonus = [float(i["credit"]) for i in items if i["item_type"] == "bonus"]
+    avoid = [float(i["credit"]) for i in items if i["item_type"] == "avoid"]
+    must_cov = mean(must) if must else None
+    bonus_rate = mean(bonus) if bonus else None
+    avoid_viol = sum(avoid)
+    composite = None
+    if must_cov is not None:
+        composite = clamp(must_cov + 0.10 * (bonus_rate or 0.0) - 0.25 * avoid_viol, 0.0, 1.0)
+    return {"must_coverage": must_cov, "bonus_rate": bonus_rate,
+            "avoid_violations": avoid_viol, "composite": composite}
+
+
+def avg_metric(dicts, key):
+    vals = [d[key] for d in dicts if d.get(key) is not None]
+    return mean(vals) if vals else None
+
+
+def aggregate_quality(scores):
+    by_rep = defaultdict(list)
+    contested = ungraded = 0
+    for r in scores:
+        by_rep[(r["model"], r["condition"], r["prompt"], r["rep"])].append(r)
+        if r.get("contested") not in (None, "", "False", "false"):
+            contested += 1
+        if r["verdict"] in UNGRADED:
+            ungraded += 1
+    rep_level = {k: rep_metrics(v) for k, v in by_rep.items()}
+
+    by_prompt = defaultdict(list)
+    for (model, cond, prompt, _rep), m in rep_level.items():
+        by_prompt[(model, cond, prompt)].append(m)
+    prompt_level = {
+        key: {k: avg_metric(ms, k) for k in
+              ("must_coverage", "bonus_rate", "avoid_violations", "composite")}
+        for key, ms in by_prompt.items()
+    }
+
+    by_cell = defaultdict(list)
+    for (model, cond, _prompt), m in prompt_level.items():
+        by_cell[(model, cond)].append(m)
+    cell_level = {}
+    for key, ms in by_cell.items():
+        cell_level[key] = {k: avg_metric(ms, k) for k in
+                           ("must_coverage", "bonus_rate", "avoid_violations", "composite")}
+        cell_level[key]["n_prompts"] = len(ms)
+    return prompt_level, cell_level, contested, ungraded
+
+
+# --- cost aggregation ------------------------------------------------------
+
+
+def aggregate_cost(manifest):
+    by_cell = defaultdict(lambda: {"cost": [], "turns": []})
+    excluded = 0
+    for r in manifest:
+        # Errored or budget-capped runs are truncated: their cost is a floor, not
+        # the real figure, so they never enter the cost mean.
+        if r.get("exit_code") != "0" or r.get("budget_hit") == "1":
+            excluded += 1
+            continue
+        cost, turns = r.get("total_cost_usd", ""), r.get("num_turns", "")
+        if cost in (None, ""):
+            excluded += 1
+            continue
+        key = (r.get("model"), r.get("condition"))
+        by_cell[key]["cost"].append(float(cost))
+        if turns not in (None, ""):
+            by_cell[key]["turns"].append(float(turns))
+    cell = {}
+    for key, v in by_cell.items():
+        cell[key] = {"cost": mean(v["cost"]) if v["cost"] else None,
+                     "turns": mean(v["turns"]) if v["turns"] else None, "n": len(v["cost"])}
+    return cell, excluded
+
+
+def delta(withv, nov):
+    return None if withv is None or nov is None else withv - nov
+
+
+# Two-sided 95% Student-t multipliers by degrees of freedom. Small n here (a
+# handful to ~26 prompts), so z=1.96 would overstate confidence — use t.
+_T95 = {1: 12.706, 2: 4.303, 3: 3.182, 4: 2.776, 5: 2.571, 6: 2.447, 7: 2.365,
+        8: 2.306, 9: 2.262, 10: 2.228, 12: 2.179, 15: 2.131, 20: 2.086,
+        25: 2.060, 30: 2.042, 40: 2.021, 60: 2.000, 120: 1.980}
+
+
+def t95(df):
+    """95% two-sided t multiplier; conservative (largest tabulated df <= df)."""
+    if df < 1:
+        return None
+    if df >= 120:
+        return 1.960
+    best = max((k for k in _T95 if k <= df), default=min(_T95))
+    return _T95[best]
+
+
+def within_week_se(prompt_q, models):
+    """Within-week paired standard error of the must_coverage lift, per model.
+
+    For each prompt present in BOTH arms, dᵢ = must_cov_with − must_cov_no; the
+    lift is mean(dᵢ) and SE = stdev(dᵢ)/√n. Pairing cancels between-prompt
+    difficulty. This measures ONLY this week's sampling uncertainty (the finite
+    prompt set + folded-in rep/judge noise) — not between-week drift. The CI is
+    used to flag whether the lift is distinguishable from zero this week."""
+    out = {}
+    for m in models:
+        prompts = {p for (mm, _c, p) in prompt_q if mm == m}
+        ds = []
+        for p in prompts:
+            no = prompt_q.get((m, "no-skill", p))
+            wi = prompt_q.get((m, "with-skill", p))
+            if not no or not wi:
+                continue
+            a, b = no.get("must_coverage"), wi.get("must_coverage")
+            if a is None or b is None:
+                continue
+            ds.append(b - a)
+        n = len(ds)
+        if n >= 2:
+            lift = mean(ds)
+            se = stdev(ds) / math.sqrt(n)
+            t = t95(n - 1)
+            half = t * se if t else None
+            excludes_zero = half is not None and abs(lift) > half
+        else:
+            lift = ds[0] if n == 1 else None
+            se = half = t = None
+            excludes_zero = False
+        out[m] = {"lift": lift, "se": se, "n": n, "half": half, "excludes_zero": excludes_zero}
+    return out
+
+
+def per_model_lifts(cell_q, cell_cost, models):
+    out = {}
+    for m in models:
+        qn, qw = cell_q.get((m, "no-skill"), {}), cell_q.get((m, "with-skill"), {})
+        cn, cw = cell_cost.get((m, "no-skill"), {}), cell_cost.get((m, "with-skill"), {})
+        out[m] = {
+            "must_lift": delta(qw.get("must_coverage"), qn.get("must_coverage")),
+            # composite_lift kept for history continuity only — not shown in the
+            # headline: differencing the clamped composite is misleading (a treatment
+            # at the 1.0 ceiling loses bonus credit the baseline keeps). Use must_lift
+            # plus the raw bonus/avoid deltas instead.
+            "composite_lift": delta(qw.get("composite"), qn.get("composite")),
+            "bonus_delta": delta(qw.get("bonus_rate"), qn.get("bonus_rate")),
+            "avoid_delta": delta(qw.get("avoid_violations"), qn.get("avoid_violations")),
+            "cost_delta": delta(cw.get("cost"), cn.get("cost")),
+            "turns_delta": delta(cw.get("turns"), cn.get("turns")),
+        }
+    return out
+
+
+# --- provenance ------------------------------------------------------------
+
+
+def provenance(manifest):
+    snaps = defaultdict(set)
+    cli, sha, stamps = set(), set(), set()
+    for r in manifest:
+        ms = (r.get("model_snapshot") or "").strip()
+        if ms and ms != "MISSING_TRANSCRIPT":
+            snaps[(r.get("model") or "").strip()].add(ms)
+        for field, bucket in (("cli_version", cli), ("skills_sha", sha), ("timestamp", stamps)):
+            v = (r.get(field) or "").strip()
+            if v:
+                bucket.add(v)
+    window = (min(stamps), max(stamps)) if stamps else None
+    return snaps, cli, sha, window
+
+
+# --- new sections ----------------------------------------------------------
+
+
+def models_present(cell_q, cell_cost):
+    seen = {m for (m, _c) in cell_q} | {m for (m, _c) in cell_cost}
+    return [m for m in MODELS_ORDER if m in seen] + sorted(m for m in seen if m not in MODELS_ORDER)
+
+
+def activation_section(manifest):
+    ws = [r for r in manifest if r.get("condition") == "with-skill"]
+    L = ["## Activation / trigger misses\n"]
+    if not ws:
+        L.append("_No with-skill runs._\n")
+        return L
+    miss = sum(1 for r in ws if r.get("skill_activation") == "none")
+    webf = sum(1 for r in ws if r.get("skill_activation") == "web_fetch")
+    L.append(f"- with-skill runs: **{len(ws)}**")
+    L.append(f"- **trigger misses** (activation=none — skill present but never reached): **{miss}**")
+    L.append(f"- lift sourced from the published site (activation=web_fetch, not the local SKILL.md): **{webf}**")
+    L.append("")
+    by_prompt = defaultdict(list)
+    for r in ws:
+        by_prompt[r.get("prompt")].append(r)
+    trows = []
+    for prompt in sorted(by_prompt):
+        runs = by_prompt[prompt]
+        acts = Counter(r.get("skill_activation") for r in runs)
+        acts_str = ", ".join(f"{k}×{v}" for k, v in sorted(acts.items()))
+        leaf = sum(1 for r in runs if r.get("reached_leaf") == "1")
+        flag = "  ⚠ never triggered" if acts.get("none", 0) == len(runs) else ""
+        trows.append([prompt, f"{acts_str}{flag}", f"{leaf}/{len(runs)}"])
+    L += md_table(["prompt", "activations (with-skill)", "reached leaf"], trows)
+    L.append("")
+    return L
+
+
+def baseline_selfserved_section(manifest):
+    ns = [r for r in manifest if r.get("condition") == "no-skill"]
+    served = [r for r in ns if r.get("fetched_site") == "1"]
+    L = ["## Lift caveat — baseline self-served the skill\n"]
+    if not ns:
+        L.append("_No no-skill runs._\n")
+        return L
+    L.append(f"- no-skill runs that fetched `skills.qdrant.tech`: **{len(served)} of {len(ns)}**")
+    if served:
+        prompts = sorted({r.get("prompt") for r in served})
+        L.append(f"- affected prompts: {', '.join(prompts)}")
+        L.append("- For these, lift is measured against a baseline that reached the "
+                 "published skill on its own — so it *understates* the skill's value.")
+    L.append("")
+    return L
+
+
+def avoid_section(scores):
+    viol = [r for r in scores if r["item_type"] == "avoid"
+            and r["verdict"] == "violated" and float(r["credit"]) > 0]
+    L = ["## `avoid` violations (most damaging failures)\n"]
+    if not viol:
+        L.append("_None._\n")
+        return L
+    trows = []
+    for r in viol:
+        ev = (r.get("evidence_quote") or "").replace("|", "\\|")[:120]
+        trows.append([r['prompt'], r['model'], r['condition'], r['item_text'][:80], ev])
+    L += md_table(["prompt", "model", "condition", "violated item", "evidence"], trows)
+    L.append("")
+    return L
+
+
+def coverage_section(manifest, scores):
+    graded = {(r["prompt"], r["model"], r["condition"], r["rep"]) for r in scores}
+    dropped = []
+    for r in manifest:
+        key = (r.get("prompt"), r.get("model"), r.get("condition"), r.get("rep"))
+        if key in graded:
+            continue
+        if r.get("budget_hit") == "1":
+            reason = "budget-capped (truncated)"
+        elif r.get("condition") == "with-skill" and r.get("skill_available") != "1":
+            reason = "invalid: skill unavailable"
+        elif r.get("exit_code") != "0":
+            reason = f"errored (exit {r.get('exit_code')})"
+        else:
+            reason = "no gradeable answer"
+        dropped.append((r.get("run_id"), r.get("prompt"), r.get("model"), r.get("condition"), reason))
+    total = len(manifest)
+    L = ["## Coverage\n"]
+    L.append(f"- runs graded: **{len(graded)} of {total}**")
+    if dropped:
+        L.append(f"- dropped: **{len(dropped)}** (a partial run is not a clean run)")
+        L.append("")
+        L += md_table(["run_id", "prompt", "model", "condition", "reason"],
+                      [[rid, p, m, c, reason] for rid, p, m, c, reason in dropped])
+    else:
+        L.append("- dropped: **0**")
+    L.append("")
+    return L
+
+
+# --- week-over-week history ------------------------------------------------
+
+HISTORY_COLS = ["run_key", "window_end", "model", "must_lift", "must_lift_se",
+                "composite_lift", "cost_delta", "turns_delta"]
+
+
+def load_history(path: Path):
+    return load_csv(path) if path.exists() else []
+
+
+def _num(v):
+    return "" if v is None else f"{v:.6f}"
+
+
+def upsert_history(path: Path, run_key, window_end, lifts, se_info):
+    rows = [r for r in load_history(path) if r.get("run_key") != run_key]
+    for model, v in lifts.items():
+        rows.append({
+            "run_key": run_key, "window_end": window_end or "", "model": model,
+            "must_lift": _num(v["must_lift"]),
+            "must_lift_se": _num(se_info.get(model, {}).get("se")),
+            "composite_lift": _num(v["composite_lift"]),
+            "cost_delta": _num(v["cost_delta"]),
+            "turns_delta": _num(v["turns_delta"]),
+        })
+    with path.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=HISTORY_COLS)
+        w.writeheader()
+        w.writerows(rows)
+
+
+def _fnum(v):
+    return float(v) if v not in ("", None) else None
+
+
+def wow_section(path: Path, run_key, current_lifts, se_info, models):
+    rows = load_history(path)
+    keys_sorted = sorted({r["run_key"] for r in rows},
+                         key=lambda k: max((r["window_end"] for r in rows if r["run_key"] == k), default=""))
+    n_runs = len(keys_sorted)  # includes the just-upserted current run
+    L = ["## Week-over-week lift delta\n"]
+    if n_runs < WOW_MIN_RUNS:
+        L.append(f"**Will be computed after four runs.** (this is run {n_runs} of "
+                 f"{WOW_MIN_RUNS}; a delta needs prior runs to estimate the between-week "
+                 "noise floor. This week's own sampling uncertainty is in the lift table "
+                 "above as ± SE.)\n")
+        return L
+    prior_keys = [k for k in keys_sorted if k != run_key]
+    prev_key = prior_keys[-1]
+    prev = {r["model"]: r for r in rows if r["run_key"] == prev_key}
+    L.append(f"vs previous run `{prev_key}`. The don't-act threshold is "
+             "**max(t·SE_Δ, between-week σ)** — a delta must clear both this week's "
+             "sampling error *and* the observed week-to-week drift to be actionable.\n")
+    trows = []
+    for m in models:
+        now = current_lifts.get(m, {}).get("must_lift")
+        pv = _fnum(prev.get(m, {}).get("must_lift"))
+        d = delta(now, pv)
+        # within-week component: combine this week's and prev week's paired SE
+        se_now = se_info.get(m, {}).get("se")
+        se_prev = _fnum(prev.get(m, {}).get("must_lift_se"))
+        within = None
+        if se_now is not None and se_prev is not None:
+            se_delta = math.sqrt(se_now ** 2 + se_prev ** 2)
+            t = t95(se_info.get(m, {}).get("n", 1) - 1) or 1.96
+            within = t * se_delta
+        # between-week component: spread of prior weekly lifts
+        hist = [_fnum(r["must_lift"]) for r in rows
+                if r["model"] == m and r["run_key"] != run_key and r["must_lift"] not in ("", None)]
+        between = pstdev(hist) if len(hist) >= 2 else None
+        cands = [x for x in (within, between) if x is not None]
+        threshold = max(cands) if cands else None
+        if d is None or threshold is None:
+            actionable = "n/a"
+        else:
+            actionable = "yes" if abs(d) > threshold else "no (within noise)"
+        trows.append([m, f"{fmt(pv)} → {fmt(now)}", signed(d), fmt(within),
+                      fmt(between), fmt(threshold), actionable])
+    L += md_table(["model", "must lift (prev → now)", "Δ", "t·SE_Δ (within)",
+                   "σ (between)", "threshold", "actionable?"], trows)
+    L.append("")
+    return L
+
+
+# --- assemble --------------------------------------------------------------
+
+
+def build_scorecard(weekdir, prompt_q, cell_q, cell_cost, contested, ungraded,
+                    cost_excluded, prov, manifest, scores, wow_lines, current_lifts, se_info):
+    models = models_present(cell_q, cell_cost)
+    L = [f"# Weekly Skill Scorecard — {weekdir.name}\n"]
+
+    # lift per model
+    L.append("## Lift per model (with-skill − no-skill)\n")
+    eps = 1e-9
+    nz = lambda key: any(current_lifts[m].get(key) is not None and abs(current_lifts[m][key]) > eps
+                         for m in models)
+    show_bonus, show_avoid = nz("bonus_delta"), nz("avoid_delta")
+    headers = ["model", "must_coverage no→with", "must lift ± SE", "95% CI != 0?"]
+    if show_bonus:
+        headers.append("Δbonus")
+    if show_avoid:
+        headers.append("Δavoid")
+    headers += ["Δcost ($)", "Δturns"]
+    rows = []
+    for m in models:
+        qn, qw = cell_q.get((m, "no-skill"), {}), cell_q.get((m, "with-skill"), {})
+        v = current_lifts[m]
+        se = se_info.get(m, {})
+        arrow = f"{fmt(qn.get('must_coverage'))} → {fmt(qw.get('must_coverage'))}"
+        se_str = f"{signed(v['must_lift'])} ± {fmt(se.get('se')) if se.get('se') is not None else 'n/a'}"
+        flag = "n/a (need >=2 prompts)" if se.get("se") is None else \
+            ("yes" if se.get("excludes_zero") else "no")
+        row = [m, arrow, se_str, flag]
+        if show_bonus:
+            row.append(signed(v.get("bonus_delta")))
+        if show_avoid:
+            row.append(signed(v.get("avoid_delta"), 2))
+        row += [signed(v['cost_delta'], 4), signed(v['turns_delta'], 1)]
+        rows.append(row)
+    L += md_table(headers, rows)
+    L.append("\n_± SE is one within-week standard error of the paired per-prompt must-coverage "
+             "lift — this week's sampling uncertainty (finite prompt set + run/judge noise), "
+             "**not** between-week drift. '≠ 0?' asks whether the 95% CI (t·SE) excludes zero: "
+             "'no' means don't act on this lift yet. Δbonus/Δavoid appear only when the skill "
+             "changed bonus depth or introduced/removed a violation. Δcost/Δturns are "
+             "within-model only; negative = cheaper/sooner. Note: turns counts all "
+             "conversation messages, including tool-result messages, not just the model's "
+             "own turns. Reported, not gated._\n")
+
+    L += wow_lines
+
+    # per-cell
+    L.append("## Per-cell metrics\n")
+    rows = []
+    for m in models:
+        for cond in CONDITIONS:
+            q = cell_q.get((m, cond))
+            if not q:
+                continue
+            c = cell_cost.get((m, cond), {})
+            rows.append([m, cond, fmt(q['must_coverage']), fmt(q['bonus_rate']),
+                         fmt(q['avoid_violations'], 2), fmt(q['composite']),
+                         fmt(c.get('cost'), 4), fmt(c.get('turns'), 1), q['n_prompts']])
+    L += md_table(["model", "condition", "must_cov", "bonus_rate", "avoid_viol",
+                   "composite", "mean cost", "mean turns", "n"], rows)
+    L.append("")
+
+    # per-prompt
+    L.append("## Per-prompt (must_coverage; with-skill lift)\n")
+    rows = []
+    for prompt in sorted({p for (_m, _c, p) in prompt_q}):
+        for m in models:
+            no, wi = prompt_q.get((m, "no-skill", prompt)), prompt_q.get((m, "with-skill", prompt))
+            if not no and not wi:
+                continue
+            mc_no = no.get("must_coverage") if no else None
+            mc_wi = wi.get("must_coverage") if wi else None
+            cp_no = no.get("composite") if no else None
+            cp_wi = wi.get("composite") if wi else None
+            rows.append([prompt, m, f"{fmt(mc_no)} → {fmt(mc_wi)}",
+                         signed(delta(mc_wi, mc_no)), f"{fmt(cp_no)} → {fmt(cp_wi)}"])
+    L += md_table(["prompt", "model", "must no→with", "must lift", "comp no→with"], rows)
+    L.append("")
+
+    # new sections
+    L += activation_section(manifest)
+    L += baseline_selfserved_section(manifest)
+    L += avoid_section(scores)
+    L += coverage_section(manifest, scores)
+
+    # run health
+    budget_capped = sum(1 for r in manifest if r.get("budget_hit") == "1")
+    L.append("## Run health\n")
+    L.append(f"- contested items: {contested}")
+    L.append(f"- ungraded items (parse/verdict errors): {ungraded}")
+    L.append(f"- budget-capped runs (hit the per-run $ cap, truncated, excluded): {budget_capped}")
+    L.append(f"- runs excluded from the cost mean (errored/capped/no-cost): {cost_excluded}")
+    L.append("")
+
+    # provenance
+    snaps, cli_v, sha_v, window = prov
+    L.append("## Provenance\n")
+    L.append("Exact model builds and versions these numbers were produced with:\n")
+    prov_rows = []
+    listed = list(models) + [m for m in sorted(snaps) if m not in set(models)]
+    for m in listed:
+        strings = sorted(snaps.get(m, []))
+        if not strings:
+            prov_rows.append([m, "(unknown)"])
+        elif len(strings) == 1:
+            prov_rows.append([m, f"`{strings[0]}`"])
+        else:
+            prov_rows.append([m, f"⚠ multiple (`{'`, `'.join(strings)}`) — model changed mid-week"])
+    L += md_table(["model", "exact snapshot string"], prov_rows)
+    L.append("")
+    L.append(f"- CLI version(s): {', '.join(f'`{v}`' for v in sorted(cli_v)) or '_(unknown)_'}")
+    L.append(f"- skills commit(s): {', '.join(f'`{v}`' for v in sorted(sha_v)) or '_(unknown)_'}")
+    if window:
+        lo, hi = window
+        L.append(f"- run window (UTC): {'`'+lo+'`' if lo == hi else '`'+lo+'` – `'+hi+'`'}")
+    if len(cli_v) > 1:
+        L.append("- ⚠ more than one CLI version present — versions were not pinned across runs.")
+    if len(sha_v) > 1:
+        L.append("- ⚠ more than one skills commit present — the skills tree changed mid-week.")
+    L.append("- Note: an alias like `claude-sonnet-5` can float to a newer build without "
+             "changing name; the run window is the only correlate for such a silent swap. "
+             "Pass a dated model id if byte-level pinning matters.")
+    L.append("")
+    return "\n".join(L)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Aggregate a weekly run into scorecard.md")
+    ap.add_argument("weekdir", type=Path, nargs="?", default=Path.cwd())
+    ap.add_argument("--history", type=Path, default=None,
+                    help="WoW history CSV (default: <weekdir>/../scorecard-history.csv)")
+    args = ap.parse_args()
+
+    weekdir = args.weekdir
+    scores_path, manifest_path = weekdir / "scores.csv", weekdir / "manifest.csv"
+    for p in (scores_path, manifest_path):
+        if not p.exists():
+            print(f"error: {p} not found", file=__import__("sys").stderr)
+            return 2
+
+    scores = load_csv(scores_path)
+    manifest = load_csv(manifest_path)
+
+    prompt_q, cell_q, contested, ungraded = aggregate_quality(scores)
+    cell_cost, cost_excluded = aggregate_cost(manifest)
+    prov = provenance(manifest)
+    models = models_present(cell_q, cell_cost)
+    current_lifts = per_model_lifts(cell_q, cell_cost, models)
+    se_info = within_week_se(prompt_q, models)
+
+    history_path = args.history or (weekdir.parent / "scorecard-history.csv")
+    window_end = prov[3][1] if prov[3] else ""
+    upsert_history(history_path, weekdir.name, window_end, current_lifts, se_info)
+    wow_lines = wow_section(history_path, weekdir.name, current_lifts, se_info, models)
+
+    report = build_scorecard(weekdir, prompt_q, cell_q, cell_cost, contested, ungraded,
+                             cost_excluded, prov, manifest, scores, wow_lines, current_lifts, se_info)
+    (weekdir / "scorecard.md").write_text(report)
+    print(report)
+    print(f"\nwrote {weekdir / 'scorecard.md'}  |  history: {history_path}",
+          file=__import__("sys").stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/scoring/validate-prompts.sh
+++ b/scripts/scoring/validate-prompts.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Preflight for the weekly scoring matrix: confirm every test-prompt's skill_url
+# resolves to a real skill on disk. Read-only — touches nothing in the skills
+# checkout. Exits non-zero (and lists every failure) so a renamed skill dir or a
+# malformed skill_url breaks loudly here rather than as a confusing mid-run
+# install failure or a false "skill unavailable".
+#
+# For each *.json under the prompts dir it checks:
+#   - the file parses as JSON and has a non-empty string skill_url
+#   - skill_url resolves (expected published-site host)
+#   - skills/<family>/SKILL.md exists   (the install/availability unit)
+#   - skills/<leaf_rel>       exists    (the activation/test-target unit)
+#
+# discord-* prompts are the held-out set: validated too (they share families and
+# may be scored later), but counted separately.
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Defaults are in-repo (this script lives in the qdrant/skills repo).
+PROMPTS_DIR="${PROMPTS_DIR:-$REPO_ROOT/evals/test-prompts}"
+SKILLS_ROOT="${SKILLS_ROOT:-$REPO_ROOT/skills}"
+VERBOSE="0"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/scoring/validate-prompts.sh [options]
+
+Checks that every test-prompt skill_url resolves to a real skill on disk.
+
+Options:
+  --prompts-dir DIR   Directory of *.json test-prompts.
+                      Default: ../skills/evals/test-prompts
+  --skills-root DIR   Root the leaf paths are relative to (the skills/ dir).
+                      Default: ../skills/skills
+  --verbose           Print an OK line for every prompt, not just failures.
+  -h, --help          Show this help.
+
+Exit codes: 0 all resolve · 1 one or more failed · 64 bad usage · 66 dir missing
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prompts-dir) PROMPTS_DIR="${2:?--prompts-dir needs a value}"; shift 2 ;;
+    --skills-root) SKILLS_ROOT="${2:?--skills-root needs a value}"; shift 2 ;;
+    --verbose)     VERBOSE="1"; shift ;;
+    -h|--help)     usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 64 ;;
+  esac
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 64
+fi
+
+# shellcheck source=resolve-skill.sh
+source "$SCRIPT_DIR/resolve-skill.sh"
+
+if [[ ! -d "$PROMPTS_DIR" ]]; then
+  echo "Prompts dir not found: $PROMPTS_DIR" >&2
+  exit 66
+fi
+if [[ ! -d "$SKILLS_ROOT" ]]; then
+  echo "Skills root not found: $SKILLS_ROOT" >&2
+  exit 66
+fi
+
+echo "Prompts: $PROMPTS_DIR"
+echo "Skills:  $SKILLS_ROOT"
+echo
+
+fail=0
+n=0
+scored=0
+heldout=0
+
+report_fail() {
+  # base, message
+  printf 'FAIL  %-52s %s\n' "$1" "$2"
+  fail=1
+}
+
+shopt -s nullglob
+for f in "$PROMPTS_DIR"/*.json; do
+  n=$((n + 1))
+  base="$(basename "$f")"
+  if [[ "$base" == discord-* ]]; then
+    heldout=$((heldout + 1))
+  else
+    scored=$((scored + 1))
+  fi
+
+  if ! jq -e . "$f" >/dev/null 2>&1; then
+    report_fail "$base" "invalid JSON"
+    continue
+  fi
+
+  url="$(jq -r 'if (.skill_url | type) == "string" and (.skill_url | length > 0) then .skill_url else empty end' "$f")"
+  if [[ -z "$url" ]]; then
+    report_fail "$base" "missing or empty skill_url"
+    continue
+  fi
+
+  if ! resolved="$(resolve_skill "$url")"; then
+    report_fail "$base" "unexpected host: $url"
+    continue
+  fi
+  family="${resolved%%$'\t'*}"
+  leaf="${resolved#*$'\t'}"
+
+  problems=()
+  [[ -f "$SKILLS_ROOT/$family/SKILL.md" ]] || problems+=("no family SKILL.md ($family/SKILL.md)")
+  [[ -f "$SKILLS_ROOT/$leaf" ]] || problems+=("no leaf ($leaf)")
+
+  if [[ ${#problems[@]} -gt 0 ]]; then
+    report_fail "$base" "$(IFS='; '; echo "${problems[*]}")"
+    continue
+  fi
+
+  if [[ "$VERBOSE" == "1" ]]; then
+    printf 'OK    %-52s %s\n' "$base" "$family"
+  fi
+done
+
+echo
+if [[ "$n" -eq 0 ]]; then
+  echo "No *.json prompts found under $PROMPTS_DIR" >&2
+  exit 1
+fi
+
+echo "Checked $n prompts ($scored scored, $heldout held-out)."
+if [[ "$fail" -eq 0 ]]; then
+  echo "All resolve. ✓"
+else
+  echo "One or more prompts failed to resolve. ✗"
+fi
+exit "$fail"


### PR DESCRIPTION
## What this PR does

This PR adds  a scoring pipeline under `scripts/scoring/` that runs each scored test-prompt through a 2×2×k matrix (Sonnet/Haiku × with/without the installed skill × k reps) under `dontAsk` with a shared tool allow-list, then grades the final answers with a blind Opus judge against the `must/bonus/avoid` rubrics. It produces a per-model lift scorecard (documented in SCORING.md and interpret-stats.md).
