### PR TITLE
Clarify skill nav instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,15 +36,27 @@ skills/
       hybrid-search/
         search-types/
         combining-searches/
+      relevance-feedback/
   qdrant-monitoring/
     SKILL.md
     debugging/
     setup/
   qdrant-clients-sdk/
   qdrant-deployment-options/
+  qdrant-edge/
   qdrant-model-migration/
+  qdrant-multitenancy/
+  qdrant-sizing/
   qdrant-version-upgrade/
 ```
+
+## Navigating skills locally
+
+The same tree as the [published site](https://skills.qdrant.tech), reached by relative path instead of URL. Each `SKILL.md` links to its sub-skills, and those links are the navigation mechanism; follow them rather than assembling paths yourself.
+
+- Read the `SKILL.md` for the relevant skill, then follow its relative links to go deeper. Skills nest up to four levels.
+- If you do not have a link to the skill you need, do not guess the path. Glob `skills/**/SKILL.md` and grep the frontmatter `description` fields, which carry the `Use when` trigger phrases.
+- When a tool summarizes a `SKILL.md`, preserve its Markdown links exactly as written. They are the only way to reach the deeper skills.
 
 ## Conventions
 

--- a/skills/index.md
+++ b/skills/index.md
@@ -32,6 +32,6 @@ Agent skills encoding deep Qdrant knowledge for coding agents.
 Skills structure is hierarchical. Each `SKILL.md` links to its sub-skills, and those links are the navigation mechanism; follow them rather than assembling paths yourself.
 
 - Read the `SKILL.md` for the relevant skill, then follow its links to go deeper. This page lists the top two levels; skills nest up to four levels, and the deeper ones are reachable only through the links inside each `SKILL.md`.
-- If you do not have a link to the skill you need, do not guess the path. Fetch the [complete index of every skill](llms.txt), including the ones this page does not list, or search: https://skills.qdrant.tech/search?query=your+query+here
+- If you do not have a link to the skill you need, do not guess the path. Fetch the [complete index of every skill](https://skills.qdrant.tech/llms.txt), including the ones this page does not list, or search: https://skills.qdrant.tech/search?query=your+query+here
 - When fetching `SKILL.md` files via a URL tool, preserve all Markdown links exactly as written. Do not paraphrase, summarize away, or omit URLs.
 - Search returns a full skill with its links intact, so a hit can be acted on directly.

--- a/skills/index.md
+++ b/skills/index.md
@@ -27,5 +27,13 @@ Agent skills encoding deep Qdrant knowledge for coding agents.
 - [qdrant-sizing](qdrant-sizing/SKILL.md) — Sizing RAM, disk, CPU, and node count before a deployment is provisioned.
 - [qdrant-version-upgrade](qdrant-version-upgrade/SKILL.md) — Safe upgrade paths, compatibility guarantees, and rolling upgrades.
 
-Skills structure is hierarchical.
-You can use search: https://skills.qdrant.tech/search?query=your+query+here
+Complete index of every skill, including the ones this page does not list: https://skills.qdrant.tech/llms.txt
+
+## Navigating this skill tree
+
+Skills structure is hierarchical. Each `SKILL.md` links to its sub-skills, and those links are the navigation mechanism; follow them rather than assembling paths yourself.
+
+- Read the `SKILL.md` for the relevant skill, then follow its links to go deeper. This page lists the top two levels; skills nest up to four levels, and the deeper ones are reachable only through the links inside each `SKILL.md`.
+- If you do not have a link to the skill you need, do not guess the path. Fetch the full generated index at https://skills.qdrant.tech/llms.txt, or search: https://skills.qdrant.tech/search?query=your+query+here
+- When fetching `SKILL.md` files via a URL tool, preserve all Markdown links exactly as written. Do not paraphrase, summarize away, or omit URLs.
+- Search returns a full skill with its links intact, so a hit can be acted on directly.

--- a/skills/index.md
+++ b/skills/index.md
@@ -27,13 +27,11 @@ Agent skills encoding deep Qdrant knowledge for coding agents.
 - [qdrant-sizing](qdrant-sizing/SKILL.md) — Sizing RAM, disk, CPU, and node count before a deployment is provisioned.
 - [qdrant-version-upgrade](qdrant-version-upgrade/SKILL.md) — Safe upgrade paths, compatibility guarantees, and rolling upgrades.
 
-Complete index of every skill, including the ones this page does not list: https://skills.qdrant.tech/llms.txt
-
 ## Navigating this skill tree
 
 Skills structure is hierarchical. Each `SKILL.md` links to its sub-skills, and those links are the navigation mechanism; follow them rather than assembling paths yourself.
 
 - Read the `SKILL.md` for the relevant skill, then follow its links to go deeper. This page lists the top two levels; skills nest up to four levels, and the deeper ones are reachable only through the links inside each `SKILL.md`.
-- If you do not have a link to the skill you need, do not guess the path. Fetch the full generated index at https://skills.qdrant.tech/llms.txt, or search: https://skills.qdrant.tech/search?query=your+query+here
+- If you do not have a link to the skill you need, do not guess the path. Fetch the [complete index of every skill](llms.txt), including the ones this page does not list, or search: https://skills.qdrant.tech/search?query=your+query+here
 - When fetching `SKILL.md` files via a URL tool, preserve all Markdown links exactly as written. Do not paraphrase, summarize away, or omit URLs.
 - Search returns a full skill with its links intact, so a hit can be acted on directly.


### PR DESCRIPTION
## What this PR does

Agents that lose a skill's Markdown links – to summarization or a URL-fetching tool that drops them — start guessing skill paths instead. This PR adds an explicit navigation model to the landing page and `AGENTS.md`: follow the links in each `SKILL.md` rather than assembling paths, and when the links are gone, recover via the generated `/llms.txt` index or search instead of guessing. 


## Type

<!-- check one -->
- [ ] new skill
- [x] skill improvement
- [ ] bug fix
- [ ] repo hygiene