### PR TITLE
Fix trigger-miss routing in the 4 skill navigation hubs

### DIFF
--- a/evals/test-prompts/qdrant-monitoring.json
+++ b/evals/test-prompts/qdrant-monitoring.json
@@ -2,7 +2,7 @@
   "name": "qdrant-monitoring",
   "product_area": "monitoring",
   "skill_url": "https://skills.qdrant.tech/qdrant-monitoring/SKILL.md",
-  "prompt": "We've run a self-hosted cluster for about six months with basically no observability - no dashboards, no alerts. Lately we've had a couple of unexplained slow spells and one node restarted on its own overnight. We want to both get proper visibility in place and get to the bottom of what's been happening. Where do we start?",
+  "prompt": "We've run a self-hosted Qdrant cluster for about six months with basically no observability - no dashboards, no alerts. Lately we've had a couple of unexplained slow spells and one node restarted on its own overnight. We want to both get proper visibility in place and get to the bottom of what's been happening. Where do we start?",
   "rubric": [
     {
       "type": "must",

--- a/skills/qdrant-monitoring/SKILL.md
+++ b/skills/qdrant-monitoring/SKILL.md
@@ -9,10 +9,8 @@ allowed-tools:
 
 # Qdrant Monitoring
 
-
 Route first, then answer. Match the user's symptom in the table, `Read` that file, and answer from it.
 Do not answer from this page alone: it contains routing only, not the guidance. If two rows match, read both.
-
 
 | The user says | Read |
 |---|---|

--- a/skills/qdrant-monitoring/SKILL.md
+++ b/skills/qdrant-monitoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qdrant-monitoring
-description: "Guides Qdrant monitoring and observability setup. Use when someone asks 'how to monitor Qdrant', 'what metrics to track', 'is Qdrant healthy', 'optimizer stuck', 'why is memory growing', 'requests are slow', or needs to set up Prometheus, Grafana, or health checks. Also use when debugging production issues that require metric analysis."
+description: "Guides Qdrant monitoring and observability setup. Use when someone asks 'how to monitor Qdrant', 'what metrics to track', 'is Qdrant healthy', 'optimizer stuck', 'why is memory growing', 'requests are slow', 'set up alerts', 'cluster health check', or needs to set up Prometheus, Grafana, health checks, or log centralization. Also use when debugging production issues that require metric analysis."
 allowed-tools:
   - Read
   - Grep
@@ -9,16 +9,15 @@ allowed-tools:
 
 # Qdrant Monitoring
 
-Qdrant monitoring allows tracking performance and health of your deployment, and identifying issues before they become outages. First determine whether you need to set up monitoring or diagnose an active issue.
+Route first, then answer. Match the user's symptom in the table, `Read` that
+file, and answer from it. Do not answer from this page alone: it contains
+routing only, not the guidance. If two rows match, read both.
 
-- Understand available metrics [Monitoring docs](https://skills.qdrant.tech/md/documentation/ops-monitoring/monitoring/)
+| The user says | Read |
+|---|---|
+| Set up monitoring: Prometheus scraping, health probes, Hybrid Cloud metrics, alerting, log centralization | `setup/SKILL.md` |
+| Diagnose an active issue: optimizer stuck, memory growing, requests slow, is Qdrant healthy | `debugging/SKILL.md` |
 
-
-## Monitoring Setup
-
-Prometheus scraping, health probes, Hybrid Cloud specifics, alerting, and log centralization. [Monitoring Setup](setup/SKILL.md)
-
-
-## Debugging with Metrics
-
-Optimizer stuck, memory growth, slow requests. Using metrics to diagnose active production issues. [Debugging with Metrics](debugging/SKILL.md)
+Qdrant monitoring tracks performance and health, and catches issues before they
+become outages. See the metric reference before tuning anything:
+[Monitoring docs](https://skills.qdrant.tech/md/documentation/ops-monitoring/monitoring/)

--- a/skills/qdrant-performance-optimization/SKILL.md
+++ b/skills/qdrant-performance-optimization/SKILL.md
@@ -10,7 +10,6 @@ allowed-tools:
 
 # Qdrant Performance Optimization
 
-
 Route first, then answer. Match the user's symptom in the table, `Read` that file, and answer from it.
 Do not answer from this page alone: it contains routing only, not the guidance. If two rows match, read both.
 

--- a/skills/qdrant-performance-optimization/SKILL.md
+++ b/skills/qdrant-performance-optimization/SKILL.md
@@ -10,28 +10,17 @@ allowed-tools:
 
 # Qdrant Performance Optimization
 
-There are different aspects of Qdrant performance, this document serves as a navigation hub for different aspects of performance optimization in Qdrant.
+Route first, then answer. Match the user's symptom in the table, `Read` that
+file, and answer from it. Do not answer from this page alone: it contains
+routing only, not the guidance. If two rows match, read both.
 
+| The user says | Read |
+|---|---|
+| Queries too slow or throughput too low, tune for latency vs QPS | `search-speed-optimization/SKILL.md` |
+| Uploads/indexing slow, HNSW build takes too long, optimizer stuck | `indexing-performance-optimization/SKILL.md` |
+| RAM/memory too high, node crashed OOM, want to move data to disk | `memory-usage-optimization/SKILL.md` |
 
-## Search Speed Optimization
-
-There are two different criteria for search speed: latency and throughput. 
-Latency is the time it takes to get a response for a single query, while throughput is the number of queries that can be processed in a given time frame.
-Depending on your use case, you may want to optimize for one or both of these metrics.
-
-More on search speed optimization can be found in the [Search Speed Optimization](search-speed-optimization/SKILL.md) skill.
-
-
-## Indexing Performance Optimization
-
-Qdrant needs to build a vector index to perform efficient similarity search. The time it takes to build the index can vary depending on the size of your dataset, hardware, and configuration.
-
-More on indexing performance optimization can be found in the [Indexing Performance Optimization](indexing-performance-optimization/SKILL.md) skill.
-
-
-## Memory Usage Optimization
-
-Vector search can be memory intensive, especially when dealing with large datasets.
-Qdrant has a flexible memory management system, which allows you to precisely control which parts of storage are kept in memory and which are stored on disk. This can help you optimize memory usage without sacrificing performance.
-
-More on memory usage optimization can be found in the [Memory Usage Optimization](memory-usage-optimization/SKILL.md) skill.
+Latency and throughput pull opposite ways on segment count. For latency,
+increase segments toward the CPU core count (`default_segment_number: 16`).
+For throughput, use fewer and larger segments (`default_segment_number: 2`).
+Applying the wrong direction makes the reported problem worse.

--- a/skills/qdrant-scaling/SKILL.md
+++ b/skills/qdrant-scaling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qdrant-scaling
-description: "Guides Qdrant scaling decisions. Use when someone asks 'how many nodes do I need', 'data doesn't fit on one node', 'need more throughput', 'cluster is slow', 'too many tenants', 'vertical or horizontal', 'how to shard', or 'need to add capacity'."
+description: "Guides Qdrant scaling decisions. Use when someone asks 'how many nodes do I need', 'data doesn't fit on one node', 'need more throughput or QPS', 'CPU is pegged / can't keep up with the request rate', 'one query is slow / p99 or tail latency too high', 'cluster is slow', 'too many tenants', 'vertical or horizontal', 'how to shard', 'need to add capacity', 'large limit / pagination / scroll is slow', or 'only recent data matters / expiring old vectors / retention window'."
 allowed-tools:
   - Read
   - Grep
@@ -9,43 +9,22 @@ allowed-tools:
 
 # Qdrant Scaling
 
-First determine what you're scaling for:
+Route first, then answer. Match the user's symptom in the table, `Read` that
+file, and answer from it. Do not answer from this page alone: it contains
+routing only, not the guidance. If two rows match, read both.
 
-- data volume
-- query throughput (QPS)
-- query latency
-- query volume
+| The user says | Read |
+|---|---|
+| Data outgrew one node, need more storage, sharding | `scaling-data-volume/SKILL.md` |
+| Can't hold the request rate, CPU pegged, need more QPS or throughput | `scaling-qps/SKILL.md` |
+| One query is slow, p99 or tail latency too high, traffic is fine | `minimize-latency/SKILL.md` |
+| Large `limit`, top-1000 queries, pagination, scroll across shards | `scaling-query-volume/SKILL.md` |
+| Many tenants or customers, one collection each, tenant isolation | `scaling-data-volume/tenant-scaling/SKILL.md` |
+| Only recent data matters, retention, expiring old vectors, time-based rotation | `scaling-data-volume/sliding-time-window/SKILL.md` |
+| Single node no longer fits the workload, before deciding to shard | `scaling-data-volume/vertical-scaling/SKILL.md` |
+| Already vertically maxed out, need more nodes, resharding | `scaling-data-volume/horizontal-scaling/SKILL.md` |
 
-After determining the scaling goal, we can choose scaling strategy based on tradeoffs and assumptions.
-Each pulls toward different strategies. Scaling for throughput and latency are opposite tuning directions.
-
-
-## Scaling Data Volume
-
-This becomes relevant when volume of the dataset exceeds the capacity of a single node.
-Read more about scaling for data volume in [Scaling Data Volume](scaling-data-volume/SKILL.md)
-
-
-## Scaling for Query Throughput
-
-If your system needs to handle more parallel queries than a single node can handle,
- then you need to scale for query throughput.
-
-Read more about scaling for query throughput in [Scaling for Query Throughput](scaling-qps/SKILL.md)
-
-## Scaling for Query Latency
-
-Latency of a single query is determined by the slowest component in the query execution path.
-It is in sometimes correlated with throughput, but not always. It might require different strategies for scaling.
-
-Read more about scaling for query latency in [Scaling for Query Latency](minimize-latency/SKILL.md)
-
-
-## Scaling for Query Volume
-
-By query volume we understand the amount of results that a single query returns. 
-If the query volume is too high, it can cause performance issues and increase latency.
-
-Tuning for query volume is opposite might require special strategies. 
-
-Read more about scaling for query volume in [Scaling for Query Volume](scaling-query-volume/SKILL.md)
+Latency and throughput pull opposite ways on segment count. For latency,
+increase segments toward the CPU core count (`default_segment_number: 16`).
+For throughput, use fewer and larger segments (`default_segment_number: 2`).
+Applying the wrong direction makes the reported problem worse.

--- a/skills/qdrant-search-quality/SKILL.md
+++ b/skills/qdrant-search-quality/SKILL.md
@@ -9,7 +9,6 @@ allowed-tools:
 
 # Qdrant Search Quality
 
-
 Route first, then answer. Match the user's symptom in the table, `Read` that file, and answer from it.
 Do not answer from this page alone: it contains routing only, not the guidance. If two rows match, read both.
 

--- a/skills/qdrant-search-quality/SKILL.md
+++ b/skills/qdrant-search-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qdrant-search-quality
-description: "Diagnoses and improves Qdrant search relevance. Use when someone reports 'search results are bad', 'wrong results', 'low precision', 'low recall', 'irrelevant matches', 'missing expected results', or asks 'how to improve search quality?', 'which embedding model?', 'should I use hybrid search?', 'should I use reranking?', 'how to measure retrieval quality?', 'build a golden set', 'ground truth dataset', or 'how to score recall@k?'. Also use when search quality degrades after quantization, model change, or data growth."
+description: "Diagnoses and improves Qdrant search relevance. Use when someone reports 'search results are bad', 'wrong results', 'low precision', 'low recall', 'irrelevant matches', 'missing expected results', or asks 'how to improve search quality?', 'which embedding model?', 'should I use hybrid search?', 'how to combine keyword and vector search / fusion / RRF / prefetch?', 'should I use reranking?', 'relevance feedback?', 'how to measure retrieval quality?', 'build a golden set', 'ground truth dataset', or 'how to score recall@k?'. Also use when search quality degrades after quantization, model change, or data growth."
 allowed-tools:
   - Read
   - Grep
@@ -9,16 +9,20 @@ allowed-tools:
 
 # Qdrant Search Quality
 
-First determine whether the problem is the embedding model, Qdrant configuration, or the query strategy. Most quality issues come from the model or data, not from Qdrant itself. If search quality is low, inspect how chunks are being passed to Qdrant before tuning any parameters. Splitting mid-sentence can drop quality 30-40%.
+Route first, then answer. Match the user's symptom in the table, `Read` that
+file, and answer from it. Do not answer from this page alone: it contains
+routing only, not the guidance. If two rows match, read both.
 
-- Start by testing with exact search to isolate the problem [Search API](https://skills.qdrant.tech/md/documentation/search/search/?s=search-api)
+| The user says | Read |
+|---|---|
+| Bad, wrong, or irrelevant results; low precision/recall; missing expected matches | `diagnosis/SKILL.md` |
+| Which embedding model to use; quality dropped after quantization, model change, or data growth | `diagnosis/SKILL.md` |
+| Build a golden set, ground truth dataset, measure recall@k, retrieval quality | `diagnosis/SKILL.md` |
+| Combine keyword and vector search, hybrid search, sparse + dense, fusion / RRF, prefetch | `search-strategies/hybrid-search/SKILL.md` |
+| Should I rerank, results too similar, need diversity, MMR, recommendation/discovery API | `search-strategies/SKILL.md` |
+| Improve results using user feedback/clicks, cheaper alternative to reranking | `search-strategies/relevance-feedback/SKILL.md` |
 
-
-## Diagnosis and Tuning
-
-Isolate the source of quality issues, establish labeled baselines to measure recall and relevance, tune HNSW parameters, and choose the right embedding model. [Diagnosis and Tuning](diagnosis/SKILL.md)
-
-
-## Search Strategies
-
-Hybrid search, reranking, relevance feedback, and exploration APIs for improving result quality. [Search Strategies](search-strategies/SKILL.md)
+Most quality issues come from the embedding model or the data, not from Qdrant's
+configuration — splitting chunks mid-sentence alone can drop quality 30-40%.
+Rule that out with exact search before tuning any Qdrant parameter:
+[Search API](https://skills.qdrant.tech/md/documentation/search/search/?s=search-api)


### PR DESCRIPTION
## What this PR does

Related to https://github.com/qdrant/skills/issues/136

This PR adjusts `qdrant-scaling`, `qdrant-search-quality`, `qdrant-monitoring`, and `qdrant-performance-optimization` symptom-to-file tables, and broadens their frontmatter descriptions to close the phrasing gaps that caused some skills to never trigger. Also fixes the `qdrant-monitoring` test prompt, which never mentioned "Qdrant".


## Type

<!-- check one -->
- [ ] new skill
- [x] skill improvement
- [ ] bug fix
- [ ] repo hygiene