### PR TITLE
Add `--jobs` N to parallelize scoring runs

### DIFF
--- a/SCORING.md
+++ b/SCORING.md
@@ -355,6 +355,13 @@ truncated answer would grade unfairly low and its cost is a floor, not the real
 figure. Keep the cap high enough that legitimate runs never hit it; if several do,
 raise it rather than let clipped runs contaminate the numbers.
 
+The runs are independent, so `run-eval-matrix.sh --jobs N` executes N at a time
+(default 1). Because each run is its own fresh container with a unique id, this
+changes **wall-time only — not results or cost** (same runs, same tokens). Runs
+are API-latency-bound, so 2–3 roughly halves/thirds the generation phase at
+negligible local cost; keep N small (≥4 risks API rate limits). The judge stage
+is unaffected.
+
 Confirm the skill-install step and `--permission-mode dontAsk` work on the pinned
 CLI version before the first scored run — verify an installed skill actually shows
 up in the `init` skill list, **and that the allow-listed tools are not denied**

--- a/SCORING.md
+++ b/SCORING.md
@@ -356,11 +356,13 @@ figure. Keep the cap high enough that legitimate runs never hit it; if several d
 raise it rather than let clipped runs contaminate the numbers.
 
 The runs are independent, so `run-eval-matrix.sh --jobs N` executes N at a time
-(default 1). Because each run is its own fresh container with a unique id, this
-changes **wall-time only — not results or cost** (same runs, same tokens). Runs
-are API-latency-bound, so 2–3 roughly halves/thirds the generation phase at
-negligible local cost; keep N small (≥4 risks API rate limits). The judge stage
-is unaffected.
+(default 1). Each run is its own fresh container with a unique per-invocation id,
+so at the recommended **2–3** concurrency this changes **wall-time only — not
+results or cost** (same runs, same tokens). Runs are API-latency-bound, so 2–3
+roughly halves/thirds the generation phase at negligible local cost. Do not push
+it higher: at ≥4 you risk API rate limits, and a rate-limited run *can* change
+results — so the wall-time-only guarantee holds only in the 2–3 range. The judge
+stage is unaffected.
 
 Confirm the skill-install step and `--permission-mode dontAsk` work on the pinned
 CLI version before the first scored run — verify an installed skill actually shows

--- a/scripts/scoring/run-eval-matrix.sh
+++ b/scripts/scoring/run-eval-matrix.sh
@@ -42,8 +42,7 @@ MAX_BUDGET_USD="2.00"
 DRY_RUN="0"
 LIMIT="0"
 # Concurrent runs. Runs are API-latency-bound, so 2-3 roughly halves/thirds
-# wall-time at negligible local cost. It does NOT change results or spend — only
-# wall-time. Keep small: >=4 risks hitting API rate limits.
+# wall-time at negligible local cost. Keep small: >=4 risks hitting API rate limits.
 JOBS="1"
 DATE_TAG="$(date -u +%Y%m%d)"
 

--- a/scripts/scoring/run-eval-matrix.sh
+++ b/scripts/scoring/run-eval-matrix.sh
@@ -42,7 +42,8 @@ MAX_BUDGET_USD="2.00"
 DRY_RUN="0"
 LIMIT="0"
 # Concurrent runs. Runs are API-latency-bound, so 2-3 roughly halves/thirds
-# wall-time at negligible local cost. Keep small: >=4 risks hitting API rate limits.
+# wall-time at negligible local cost. It does NOT change results or spend — only
+# wall-time. Keep small: >=4 risks hitting API rate limits.
 JOBS="1"
 DATE_TAG="$(date -u +%Y%m%d)"
 # Stamped once per invocation. Appended to each run id so ids are deterministic
@@ -158,16 +159,19 @@ echo
 
 # Each task writes its manifest row to its own file here; they are concatenated
 # (sorted) into manifest.csv after all workers finish, so concurrent writes never
-# race on a single file. Worker skill-staging dirs live under STAGE_BASE so an
-# interrupt can clean them up in one sweep.
-MANIFEST_DIR="$OUT_DIR/.manifest.d"
-STAGE_BASE="$OUT_DIR/.stage"
+# race on a single file. The dir is stamped per invocation so two overlapping runs
+# into the same out-dir never clobber each other's rows (and so it's never stale —
+# no destructive startup cleanup needed).
+MANIFEST_DIR="$OUT_DIR/.manifest.d-$RUN_STAMP"
+# Worker skill-staging dirs live under a per-invocation temp base (NOT under
+# $OUT_DIR): staging is the bind-mount source for --skills-dir, so keeping it out
+# of the shared out-dir means a sibling run can't yank it from a live container.
+# Set only for real runs; cleaned by the trap / at the end.
+STAGE_BASE=""
 
 if [[ "$DRY_RUN" != "1" ]]; then
-  # Start from a clean slate: stale .row files from an interrupted prior run must
-  # not leak into this run's manifest.
-  rm -rf "$MANIFEST_DIR" "$STAGE_BASE"
-  mkdir -p "$OUT_DIR" "$MANIFEST_DIR" "$STAGE_BASE"
+  STAGE_BASE="$(mktemp -d "${TMPDIR:-/tmp}/skill-eval-stage.XXXXXX")"
+  mkdir -p "$OUT_DIR" "$MANIFEST_DIR"
   if [[ ! -f "$MANIFEST" ]]; then
     echo "prompt,skill_family,skill_leaf,model,condition,rep,run_id,exit_code,skills_sha,timestamp" > "$MANIFEST"
   fi
@@ -205,6 +209,18 @@ run_one() {
   # run's transcript or double-counts its manifest row.
   local run_id
   run_id="$(printf '%s' "$name-$model-$condition-r$rep-$RUN_STAMP" | tr -c 'A-Za-z0-9._-' '_')"
+  # The harness requires the id to start with a letter/digit (Docker's --name
+  # rule); slugify keeps a leading -/. so guard it here.
+  [[ "$run_id" =~ ^[A-Za-z0-9] ]] || run_id="r-$run_id"
+
+  # Dry-run needs only $family for the printout — return before any staging so no
+  # mktemp/cp runs (STAGE_BASE isn't even created in dry mode).
+  if [[ "$DRY_RUN" == "1" ]]; then
+    printf '  DRY  %-42s %-7s %-11s rep=%s  install=%s\n' \
+      "$name" "$model" "$condition" "$rep" \
+      "$([[ "$condition" == with-skill ]] && echo "$family" || echo none)"
+    return 0
+  fi
 
   local stage=""
   if [[ "$condition" == "with-skill" ]]; then
@@ -219,14 +235,6 @@ run_one() {
 
   local ts exit_code tmplog
   ts="$(date -u +%Y%m%dT%H%M%SZ)"
-
-  if [[ "$DRY_RUN" == "1" ]]; then
-    printf '  DRY  %-42s %-7s %-11s rep=%s  install=%s\n' \
-      "$name" "$model" "$condition" "$rep" \
-      "$([[ "$condition" == with-skill ]] && echo "$family" || echo none)"
-    [[ -n "$stage" ]] && rm -rf "$stage"
-    return 0
-  fi
 
   # Capture harness output per-task so parallel workers don't interleave on the
   # console; keep it as a diagnostic if the run failed, discard it otherwise.
@@ -287,7 +295,15 @@ cleanup_interrupt() {
   local p
   for p in "${pids[@]:-}"; do [[ -n "$p" ]] && kill_tree "$p"; done
   wait 2>/dev/null || true
-  rm -rf "$MANIFEST_DIR" "$STAGE_BASE"
+  # Completed runs already cost API spend — keep their rows so the partial matrix
+  # can still be extracted/judged/topped-up (matches pre-parallelism behavior).
+  if compgen -G "$MANIFEST_DIR/*.row" >/dev/null 2>&1; then
+    local n; n="$(find "$MANIFEST_DIR" -name '*.row' | wc -l | tr -d ' ')"
+    cat "$MANIFEST_DIR"/*.row | sort >> "$MANIFEST"
+    echo "Kept $n completed run(s) in $MANIFEST" >&2
+  fi
+  rm -rf "$MANIFEST_DIR"
+  [[ -n "$STAGE_BASE" ]] && rm -rf "$STAGE_BASE"
   exit 130
 }
 trap cleanup_interrupt INT TERM

--- a/scripts/scoring/run-eval-matrix.sh
+++ b/scripts/scoring/run-eval-matrix.sh
@@ -46,6 +46,11 @@ LIMIT="0"
 # wall-time. Keep small: >=4 risks hitting API rate limits.
 JOBS="1"
 DATE_TAG="$(date -u +%Y%m%d)"
+# Stamped once per invocation. Appended to each run id so ids are deterministic
+# *within* a run but unique *across* invocations — re-running (e.g. after a
+# partial failure) into the same out-dir can't clobber a prior run's transcript
+# or double-count its manifest rows.
+RUN_STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 
 usage() {
   cat <<'USAGE'
@@ -154,11 +159,16 @@ echo
 
 # Each task writes its manifest row to its own file here; they are concatenated
 # (sorted) into manifest.csv after all workers finish, so concurrent writes never
-# race on a single file.
+# race on a single file. Worker skill-staging dirs live under STAGE_BASE so an
+# interrupt can clean them up in one sweep.
 MANIFEST_DIR="$OUT_DIR/.manifest.d"
+STAGE_BASE="$OUT_DIR/.stage"
 
 if [[ "$DRY_RUN" != "1" ]]; then
-  mkdir -p "$OUT_DIR" "$MANIFEST_DIR"
+  # Start from a clean slate: stale .row files from an interrupted prior run must
+  # not leak into this run's manifest.
+  rm -rf "$MANIFEST_DIR" "$STAGE_BASE"
+  mkdir -p "$OUT_DIR" "$MANIFEST_DIR" "$STAGE_BASE"
   if [[ ! -f "$MANIFEST" ]]; then
     echo "prompt,skill_family,skill_leaf,model,condition,rep,run_id,exit_code,skills_sha,timestamp" > "$MANIFEST"
   fi
@@ -190,18 +200,22 @@ run_one() {
   [[ -n "$ALLOWED_TOOLS" ]] && args+=(--extra-args "--allowedTools $ALLOWED_TOOLS --")
   [[ -n "$MAX_BUDGET_USD" ]] && args+=(--max-budget-usd "$MAX_BUDGET_USD")
 
+  # Descriptive, unique-per-invocation run id. Slugified so an odd char in the
+  # prompt .name (space, :, /) can't reach --run-id raw; RUN_STAMP makes it unique
+  # across invocations so a re-run into the same out-dir never clobbers a prior
+  # run's transcript or double-counts its manifest row.
+  local run_id
+  run_id="$(printf '%s' "$name-$model-$condition-r$rep-$RUN_STAMP" | tr -c 'A-Za-z0-9._-' '_')"
+
   local stage=""
   if [[ "$condition" == "with-skill" ]]; then
-    stage="$(mktemp -d)"
+    stage="$(mktemp -d "$STAGE_BASE/stage.XXXXXX")"
     # Copy the whole family subtree under its real name so progressive-disclosure
     # relative links resolve and the container installs it as ~/.claude/skills/<family>.
     cp -R "$SKILLS_ROOT/$family" "$stage/$family"
     args+=(--skills-dir "$stage")
   fi
 
-  # Descriptive, unique-per-task run id — passed to the harness via --run-id so
-  # concurrent runs never share a dir or Docker --name. All chars are safe.
-  local run_id="$name-$model-$condition-r$rep"
   args+=(--run-id "$run_id")
 
   local ts exit_code tmplog
@@ -215,20 +229,27 @@ run_one() {
     return 0
   fi
 
-  # Capture harness output per-task so parallel workers don't interleave on the console.
+  # Capture harness output per-task so parallel workers don't interleave on the
+  # console; keep it as a diagnostic if the run failed, discard it otherwise.
   tmplog="$(mktemp)"
   set +e
   "$HARNESS" "${args[@]}" "$prompt_file" >"$tmplog" 2>&1
   exit_code=$?
   set -e
-  rm -f "$tmplog"
+  if [[ "$exit_code" -ne 0 ]]; then
+    mv "$tmplog" "$OUT_DIR/$run_id.harness.log"
+  else
+    rm -f "$tmplog"
+  fi
   [[ -n "$stage" ]] && rm -rf "$stage"
 
   # One row per task, written to its own file — concatenated after the pool drains.
   echo "$name,$family,$leaf,$model,$condition,$rep,$run_id,$exit_code,$skills_sha,$ts" \
     > "$MANIFEST_DIR/$run_id.row"
-  printf '  ok   %-42s %-7s %-11s rep=%s  run_id=%s exit=%s\n' \
-    "$name" "$model" "$condition" "$rep" "$run_id" "$exit_code"
+  local status_word="ok  "
+  [[ "$exit_code" -ne 0 ]] && status_word="FAIL"
+  printf '  %s %-42s %-7s %-11s rep=%s  run_id=%s exit=%s\n' \
+    "$status_word" "$name" "$model" "$condition" "$rep" "$run_id" "$exit_code"
   return 0
 }
 
@@ -247,6 +268,31 @@ done
 # Rolling PID pool: keep up to $JOBS workers in flight (bash 3.2-safe — no
 # `wait -n`). Poll for any finished worker before launching the next.
 pids=()
+
+# Recursively SIGTERM a process and all its descendants (children first). A worker
+# subshell has a harness child which in turn has a `docker run` child; killing only
+# the tracked worker pid would orphan those, so walk the whole tree. SIGTERM (not
+# KILL) lets `docker run` forward the signal so its `--rm` container stops cleanly.
+kill_tree() {
+  local pid="$1" child
+  for child in $(pgrep -P "$pid" 2>/dev/null); do kill_tree "$child"; done
+  kill "$pid" 2>/dev/null || true
+}
+
+# On Ctrl-C / termination, stop the whole pool and clear temp state rather than
+# leaving orphaned workers, containers, and half-written temp dirs.
+cleanup_interrupt() {
+  trap - INT TERM
+  echo >&2
+  echo "Interrupted — stopping workers and cleaning up..." >&2
+  local p
+  for p in "${pids[@]:-}"; do [[ -n "$p" ]] && kill_tree "$p"; done
+  wait 2>/dev/null || true
+  rm -rf "$MANIFEST_DIR" "$STAGE_BASE"
+  exit 130
+}
+trap cleanup_interrupt INT TERM
+
 reap_one() {
   while :; do
     local i
@@ -275,10 +321,11 @@ done
 
 # Assemble the manifest from per-task rows in a deterministic order.
 if [[ "$DRY_RUN" != "1" ]]; then
+  trap - INT TERM
   if compgen -G "$MANIFEST_DIR/*.row" >/dev/null; then
     cat "$MANIFEST_DIR"/*.row | sort >> "$MANIFEST"
   fi
-  rm -rf "$MANIFEST_DIR"
+  rm -rf "$MANIFEST_DIR" "$STAGE_BASE"
 fi
 
 echo

--- a/scripts/scoring/run-eval-matrix.sh
+++ b/scripts/scoring/run-eval-matrix.sh
@@ -41,9 +41,10 @@ MAX_TURNS="20"
 MAX_BUDGET_USD="2.00"
 DRY_RUN="0"
 LIMIT="0"
-# Concurrent runs. Runs are API-latency-bound, so 2-3 roughly halves/thirds
-# wall-time at negligible local cost. It does NOT change results or spend — only
-# wall-time. Keep small: >=4 risks hitting API rate limits.
+# Concurrent runs. At the recommended 2-3, runs are API-latency-bound, so this
+# roughly halves/thirds wall-time at negligible local cost and does NOT change
+# results or spend. Do not go higher: >=4 risks API rate limits, and a
+# rate-limited run can change results.
 JOBS="1"
 DATE_TAG="$(date -u +%Y%m%d)"
 # Stamped once per invocation. Appended to each run id so ids are deterministic
@@ -63,8 +64,9 @@ Options:
   --conditions LIST     Comma list of no-skill,with-skill. Default: both
   --reps N              Repetitions per cell. Default: 2
   --jobs N              Runs to execute concurrently. Default: 1 (sequential).
-                        Changes wall-time only, not results or cost; 2-3 is the
-                        sweet spot, >=4 risks API rate limits.
+                        At the recommended 2-3, changes wall-time only, not
+                        results or cost; >=4 risks API rate limits (which can
+                        change results).
   --prompts-dir DIR     Test-prompt JSONs. Default: ../skills/evals/test-prompts
   --skills-root DIR     Skills root for staging. Default: ../skills/skills
   --out-dir DIR         Weekly output dir. Default: runs/weekly/<UTC-date>

--- a/scripts/scoring/run-eval-matrix.sh
+++ b/scripts/scoring/run-eval-matrix.sh
@@ -41,6 +41,10 @@ MAX_TURNS="20"
 MAX_BUDGET_USD="2.00"
 DRY_RUN="0"
 LIMIT="0"
+# Concurrent runs. Runs are API-latency-bound, so 2-3 roughly halves/thirds
+# wall-time at negligible local cost. It does NOT change results or spend — only
+# wall-time. Keep small: >=4 risks hitting API rate limits.
+JOBS="1"
 DATE_TAG="$(date -u +%Y%m%d)"
 
 usage() {
@@ -53,6 +57,9 @@ Options:
   --models LIST         Comma list of models. Default: sonnet,haiku
   --conditions LIST     Comma list of no-skill,with-skill. Default: both
   --reps N              Repetitions per cell. Default: 2
+  --jobs N              Runs to execute concurrently. Default: 1 (sequential).
+                        Changes wall-time only, not results or cost; 2-3 is the
+                        sweet spot, >=4 risks API rate limits.
   --prompts-dir DIR     Test-prompt JSONs. Default: ../skills/evals/test-prompts
   --skills-root DIR     Skills root for staging. Default: ../skills/skills
   --out-dir DIR         Weekly output dir. Default: runs/weekly/<UTC-date>
@@ -74,6 +81,7 @@ while [[ $# -gt 0 ]]; do
     --models) MODELS="${2:?}"; shift 2 ;;
     --conditions) CONDITIONS="${2:?}"; shift 2 ;;
     --reps) REPS="${2:?}"; shift 2 ;;
+    --jobs) JOBS="${2:?}"; shift 2 ;;
     --prompts-dir) PROMPTS_DIR="${2:?}"; shift 2 ;;
     --skills-root) SKILLS_ROOT="${2:?}"; shift 2 ;;
     --out-dir) OUT_DIR="${2:?}"; shift 2 ;;
@@ -92,6 +100,11 @@ done
 
 [[ -d "$PROMPTS_DIR" ]] || { echo "Prompts dir not found: $PROMPTS_DIR" >&2; exit 66; }
 [[ -d "$SKILLS_ROOT" ]] || { echo "Skills root not found: $SKILLS_ROOT" >&2; exit 66; }
+
+[[ "$JOBS" =~ ^[1-9][0-9]*$ ]] || { echo "Invalid --jobs '$JOBS' (want a positive integer)" >&2; exit 64; }
+if [[ "$JOBS" -ge 4 ]]; then
+  echo "Warning: --jobs $JOBS — high concurrency may hit API rate limits; 2-3 is the sweet spot." >&2
+fi
 
 if [[ -z "$OUT_DIR" ]]; then
   OUT_DIR="$REPO_ROOT/evals/weekly/$DATE_TAG"
@@ -134,12 +147,18 @@ echo "  reps:       $REPS"
 echo "  prompts:    $n_prompts scored"
 echo "  skills_sha: $skills_sha"
 echo "  total runs: $total"
+echo "  jobs:       $JOBS concurrent"
 echo "  mode:       $PERMISSION_MODE  max-turns: $MAX_TURNS  budget: ${MAX_BUDGET_USD:-none}"
 echo "  allowed:    ${ALLOWED_TOOLS:-<none>}"
 echo
 
+# Each task writes its manifest row to its own file here; they are concatenated
+# (sorted) into manifest.csv after all workers finish, so concurrent writes never
+# race on a single file.
+MANIFEST_DIR="$OUT_DIR/.manifest.d"
+
 if [[ "$DRY_RUN" != "1" ]]; then
-  mkdir -p "$OUT_DIR"
+  mkdir -p "$OUT_DIR" "$MANIFEST_DIR"
   if [[ ! -f "$MANIFEST" ]]; then
     echo "prompt,skill_family,skill_leaf,model,condition,rep,run_id,exit_code,skills_sha,timestamp" > "$MANIFEST"
   fi
@@ -180,7 +199,12 @@ run_one() {
     args+=(--skills-dir "$stage")
   fi
 
-  local ts run_id exit_code tmplog
+  # Descriptive, unique-per-task run id — passed to the harness via --run-id so
+  # concurrent runs never share a dir or Docker --name. All chars are safe.
+  local run_id="$name-$model-$condition-r$rep"
+  args+=(--run-id "$run_id")
+
+  local ts exit_code tmplog
   ts="$(date -u +%Y%m%dT%H%M%SZ)"
 
   if [[ "$DRY_RUN" == "1" ]]; then
@@ -191,31 +215,71 @@ run_one() {
     return 0
   fi
 
+  # Capture harness output per-task so parallel workers don't interleave on the console.
   tmplog="$(mktemp)"
   set +e
   "$HARNESS" "${args[@]}" "$prompt_file" >"$tmplog" 2>&1
   exit_code=$?
   set -e
-
-  run_id="$(grep -o 'Starting Claude Code test: [^ ]*' "$tmplog" | tail -1 | awk '{print $NF}')"
-  [[ -n "$run_id" ]] || run_id="MISSING-$ts"
   rm -f "$tmplog"
   [[ -n "$stage" ]] && rm -rf "$stage"
 
-  echo "$name,$family,$leaf,$model,$condition,$rep,$run_id,$exit_code,$skills_sha,$ts" >> "$MANIFEST"
+  # One row per task, written to its own file — concatenated after the pool drains.
+  echo "$name,$family,$leaf,$model,$condition,$rep,$run_id,$exit_code,$skills_sha,$ts" \
+    > "$MANIFEST_DIR/$run_id.row"
   printf '  ok   %-42s %-7s %-11s rep=%s  run_id=%s exit=%s\n' \
     "$name" "$model" "$condition" "$rep" "$run_id" "$exit_code"
+  return 0
 }
 
+# Build the flat task list (prompt × model × condition × rep).
+tasks=()
 for prompt_file in "${PROMPTS[@]}"; do
   for model in "${MODEL_ARR[@]}"; do
     for condition in "${COND_ARR[@]}"; do
       for ((rep = 1; rep <= REPS; rep++)); do
-        run_one "$prompt_file" "$model" "$condition" "$rep" || true
+        tasks+=("$prompt_file"$'\t'"$model"$'\t'"$condition"$'\t'"$rep")
       done
     done
   done
 done
+
+# Rolling PID pool: keep up to $JOBS workers in flight (bash 3.2-safe — no
+# `wait -n`). Poll for any finished worker before launching the next.
+pids=()
+reap_one() {
+  while :; do
+    local i
+    for i in "${!pids[@]}"; do
+      if ! kill -0 "${pids[$i]}" 2>/dev/null; then
+        wait "${pids[$i]}" 2>/dev/null || true
+        unset 'pids[$i]'
+        return 0
+      fi
+    done
+    sleep 1
+  done
+}
+
+for task in "${tasks[@]}"; do
+  IFS=$'\t' read -r tf tm tc tr <<< "$task"
+  if [[ "$JOBS" -le 1 || "$DRY_RUN" == "1" ]]; then
+    run_one "$tf" "$tm" "$tc" "$tr" || true
+  else
+    (( ${#pids[@]} >= JOBS )) && reap_one
+    run_one "$tf" "$tm" "$tc" "$tr" &
+    pids+=("$!")
+  fi
+done
+[[ "$JOBS" -gt 1 && "$DRY_RUN" != "1" ]] && wait
+
+# Assemble the manifest from per-task rows in a deterministic order.
+if [[ "$DRY_RUN" != "1" ]]; then
+  if compgen -G "$MANIFEST_DIR/*.row" >/dev/null; then
+    cat "$MANIFEST_DIR"/*.row | sort >> "$MANIFEST"
+  fi
+  rm -rf "$MANIFEST_DIR"
+fi
 
 echo
 if [[ "$DRY_RUN" == "1" ]]; then

--- a/skill-test/README.md
+++ b/skill-test/README.md
@@ -285,10 +285,11 @@ to set it explicitly instead:
 scripts/run-claude-test.sh --run-id my-unique-id prompts/qdrant-smoke.md
 ```
 
-`ID` must be filesystem/Docker-safe (letters, digits, `.`, `_`, `-`). This lets a
-batch runner give each run a unique, descriptive id so that **concurrent** runs
-never collide on a directory or a Docker `--name` (two runs of the same prompt in
-the same second would otherwise clash).
+`ID` must start with a letter or digit, then letters, digits, `.`, `_`, `-`
+(Docker's `--name` rule). This lets a batch runner give each run a unique,
+descriptive id so that **concurrent** runs never collide on a directory or a
+Docker `--name` (two runs of the same prompt in the same second would otherwise
+clash).
 
 For tests that intentionally need Claude Code to execute commands or edit a
 throwaway workspace, use a disposable workspace and pass a more permissive mode,

--- a/skill-test/README.md
+++ b/skill-test/README.md
@@ -277,6 +277,19 @@ total, since there is no user to approve a fallback prompt. A test that repeated
 attempts out-of-scope actions can therefore end early, where `dontAsk` would
 deny each call and let the run continue to completion.
 
+By default the run id (the `runs/<id>/` directory name and the Docker container
+`--name`) is derived from the timestamp and the prompt name. Pass `--run-id ID`
+to set it explicitly instead:
+
+```bash
+scripts/run-claude-test.sh --run-id my-unique-id prompts/qdrant-smoke.md
+```
+
+`ID` must be filesystem/Docker-safe (letters, digits, `.`, `_`, `-`). This lets a
+batch runner give each run a unique, descriptive id so that **concurrent** runs
+never collide on a directory or a Docker `--name` (two runs of the same prompt in
+the same second would otherwise clash).
+
 For tests that intentionally need Claude Code to execute commands or edit a
 throwaway workspace, use a disposable workspace and pass a more permissive mode,
 for example:

--- a/skill-test/scripts/run-claude-test.sh
+++ b/skill-test/scripts/run-claude-test.sh
@@ -20,6 +20,7 @@ PERMISSION_MODE="auto"
 MAX_TURNS="20"
 MODEL=""
 MAX_BUDGET_USD=""
+RUN_ID=""
 BUILD_IMAGE="0"
 CLAUDE_CODE_VERSION="${CLAUDE_CODE_VERSION:-latest}"
 CLAUDE_EXTRA_ARGS="${CLAUDE_EXTRA_ARGS:-}"
@@ -57,6 +58,10 @@ Options:
   --model MODEL                Pass --model to Claude Code.
   --choose-model               Interactively choose a model from a menu.
   --max-budget-usd USD         Stop once this print-mode budget is reached.
+  --run-id ID                  Use this exact run id (dir name + Docker --name) instead of
+                               deriving one from the timestamp and prompt name. Must be
+                               filesystem/Docker-safe (letters, digits, . _ -). Lets a
+                               parallel batch runner give each concurrent run a unique id.
   --extra-args "ARGS"          Advanced Claude Code flags passed through by the container.
   --allow-missing-auth         Skip local auth preflight checks.
   --no-render                  Do not generate readable.md after the run.
@@ -236,6 +241,11 @@ while [[ $# -gt 0 ]]; do
       MAX_BUDGET_USD="$2"
       shift 2
       ;;
+    --run-id)
+      require_value "$1" "${2:-}"
+      RUN_ID="$2"
+      shift 2
+      ;;
     --extra-args)
       require_value "$1" "${2:-}"
       CLAUDE_EXTRA_ARGS="$2"
@@ -346,21 +356,32 @@ if [[ "$BUILD_IMAGE" == "1" ]]; then
     --claude-code-version "$CLAUDE_CODE_VERSION"
 fi
 
-if [[ -n "$TEST_PROMPT_JSON" ]]; then
-  # Prefer the test-prompt's canonical .name over the file name so the run id
-  # tracks the test even if the file is renamed. Fall back to the file name if
-  # .name is missing or empty.
-  prompt_base="$(jq -r 'if (.name | type == "string") and (.name | length > 0) then .name else empty end' "$TEST_PROMPT_JSON")"
-  if [[ -z "$prompt_base" ]]; then
+if [[ -n "$RUN_ID" ]]; then
+  # Caller-supplied run id (e.g. a parallel batch runner assigning a unique,
+  # descriptive id per task so concurrent runs never share a dir or Docker
+  # --name). Must be filesystem/Docker-name safe: letters, digits, ., _, - only.
+  if [[ ! "$RUN_ID" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "Invalid --run-id '$RUN_ID' (allowed: letters, digits, . _ -)" >&2
+    exit 64
+  fi
+  run_id="$RUN_ID"
+else
+  if [[ -n "$TEST_PROMPT_JSON" ]]; then
+    # Prefer the test-prompt's canonical .name over the file name so the run id
+    # tracks the test even if the file is renamed. Fall back to the file name if
+    # .name is missing or empty.
+    prompt_base="$(jq -r 'if (.name | type == "string") and (.name | length > 0) then .name else empty end' "$TEST_PROMPT_JSON")"
+    if [[ -z "$prompt_base" ]]; then
+      prompt_base="$(basename "$PROMPT_SOURCE_PATH")"
+      prompt_base="${prompt_base%.*}"
+    fi
+  else
     prompt_base="$(basename "$PROMPT_SOURCE_PATH")"
     prompt_base="${prompt_base%.*}"
   fi
-else
-  prompt_base="$(basename "$PROMPT_SOURCE_PATH")"
-  prompt_base="${prompt_base%.*}"
+  prompt_slug="$(printf '%s' "$prompt_base" | tr -c 'A-Za-z0-9._-' '_')"
+  run_id="$(date -u +%Y%m%dT%H%M%SZ)-$prompt_slug"
 fi
-prompt_slug="$(printf '%s' "$prompt_base" | tr -c 'A-Za-z0-9._-' '_')"
-run_id="$(date -u +%Y%m%dT%H%M%SZ)-$prompt_slug"
 
 plugin_urls_joined=""
 if [[ "${#PLUGIN_URLS[@]}" -gt 0 ]]; then

--- a/skill-test/scripts/run-claude-test.sh
+++ b/skill-test/scripts/run-claude-test.sh
@@ -59,9 +59,10 @@ Options:
   --choose-model               Interactively choose a model from a menu.
   --max-budget-usd USD         Stop once this print-mode budget is reached.
   --run-id ID                  Use this exact run id (dir name + Docker --name) instead of
-                               deriving one from the timestamp and prompt name. Must be
-                               filesystem/Docker-safe (letters, digits, . _ -). Lets a
-                               parallel batch runner give each concurrent run a unique id.
+                               deriving one from the timestamp and prompt name. Must start
+                               with a letter/digit, then letters, digits, . _ - (Docker's
+                               --name rule). Lets a parallel batch runner give each
+                               concurrent run a unique id.
   --extra-args "ARGS"          Advanced Claude Code flags passed through by the container.
   --allow-missing-auth         Skip local auth preflight checks.
   --no-render                  Do not generate readable.md after the run.
@@ -360,8 +361,10 @@ if [[ -n "$RUN_ID" ]]; then
   # Caller-supplied run id (e.g. a parallel batch runner assigning a unique,
   # descriptive id per task so concurrent runs never share a dir or Docker
   # --name). Must be filesystem/Docker-name safe: letters, digits, ., _, - only.
-  if [[ ! "$RUN_ID" =~ ^[A-Za-z0-9._-]+$ ]]; then
-    echo "Invalid --run-id '$RUN_ID' (allowed: letters, digits, . _ -)" >&2
+  # Must start with a letter or digit (Docker's --name rule) and contain only
+  # safe chars. Rejects a leading -/., and `..` path traversal.
+  if [[ ! "$RUN_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+    echo "Invalid --run-id '$RUN_ID' (must start with a letter/digit; allowed: letters, digits, . _ -)" >&2
     exit 64
   fi
   run_id="$RUN_ID"


### PR DESCRIPTION
## What this PR does

This PR adds an opttional `--jobs N` flag to `run-eval-matrix.sh` (default is `1`  which is the original, not-parallel run behavior) that runs N test prompts at a time via a bash-3.2-safe rolling pool. It roughly halves/thirds the runtime at 2–3 concurrent. It changes wall-time only — not results or cost (same runs, same tokens); the judge stage is untouched.