### PR TITLE
Ignore qdrant.tech links in lychee (flaky in CI)

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -3,3 +3,9 @@ https://docs.cursor.com/context/skills
 # skill-test/README.md placeholder URLs (illustrative, not real endpoints)
 https://skills.qdrant.tech/path/to/plugin.zip
 https://skills.qdrant.tech/\.\.\./SKILL.md
+
+# Intermittently fail with "Connection failed" in CI (~50% of runs),
+# likely the site's CDN rate-limiting/blocking GitHub Actions'
+# shared runner IPs
+https://qdrant.tech/
+https://qdrant.tech/documentation/


### PR DESCRIPTION
`qdrant.tech/` and `qdrant.tech/documentation/` intermittently fail link checks with connection errors (~50% of runs), likely the site's CDN rate-limiting/blocking GitHub Actions' shared runner IPs. Adding them to `.lycheeignore` to stop the flaky failures.
