### PR TITLE
Update hybrid search 

### DIFF
--- a/evals/test-prompts/qdrant-hybrid-search.json
+++ b/evals/test-prompts/qdrant-hybrid-search.json
@@ -6,11 +6,11 @@
   "rubric": [
     {
       "type": "must",
-      "text": "Notes that on Qdrant 1.19+ the `idf` search param can scope IDF statistics to a payload-filtered corpus (e.g. tenant_id), giving per-tenant term statistics without shard-level partitioning"
+      "text": "Notes that on Qdrant 1.19 or newer the `idf` search param can scope IDF statistics to a payload-filtered corpus (e.g. tenant_id), giving per-tenant term statistics without shard-level partitioning"
     },
     {
       "type": "must",
-      "text": "Notes that on version 1.18 and older, IDF statistics are not tenant-isolated; they are computed per shard, which absolutely can contaminate tenant A's statistics with tenant B's data in a multi-tenant collection"
+      "text": "Notes that on version 1.18 and older, IDF statistics are not tenant-isolated; they are computed per shard, which can contaminate tenant A's statistics with tenant B's data in a multi-tenant collection"
     },
     {
       "type": "must",
@@ -23,6 +23,10 @@
     {
       "type": "bonus",
       "text": "Notes that using the `idf` parameter on a vector without the IDF modifier returns an error"
+    },
+    {
+      "type": "bonus",
+      "text": "Notes prefetch runs per shard (limit x #shards retrieved under the hood, then merged by score)"
     },
     {
       "type": "bonus",

--- a/evals/test-prompts/qdrant-hybrid-search.json
+++ b/evals/test-prompts/qdrant-hybrid-search.json
@@ -6,11 +6,15 @@
   "rubric": [
     {
       "type": "must",
-      "text": "States that sparse/payload/dense indexes and the IDF modifier are computed per shard, not per tenant"
+      "text": "Notes that on Qdrant 1.19+ the `idf` search param can scope IDF statistics to a payload-filtered corpus (e.g. tenant_id), giving per-tenant term statistics without shard-level partitioning"
     },
     {
       "type": "must",
-      "text": "Concludes that in a shared collection term statistics are not tenant-isolated by default (the customer's concern is valid)"
+      "text": "Notes that on version 1.18 and older, IDF statistics are not tenant-isolated; they are computed per shard, which absolutely can contaminate tenant A's statistics with tenant B's data in a multi-tenant collection"
+    },
+    {
+      "type": "must",
+      "text": "Indicates that if you are on version 1.19 or above and wish to use per-tenant IDF statistics, the tenant field has to be indexed"
     },
     {
       "type": "must",
@@ -18,15 +22,23 @@
     },
     {
       "type": "bonus",
-      "text": "Notes prefetch runs per shard (limit x #shards retrieved under the hood, then merged by score)"
+      "text": "Notes that using the `idf` parameter on a vector without the IDF modifier returns an error"
     },
     {
       "type": "bonus",
-      "text": "Points toward shard-level partitioning (e.g. a shard key per tenant) if true statistical isolation is required"
+      "text": "Notes that if the corpus filter matches no points, IDF statistics do not fall back to shard-wide statistics. Instead, every term gets the same constant weight, so ranking degenerates to plain TF with no rarity signal."
+    },
+    {
+      "type": "bonus",
+      "text": "Recommends version upgrade to 1.19+"
+    },
+    {
+      "type": "bonus",
+      "text": "Points toward shard-level partitioning (e.g. a shard key per tenant) as the alternative when running 1.18 or older, or when isolation beyond term statistics is required"
     },
     {
       "type": "avoid",
-      "text": "Claims Qdrant isolates IDF / term statistics per tenant automatically"
+      "text": "Presents shard-key partitioning as the only way to isolate term statistics, without mentioning the 1.19+ scoped `idf` search param"
     }
   ]
 }

--- a/skills/qdrant-search-quality/search-strategies/hybrid-search/SKILL.md
+++ b/skills/qdrant-search-quality/search-strategies/hybrid-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qdrant-hybrid-search
-description: "Explains hybrid search in Qdrant. Use when someone asks 'how do I setup hybrid search?', 'how to combine keyword and semantic search?', 'sparse plus dense vectors?', 'missing keyword matches', 'how to combine results from multiple searches?' and 'combining multiple representations'"
+description: "Explains hybrid search in Qdrant. Use when someone asks 'how do I setup hybrid search?', 'how to combine keyword and semantic search?', 'sparse plus dense vectors?', 'missing keyword matches', 'how to combine results from multiple searches?' and 'combining multiple representations'. Also use for how a hybrid query is scoped: 'how is IDF scoped?', 'can one tenant's data contaminate another tenant's scoring?'"
 allowed-tools:
   - Read
   - Grep

--- a/skills/qdrant-search-quality/search-strategies/hybrid-search/search-types/SKILL.md
+++ b/skills/qdrant-search-quality/search-strategies/hybrid-search/search-types/SKILL.md
@@ -30,6 +30,7 @@ Most likely you need a sparse vector for exact text search alongside the dense o
 
 What to remember when using sparse vectors for lexical search:
 - tokenization and stemming affect exact matches, especially on custom codes, terms, etc.
+- IDF statistics are computed over a corpus. On Qdrant 1.18 and older that corpus is the data in the whole shard being queried, which distorts scoring in multi-tenant collections: tenants with different vocabularies get merged into one statistic, so a term's IDF no longer reflects how rare it is inside either tenant's data. On 1.19+ you can narrow the corpus the statistics are computed over down to a single tenant, so IDF reflects term rarity within that tenant. See [Per-tenant IDF statistics](https://skills.qdrant.tech/md/documentation/manage-data/multitenancy/?s=per-tenant-idf-statistics).
 
 What to remember when using Qdrant BM25 and miniCOIL (based on BM25):
 - `avg_len` in formula is not computed server-side, it is a user responsibility and passed as a parameter. Calibrate per field — defaults assume document-length text; short fields (titles, tags) need a much smaller value or BM25 scoring is skewed (`avg_len=256` against a 10-word title overweights term frequency).


### PR DESCRIPTION
## What this PR does

Sparse vector IDF statistics are computed over a corpus. On 1.18 and older that corpus is the whole shard, so in a multi-tenant collection one tenant's vocabulary distorts another's term rarity. On 1.19+ the corpus can be narrowed to a single tenant.

Adds a note on this to the sparse-vector guidance in search-types/SKILL.md, linking to the per-tenant IDF statistics docs.
Updates the qdrant-hybrid-search eval rubric, which predated 1.19 and treated shard-key partitioning as the only route to tenant-isolated term statistics.

## Type

<!-- check one -->
- [ ] new skill
- [x] skill improvement
- [ ] bug fix
- [ ] repo hygiene

## Checklist

<!-- for new/improved skills, check all that apply -->
- [x] `python3 scripts/validate_skills.py` passes
- [x] skill answers "when?" or "why?", not "how?"
- [x] skill navigates to docs, does not duplicate or replace them
- [x] description has `Use when` with 5+ trigger phrases
- [x] leaf skills omit `allowed-tools`, hub skills declare them
- [x] ends with `## What NOT to Do` section
- [x] no code blocks except minimal snippets when absolutely required (reference the docs instead)
- [x] all doc links go to `skills.qdrant.tech/md/documentation/`
- [x] tested with a realistic prompt (paste below or link to eval)

## Test prompt

```
prompt: We run hybrid search (dense + sparse) inside one large collection shared across all customers, partitioned by a tenant_id payload field. A customer asked whether their term statistics and scoring could be \"contaminated\" by other tenants' data. In a setup like ours, how does Qdrant actually scope the pieces of a hybrid query?

Answer summary: A third skill-test run scores 3/4 musts and clears the avoid, up from 1/4 in the no-skill baseline: it now names the 1.19 per-tenant IDF feature, correctly identifies the pre-1.19 corpus as per-shard, and offers shard-per-tenant as the alternative. It still misses the payload-index prerequisite and only hedges about version rather than recommending the upgrade.
```
