### PR TITLE
Improve verison-upgrade skill

### DIFF
--- a/skills/qdrant-version-upgrade/SKILL.md
+++ b/skills/qdrant-version-upgrade/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qdrant-version-upgrade
-description: "Guidance on how to upgrade your Qdrant version without interrupting the availability of your application and ensuring data integrity."
+description: "Covers upgrading Qdrant server and SDKs without interrupting availability or losing data integrity. Use when someone asks 'how do I upgrade Qdrant', 'can I jump from 1.15 to 1.18', 'rolling upgrade without downtime', 'do I upgrade the client or the server first', 'which SDK version matches my server', 'what should I check before upgrading', or 'something changed after we upgraded'."
 ---
 
 
@@ -19,3 +19,32 @@ Qdrant has the following guarantees about version compatibility:
 - A Qdrant cluster with a replication factor of 2 or higher can be upgraded without downtime by performing a rolling upgrade. This means that you can upgrade one node at a time while the other nodes continue to serve requests. This allows you to maintain availability of your application during the upgrade process. More about replication factor: [Replication factor](https://skills.qdrant.tech/md/documentation/scaling/distributed_deployment/?s=replication-factor)
 
 For managing Qdrant version upgrades in Qdrant Cloud, you can use the [qcloud](https://github.com/qdrant/qcloud-cli) CLI tool.
+
+## Staying Up to Date
+
+Stay up to date with Qdrant releases. Upgrading to newer versions gives you access to the latest bug fixes, security updates, performance improvements, and new features. Regular upgrades also reduce the complexity of future migrations by avoiding large version jumps.
+
+## Pre-Upgrade Checklist
+
+1. Back up first: It's recommended to take a backup or snapshot before updating to allow for rollbacks. If the upgrade fails or you need to revert, you can restore the pre-upgrade snapshot. Qdrant Cloud applies data migrations during upgrades, so there's no live downgrade.
+
+2. It's recommended to run at least 2 CPU cores per node. During upgrades, Qdrant may perform background optimization while still handling regular operations. With only 1 core, these tasks can compete for CPU resources and can significantly slow down the upgrade process.
+
+3. Use replication factor ≥ 2 if you need a zero-downtime rolling upgrade. With a replication factor of 1, the upgrade requires downtime window.
+
+4. Test your client app against the target server version first in a non-prod environment, and check SDK release notes for deprecated/removed methods before switching over.
+
+5. For multi-version jumps, expect to move through each intermediate minor version in sequence (e.g., 1.15→1.16→1.17), with nodes restarting one at a time, and this takes longer than a single-version bump, so plan for it and prefer non-peak hours. Qdrant Cloud automates this chaining for you.
+
+6. Check release notes for default and behavior changes, not just deprecations. Version upgrades may introduce changes to default settings, validation rules, or query behavior that can affect existing workloads even when APIs remain compatible.
+
+## Troubleshooting After an Upgrade
+
+When investigating a bug or unexpected behavior after an upgrade, check the [release notes/changelog](https://github.com/qdrant/qdrant/releases) between the source and target versions for deprecations, default-value changes, and behavior changes that may affect your workload.
+
+## What NOT to Do
+
+- Treat identical absolute scores as an acceptance criterion across versions
+- Read only the target version's notes and skip intermediate minor and patch releases
+- Jump multiple minor versions at once on self-hosted deployments
+- Assume a rolling upgrade finished without confirming that every node reports the target version

--- a/skills/qdrant-version-upgrade/SKILL.md
+++ b/skills/qdrant-version-upgrade/SKILL.md
@@ -3,7 +3,6 @@ name: qdrant-version-upgrade
 description: "Covers upgrading Qdrant server and SDKs without interrupting availability or losing data integrity. Use when someone asks 'how do I upgrade Qdrant', 'can I jump from 1.15 to 1.18', 'rolling upgrade without downtime', 'do I upgrade the client or the server first', 'which SDK version matches my server', 'what should I check before upgrading', or 'something changed after we upgraded'."
 ---
 
-
 # Qdrant Version Upgrade
 
 Qdrant has the following guarantees about version compatibility:
@@ -20,27 +19,34 @@ Qdrant has the following guarantees about version compatibility:
 
 For managing Qdrant version upgrades in Qdrant Cloud, you can use the [qcloud](https://github.com/qdrant/qcloud-cli) CLI tool.
 
-## Staying Up to Date
-
-Stay up to date with Qdrant releases. Upgrading to newer versions gives you access to the latest bug fixes, security updates, performance improvements, and new features. Regular upgrades also reduce the complexity of future migrations by avoiding large version jumps.
-
 ## Pre-Upgrade Checklist
 
-1. Back up first: It's recommended to take a backup or snapshot before updating to allow for rollbacks. If the upgrade fails or you need to revert, you can restore the pre-upgrade snapshot. Qdrant Cloud applies data migrations during upgrades, so there's no live downgrade.
+1. Back up first: It's recommended to take a backup or snapshot before updating to allow for rollbacks. If the upgrade fails or you need to revert, you can restore the pre-upgrade snapshot. Qdrant Cloud applies data migrations during upgrades, so there's no live downgrade. [Snapshots](https://skills.qdrant.tech/md/documentation/snapshots/) [Cloud backups](https://skills.qdrant.tech/md/documentation/cloud/backups/)
 
-2. It's recommended to run at least 2 CPU cores per node. During upgrades, Qdrant may perform background optimization while still handling regular operations. With only 1 core, these tasks can compete for CPU resources and can significantly slow down the upgrade process.
+2. Check [release notes](https://github.com/qdrant/qdrant/releases) for default and behavior changes, not just deprecations. Version upgrades may introduce changes to default settings, validation rules, or query behavior that can affect existing workloads even when APIs remain compatible.
 
-3. Use replication factor ≥ 2 if you need a zero-downtime rolling upgrade. With a replication factor of 1, the upgrade requires downtime window.
+3. Test your client app against the target server version first in a non-prod environment, and check SDK release notes for deprecated/removed methods before switching over.
 
-4. Test your client app against the target server version first in a non-prod environment, and check SDK release notes for deprecated/removed methods before switching over.
+4. It's recommended to run at least 2 CPU cores per node. During upgrades, Qdrant may perform background optimization while still handling regular operations. With only 1 core, these tasks can compete for CPU resources and can significantly slow down the upgrade process.
 
-5. For multi-version jumps, expect to move through each intermediate minor version in sequence (e.g., 1.15→1.16→1.17), with nodes restarting one at a time, and this takes longer than a single-version bump, so plan for it and prefer non-peak hours. Qdrant Cloud automates this chaining for you.
+5. Use a replication factor of 2 or higher if you need a zero-downtime rolling upgrade. With a replication factor of 1, the upgrade requires a downtime window.
 
-6. Check release notes for default and behavior changes, not just deprecations. Version upgrades may introduce changes to default settings, validation rules, or query behavior that can affect existing workloads even when APIs remain compatible.
+## Crossing More Then One Minor Versions
 
-## Troubleshooting After an Upgrade
+Use when: the running version is two or more minor versions behind the target.
 
-When investigating a bug or unexpected behavior after an upgrade, check the [release notes/changelog](https://github.com/qdrant/qdrant/releases) between the source and target versions for deprecations, default-value changes, and behavior changes that may affect your workload.
+- Self-hosted: step through every intermediate minor version, and land on the latest patch of each before moving on. From 1.15 to 1.17, go to the newest 1.16.x first, then 1.17.x. [Upgrading Qdrant](https://skills.qdrant.tech/md/documentation/upgrades/)
+- Each step is its own rolling restart, so the total is a multiple of a single-version upgrade. This takes longer than a single-version bump, so plan for it and prefer non-peak hours.
+- Qdrant Cloud chains the intermediate updates for you, so 1.15.x to 1.17.x is a single action. [Updating Qdrant Cloud clusters](https://skills.qdrant.tech/md/documentation/cloud/cluster-upgrades/)
+- Upgrade on a regular cadence to keep future jumps to one minor version. Regular upgrades also reduce the complexity of future migrations by avoiding large version jumps.
+
+## Troubleshooting Behavior Changes After an Upgrade
+
+Use when: results, scores, or latency look different once the new version is live.
+
+- When investigating a bug or unexpected behavior after an upgrade, check the [release notes/changelog](https://github.com/qdrant/qdrant/releases) between the source and target versions for deprecations, default-value changes, and behavior changes that may affect your workload.
+
+- Compare relative ranking and recall against your pre-upgrade baseline, not absolute score values. Scoring internals can change between versions and still be correct.
 
 ## What NOT to Do
 


### PR DESCRIPTION
## What this PR does

Improves version-upgarde skill which now only gives general information. 

- Improves the description: Use when + Trigger phrases
- Adds a pre-upgarde checklist, describing recommendations and the why behind them/ problems that could emerge. 
- Adds a "troubleshooting after an upgrade" section that prompts the agent to check the changelog in release notes to investigate potential changes and their impact on workloads. 
- Adds What not to do section

## Type

<!-- check one -->
- [ ] new skill
- [x] skill improvement
- [ ] bug fix
- [ ] repo hygiene

## Checklist

<!-- for new/improved skills, check all that apply -->
- [x] `python3 scripts/validate_skills.py` passes
- [x] skill answers "when?" or "why?", not "how?"
- [x] skill navigates to docs, does not duplicate or replace them
- [x] description has `Use when` with 5+ trigger phrases
- [x] leaf skills omit `allowed-tools`, hub skills declare them
- [x] ends with `## What NOT to Do` section
- [x] no code blocks except minimal snippets when absolutely required (reference the docs instead)
- [x] all doc links go to `skills.qdrant.tech/md/documentation/`
- [x] tested with a realistic prompt (paste below or link to eval)

## Test prompt

```
Prompt 1: We're on self-hosted 1.15 and want to get to 1.17. It's a replicated 3-node cluster serving live traffic, and our Python client is pinned to 1.15. Can we jump straight there, what order do we upgrade server vs. client in, and how do we avoid downtime or breaking our stored data?
Answer summary: The agent explained why a direct 1.15 → 1.17 upgrade is not recommended due to storage compatibility guarantees only covering one minor version, and recommended upgrading through intermediate versions with the SDK updated first. It covered zero-downtime rolling upgrades with replication factor ≥2, as well as safeguards including snapshots, resource checks, release notes review, and post-upgrade validation.
```
```
Prompt 2 (from discord): We recently upgraded our Qdrant server from v1.15.5 to v1.18.0 and noticed significant differences in search results for the same queries against the same database. Setup: Collection uses scalar quantization, embedding model ibm-granite/granite-embedding-107m-multilingual, database unchanged between both versions. Observed issues: (1) Score mismatch - same top result in both versions, but different similarity score. (2) Result mismatch - a different query returns a completely different top result depending on version. Could you help us understand if there were any changes in v1.16-v1.18 related to scalar quantization scoring or ranking that could explain this behavior? [CSV of before/after scores per query attached] We didn't touch anything, devops just updated the cluster from 1.15.5 to 1.18.0. No quantile set. Cosine distance.: 
Answer: The agent investigated the search result drift after the upgrade by checking Qdrant release notes and identified quantization/scoring changes as the likely area. It explained that score differences can occur due to changes in scoring internals, that close results may swap positions, and recommended rescoring with oversampling to improve stability. It also suggested validation steps such as checking CPU architecture changes, running exact search, and verifying the upgrade path.
```
