### PR TITLE
Add a GH action to A/B test skill changes on PRs

### DIFF
--- a/.github/workflows/skill-ab-test.yml
+++ b/.github/workflows/skill-ab-test.yml
@@ -3,8 +3,16 @@ name: skill A/B test
 # Triggered by adding the `A/B test` label to a PR. Compares the skill(s) the
 # PR touches — current main (Version A) vs the PR's amended version
 # (Version B) — using the same weekly scoring harness as skill-scoring.yml
-# (see SCORING.md), scoped to only the scored test-prompt(s) that target the
-# changed skill family/families.
+# (see SCORING.md), scoped to only the scored test-prompt(s) whose target leaf
+# skill was actually changed (not the whole family — a family can have many
+# leaves and a one-leaf change should not re-score its siblings too).
+#
+# Caveat: a change to only a family's top-level hub SKILL.md (shared
+# navigation/routing prose, no leaf changed) matches zero prompts, since no
+# scored prompt targets a hub file directly. That's an accepted gap in this
+# label-triggered test, not a bug — routing-only changes need a hand-designed
+# eval (see evals/pr118-ab in the skill-test repo for prior art), not this
+# per-leaf-prompt harness.
 #
 # Label-add only: no re-run on push, so spend stays bounded and predictable.
 # Re-add the label after pushing changes to re-test. Re-adding edits the same
@@ -50,7 +58,7 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Determine changed skill families and matched prompts
+      - name: Determine changed leaf skill(s) and matched prompts
         id: match
         run: |
           set -euo pipefail
@@ -59,12 +67,12 @@ jobs:
                                 "${{ github.event.pull_request.head.sha }}" \
                                 -- skills/ \
             | scripts/scoring/match-changed-prompts.sh --out-dir /tmp/ab-prompts \
-            > /tmp/families.txt 2> /tmp/match.log
+            > /tmp/leaves.txt 2> /tmp/match.log
           cat /tmp/match.log >&2
           matched="$(grep -o 'MATCHED=[0-9]*' /tmp/match.log | tail -1 | cut -d= -f2)"
           {
-            echo "families<<EOF"
-            cat /tmp/families.txt
+            echo "leaves<<EOF"
+            cat /tmp/leaves.txt
             echo "EOF"
             echo "matched=$matched"
           } >> "$GITHUB_OUTPUT"
@@ -152,7 +160,7 @@ jobs:
               echo "$COMMENT_MARKER"
               cat /tmp/ab-out/ab-scorecard.md
               echo
-              echo "Families tested: ${{ steps.match.outputs.families }}"
+              echo "Skill(s) tested: ${{ steps.match.outputs.leaves }}"
               echo
               echo "Full transcripts: [workflow run]($run_url) artifact \`ab-test-${{ github.event.pull_request.number }}-${{ github.run_id }}\`."
             } > /tmp/comment-body.md

--- a/.github/workflows/skill-ab-test.yml
+++ b/.github/workflows/skill-ab-test.yml
@@ -1,0 +1,168 @@
+name: skill A/B test
+
+# Triggered by adding the `A/B test` label to a PR. Compares the skill(s) the
+# PR touches — current main (Version A) vs the PR's amended version
+# (Version B) — using the same weekly scoring harness as skill-scoring.yml
+# (see SCORING.md), scoped to only the scored test-prompt(s) that target the
+# changed skill family/families.
+#
+# Label-add only: no re-run on push, so spend stays bounded and predictable.
+# Re-add the label after pushing changes to re-test. Re-adding edits the same
+# PR comment in place rather than posting a new one each time.
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: skill-ab-test-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  COMMENT_MARKER: "<!-- skill-ab-test:scorecard -->"
+
+jobs:
+  ab-test:
+    if: github.event.label.name == 'A/B test'
+    runs-on: ubuntu-latest
+    # A 1-prompt x 1-model x 2-rep x 2-version run is a small fraction of the
+    # weekly job's volume; this timeout is a generous ceiling, not an estimate.
+    timeout-minutes: 120
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout PR head (Version B)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Checkout PR base (Version A skills tree)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base-checkout
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Determine changed skill families and matched prompts
+        id: match
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/ab-prompts
+          git diff --name-only "${{ github.event.pull_request.base.sha }}" \
+                                "${{ github.event.pull_request.head.sha }}" \
+                                -- skills/ \
+            | scripts/scoring/match-changed-prompts.sh --out-dir /tmp/ab-prompts \
+            > /tmp/families.txt 2> /tmp/match.log
+          cat /tmp/match.log >&2
+          matched="$(grep -o 'MATCHED=[0-9]*' /tmp/match.log | tail -1 | cut -d= -f2)"
+          {
+            echo "families<<EOF"
+            cat /tmp/families.txt
+            echo "EOF"
+            echo "matched=$matched"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Comment — no scored prompts cover this PR's skill(s)
+        if: steps.match.outputs.matched == '0'
+        run: |
+          set -euo pipefail
+          {
+            echo "$COMMENT_MARKER"
+            echo "## 🧪 Skill A/B Test"
+            echo
+            echo "No scored prompt under \`evals/test-prompts/\` targets the skill(s) this PR changes, so there is nothing to compare. Add or update a test prompt for this skill family to enable the A/B test."
+          } > /tmp/comment-body.md
+          scripts/scoring/post-pr-comment.sh --pr "${{ github.event.pull_request.number }}" \
+            --marker "$COMMENT_MARKER" --body-file /tmp/comment-body.md
+
+      - name: Install Claude CLI (host — used by the blind judge)
+        if: steps.match.outputs.matched != '0'
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Build harness Docker image
+        if: steps.match.outputs.matched != '0'
+        run: skill-test/scripts/build-image.sh
+
+      - name: Run Version A (main @ PR base)
+        if: steps.match.outputs.matched != '0'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -euo pipefail
+          scripts/scoring/run-eval-matrix.sh \
+            --models sonnet --conditions with-skill --reps 2 \
+            --prompts-dir /tmp/ab-prompts \
+            --skills-root "$GITHUB_WORKSPACE/base-checkout/skills" \
+            --out-dir /tmp/ab-out/version-a
+          scripts/scoring/extract-run-signals.sh --out-dir /tmp/ab-out/version-a
+
+      - name: Run Version B (this PR)
+        if: steps.match.outputs.matched != '0'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -euo pipefail
+          scripts/scoring/run-eval-matrix.sh \
+            --models sonnet --conditions with-skill --reps 2 \
+            --prompts-dir /tmp/ab-prompts \
+            --skills-root "$GITHUB_WORKSPACE/skills" \
+            --out-dir /tmp/ab-out/version-b
+          scripts/scoring/extract-run-signals.sh --out-dir /tmp/ab-out/version-b
+
+      - name: Judge both versions (blind Opus)
+        if: steps.match.outputs.matched != '0'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -euo pipefail
+          scripts/scoring/judge-runs.sh --out-dir /tmp/ab-out/version-a
+          scripts/scoring/judge-runs.sh --out-dir /tmp/ab-out/version-b
+
+      - name: Compare — build the A/B scorecard
+        if: always() && steps.match.outputs.matched != '0'
+        run: |
+          scripts/scoring/compare-ab.py \
+            --a /tmp/ab-out/version-a --b /tmp/ab-out/version-b \
+            --label-a "main@${{ github.event.pull_request.base.sha }}" \
+            --label-b "PR#${{ github.event.pull_request.number }}@${{ github.event.pull_request.head.sha }}" \
+            --out /tmp/ab-out/ab-scorecard.md
+
+      - name: Upload results (scorecard + manifests + scores + transcripts)
+        if: always() && steps.match.outputs.matched != '0'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ab-test-${{ github.event.pull_request.number }}-${{ github.run_id }}
+          path: /tmp/ab-out
+          if-no-files-found: warn
+
+      - name: Comment — post the scorecard
+        if: always() && steps.match.outputs.matched != '0'
+        run: |
+          set -euo pipefail
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [[ -f /tmp/ab-out/ab-scorecard.md ]]; then
+            {
+              echo "$COMMENT_MARKER"
+              cat /tmp/ab-out/ab-scorecard.md
+              echo
+              echo "Families tested: ${{ steps.match.outputs.families }}"
+              echo
+              echo "Full transcripts: [workflow run]($run_url) artifact \`ab-test-${{ github.event.pull_request.number }}-${{ github.run_id }}\`."
+            } > /tmp/comment-body.md
+          else
+            {
+              echo "$COMMENT_MARKER"
+              echo "## 🧪 Skill A/B Test"
+              echo
+              echo "The run did not produce a scorecard (it may have failed before comparison). Check the [workflow run]($run_url) for details."
+            } > /tmp/comment-body.md
+          fi
+          scripts/scoring/post-pr-comment.sh --pr "${{ github.event.pull_request.number }}" \
+            --marker "$COMMENT_MARKER" --body-file /tmp/comment-body.md

--- a/.github/workflows/skill-ab-test.yml
+++ b/.github/workflows/skill-ab-test.yml
@@ -26,7 +26,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: skill-ab-test-${{ github.event.pull_request.number }}
+  group: skill-ab-test-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
   cancel-in-progress: true
 
 env:

--- a/scripts/scoring/compare-ab.py
+++ b/scripts/scoring/compare-ab.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Compare two versions of the same skill (A vs B) scored by the weekly harness.
+
+Unlike summarize-eval.py — which diffs `no-skill` vs `with-skill` within one
+run to measure lift — this diffs two *separate* run directories that each used
+the `with-skill` condition, one per skill version (e.g. main vs a PR branch).
+Both directories are expected to be produced the normal way:
+
+    run-eval-matrix.sh --conditions with-skill --skills-root <version> ...
+    extract-run-signals.sh --out-dir <version-dir>
+    judge-runs.sh --out-dir <version-dir>
+
+against the *same* (matched) prompt subset, so every prompt in A has a
+counterpart in B. Reuses SCORING.md's aggregation order
+
+    item  ->  prompt x rep  ->  prompt  ->  model
+
+and its paired within-run SE math, applied across the A/B pair instead of
+across the no-skill/with-skill pair. Nothing here gates; it reports a scorecard.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+from statistics import mean, stdev
+
+# --- small helpers (duplicated from summarize-eval.py; these two scripts are
+# each meant to run standalone, and the shared surface is small) ------------
+
+
+def clamp(x, lo, hi):
+    return max(lo, min(hi, x))
+
+
+def fmt(x, nd=3):
+    return "n/a" if x is None else f"{x:.{nd}f}"
+
+
+def signed(x, nd=3):
+    return "n/a" if x is None else f"{x:+.{nd}f}"
+
+
+def md_table(headers, rows):
+    rows = [[str(c) for c in r] for r in rows]
+    widths = [len(h) for h in headers]
+    for r in rows:
+        for i, c in enumerate(r):
+            widths[i] = max(widths[i], len(c))
+
+    def line(cells):
+        return "| " + " | ".join(c.ljust(widths[i]) for i, c in enumerate(cells)) + " |"
+
+    out = [line(headers), "| " + " | ".join("-" * w for w in widths) + " |"]
+    out += [line(r) for r in rows]
+    return out
+
+
+_T95 = {1: 12.706, 2: 4.303, 3: 3.182, 4: 2.776, 5: 2.571, 6: 2.447, 7: 2.365,
+        8: 2.306, 9: 2.262, 10: 2.228, 12: 2.179, 15: 2.131, 20: 2.086,
+        25: 2.060, 30: 2.042, 40: 2.021, 60: 2.000, 120: 1.980}
+
+
+def t95(df):
+    if df < 1:
+        return None
+    if df >= 120:
+        return 1.960
+    best = max((k for k in _T95 if k <= df), default=min(_T95))
+    return _T95[best]
+
+
+def load_csv(path: Path):
+    with path.open() as f:
+        return list(csv.DictReader(f))
+
+
+def delta(bv, av):
+    return None if bv is None or av is None else bv - av
+
+
+# --- quality aggregation (per version dir) ----------------------------------
+
+
+UNGRADED = {"", "PARSE_ERROR"}
+
+
+def rep_metrics(items):
+    must = [float(i["credit"]) for i in items if i["item_type"] == "must"]
+    bonus = [float(i["credit"]) for i in items if i["item_type"] == "bonus"]
+    avoid = [float(i["credit"]) for i in items if i["item_type"] == "avoid"]
+    must_cov = mean(must) if must else None
+    bonus_rate = mean(bonus) if bonus else None
+    avoid_viol = sum(avoid)
+    composite = None
+    if must_cov is not None:
+        composite = clamp(must_cov + 0.10 * (bonus_rate or 0.0) - 0.25 * avoid_viol, 0.0, 1.0)
+    return {"must_coverage": must_cov, "bonus_rate": bonus_rate,
+            "avoid_violations": avoid_viol, "composite": composite}
+
+
+def avg_metric(dicts, key):
+    vals = [d[key] for d in dicts if d.get(key) is not None]
+    return mean(vals) if vals else None
+
+
+def aggregate_quality(scores):
+    """item -> prompt x rep -> prompt (per model). No condition axis: every row
+    in `scores` is assumed to be one skill version's with-skill runs."""
+    by_rep = defaultdict(list)
+    contested = ungraded = 0
+    for r in scores:
+        by_rep[(r["model"], r["prompt"], r["rep"])].append(r)
+        if r.get("contested") not in (None, "", "False", "false"):
+            contested += 1
+        if r["verdict"] in UNGRADED:
+            ungraded += 1
+    rep_level = {k: rep_metrics(v) for k, v in by_rep.items()}
+
+    by_prompt = defaultdict(list)
+    for (model, prompt, _rep), m in rep_level.items():
+        by_prompt[(model, prompt)].append(m)
+    prompt_level = {
+        key: {k: avg_metric(ms, k) for k in
+              ("must_coverage", "bonus_rate", "avoid_violations", "composite")}
+        for key, ms in by_prompt.items()
+    }
+
+    by_model = defaultdict(list)
+    for (model, _prompt), m in prompt_level.items():
+        by_model[model].append(m)
+    model_level = {m: {k: avg_metric(ms, k) for k in
+                        ("must_coverage", "bonus_rate", "avoid_violations", "composite")}
+                   for m, ms in by_model.items()}
+    for m, ms in by_model.items():
+        model_level[m]["n_prompts"] = len(ms)
+    return prompt_level, model_level, contested, ungraded
+
+
+def aggregate_cost(manifest):
+    by_model = defaultdict(lambda: {"cost": [], "turns": []})
+    excluded = 0
+    for r in manifest:
+        if r.get("exit_code") != "0" or r.get("budget_hit") == "1":
+            excluded += 1
+            continue
+        cost, turns = r.get("total_cost_usd", ""), r.get("num_turns", "")
+        if cost in (None, ""):
+            excluded += 1
+            continue
+        by_model[r.get("model")]["cost"].append(float(cost))
+        if turns not in (None, ""):
+            by_model[r.get("model")]["turns"].append(float(turns))
+    out = {}
+    for m, v in by_model.items():
+        out[m] = {"cost": mean(v["cost"]) if v["cost"] else None,
+                  "turns": mean(v["turns"]) if v["turns"] else None, "n": len(v["cost"])}
+    return out, excluded
+
+
+def paired_se(prompt_q_a, prompt_q_b, models):
+    """Paired within-run SE of the must_coverage delta (B - A), per model. Same
+    math as summarize-eval.py's within_week_se, but pairing A/B per prompt
+    instead of no-skill/with-skill per prompt."""
+    out = {}
+    for m in models:
+        prompts = {p for (mm, p) in prompt_q_a if mm == m} & {p for (mm, p) in prompt_q_b if mm == m}
+        ds = []
+        for p in prompts:
+            a, b = prompt_q_a.get((m, p)), prompt_q_b.get((m, p))
+            if not a or not b:
+                continue
+            av, bv = a.get("must_coverage"), b.get("must_coverage")
+            if av is None or bv is None:
+                continue
+            ds.append(bv - av)
+        n = len(ds)
+        if n >= 2:
+            lift = mean(ds)
+            se = stdev(ds) / math.sqrt(n)
+            t = t95(n - 1)
+            half = t * se if t else None
+            excludes_zero = half is not None and abs(lift) > half
+        else:
+            lift = ds[0] if n == 1 else None
+            se = half = t = None
+            excludes_zero = False
+        out[m] = {"delta": lift, "se": se, "n": n, "half": half, "excludes_zero": excludes_zero}
+    return out
+
+
+def models_present(*model_dicts):
+    order = ["sonnet", "haiku"]
+    seen = set()
+    for d in model_dicts:
+        seen |= set(d)
+    return [m for m in order if m in seen] + sorted(m for m in seen if m not in order)
+
+
+def coverage_lines(label, manifest, scores):
+    graded = {(r["prompt"], r["model"], r["rep"]) for r in scores}
+    dropped = []
+    for r in manifest:
+        key = (r.get("prompt"), r.get("model"), r.get("rep"))
+        if key in graded:
+            continue
+        if r.get("budget_hit") == "1":
+            reason = "budget-capped (truncated)"
+        elif r.get("skill_available") != "1":
+            reason = "invalid: skill unavailable"
+        elif r.get("exit_code") != "0":
+            reason = f"errored (exit {r.get('exit_code')})"
+        else:
+            reason = "no gradeable answer"
+        dropped.append((r.get("run_id"), r.get("prompt"), r.get("model"), reason))
+    L = [f"**{label}**: graded {len(graded)} of {len(manifest)}"]
+    if dropped:
+        L.append("")
+        L += md_table(["run_id", "prompt", "model", "reason"], dropped)
+    return L
+
+
+def avoid_lines(label, scores):
+    viol = [r for r in scores if r["item_type"] == "avoid"
+            and r["verdict"] == "violated" and float(r["credit"]) > 0]
+    if not viol:
+        return [f"**{label}**: none"]
+    rows = [[r["prompt"], r["model"], r["item_text"][:80],
+              (r.get("evidence_quote") or "").replace("|", "\\|")[:120]] for r in viol]
+    return [f"**{label}**:", ""] + md_table(["prompt", "model", "violated item", "evidence"], rows)
+
+
+def provenance_lines(label, manifest):
+    sha = {(r.get("skills_sha") or "").strip() for r in manifest if r.get("skills_sha")}
+    cli = {(r.get("cli_version") or "").strip() for r in manifest if r.get("cli_version")}
+    return [f"- **{label}** — skills commit(s): {', '.join(f'`{v}`' for v in sorted(sha)) or '_(unknown)_'}, "
+            f"CLI: {', '.join(f'`{v}`' for v in sorted(cli)) or '_(unknown)_'}"]
+
+
+def build_scorecard(dir_a, dir_b, label_a, label_b,
+                     pq_a, pq_b, mq_a, mq_b, cost_a, cost_b,
+                     manifest_a, manifest_b, scores_a, scores_b):
+    models = models_present(mq_a, mq_b)
+    se_info = paired_se(pq_a, pq_b, models)
+
+    L = [f"# Skill A/B Scorecard\n",
+         f"**A** = `{label_a}` (`{dir_a}`)  \n**B** = `{label_b}` (`{dir_b}`)\n"]
+
+    L.append("## Lift per model (B - A)\n")
+    eps = 1e-9
+    def nz(key):
+        return any(abs((mq_b.get(m, {}).get(key) or 0) - (mq_a.get(m, {}).get(key) or 0)) > eps
+                   for m in models)
+    show_bonus, show_avoid = nz("bonus_rate"), nz("avoid_violations")
+    headers = ["model", "must_coverage A -> B", "delta +/- SE", "95% CI != 0?"]
+    if show_bonus:
+        headers.append("d_bonus")
+    if show_avoid:
+        headers.append("d_avoid")
+    headers += ["d_cost ($)", "d_turns"]
+    rows = []
+    for m in models:
+        a, b = mq_a.get(m, {}), mq_b.get(m, {})
+        ca, cb = cost_a.get(m, {}), cost_b.get(m, {})
+        se = se_info.get(m, {})
+        arrow = f"{fmt(a.get('must_coverage'))} -> {fmt(b.get('must_coverage'))}"
+        se_str = f"{signed(se.get('delta'))} +/- {fmt(se.get('se')) if se.get('se') is not None else 'n/a'}"
+        flag = "n/a (need >=2 prompts)" if se.get("se") is None else \
+            ("yes" if se.get("excludes_zero") else "no")
+        row = [m, arrow, se_str, flag]
+        if show_bonus:
+            row.append(signed(delta(b.get("bonus_rate"), a.get("bonus_rate"))))
+        if show_avoid:
+            row.append(signed(delta(b.get("avoid_violations"), a.get("avoid_violations")), 2))
+        row += [signed(delta(cb.get("cost"), ca.get("cost")), 4),
+                signed(delta(cb.get("turns"), ca.get("turns")), 1)]
+        rows.append(row)
+    L += md_table(headers, rows)
+    L.append("\n_+/- SE is one within-run standard error of the paired per-prompt must-coverage "
+             "delta (B - A) - sampling uncertainty from this prompt set and rep/judge noise, not "
+             "a claim about generalization beyond the matched prompts. '!= 0?' asks whether the "
+             "95% CI (t*SE) excludes zero. Reported, not gated._\n")
+
+    L.append("## Per-model summary\n")
+    rows = []
+    for m in models:
+        a, b = mq_a.get(m, {}), mq_b.get(m, {})
+        ca, cb = cost_a.get(m, {}), cost_b.get(m, {})
+        rows.append([m, "A", fmt(a.get("must_coverage")), fmt(a.get("bonus_rate")),
+                     fmt(a.get("avoid_violations"), 2), fmt(a.get("composite")),
+                     fmt(ca.get("cost"), 4), fmt(ca.get("turns"), 1), a.get("n_prompts", 0)])
+        rows.append([m, "B", fmt(b.get("must_coverage")), fmt(b.get("bonus_rate")),
+                     fmt(b.get("avoid_violations"), 2), fmt(b.get("composite")),
+                     fmt(cb.get("cost"), 4), fmt(cb.get("turns"), 1), b.get("n_prompts", 0)])
+    L += md_table(["model", "version", "must_cov", "bonus_rate", "avoid_viol",
+                   "composite", "mean cost", "mean turns", "n"], rows)
+    L.append("")
+
+    L.append("## Per-prompt (must_coverage; A -> B)\n")
+    rows = []
+    for prompt in sorted({p for (_m, p) in pq_a} | {p for (_m, p) in pq_b}):
+        for m in models:
+            a, b = pq_a.get((m, prompt)), pq_b.get((m, prompt))
+            if not a and not b:
+                continue
+            mc_a = a.get("must_coverage") if a else None
+            mc_b = b.get("must_coverage") if b else None
+            cp_a = a.get("composite") if a else None
+            cp_b = b.get("composite") if b else None
+            rows.append([prompt, m, f"{fmt(mc_a)} -> {fmt(mc_b)}",
+                         signed(delta(mc_b, mc_a)), f"{fmt(cp_a)} -> {fmt(cp_b)}"])
+    L += md_table(["prompt", "model", "must A->B", "delta", "composite A->B"], rows)
+    L.append("")
+
+    L.append("## `avoid` violations\n")
+    L += avoid_lines("A", scores_a)
+    L.append("")
+    L += avoid_lines("B", scores_b)
+    L.append("")
+
+    L.append("## Coverage\n")
+    L += coverage_lines("A", manifest_a, scores_a)
+    L.append("")
+    L += coverage_lines("B", manifest_b, scores_b)
+    L.append("")
+
+    L.append("## Provenance\n")
+    L += provenance_lines("A", manifest_a)
+    L += provenance_lines("B", manifest_b)
+    L.append("")
+
+    return "\n".join(L)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Compare two skill-version run dirs (A vs B).")
+    ap.add_argument("--a", type=Path, required=True, help="Version A run dir (has scores.csv/manifest.csv)")
+    ap.add_argument("--b", type=Path, required=True, help="Version B run dir")
+    ap.add_argument("--label-a", default="A", help="Human label for version A (e.g. a git ref)")
+    ap.add_argument("--label-b", default="B", help="Human label for version B")
+    ap.add_argument("--out", type=Path, default=None,
+                    help="Output markdown path. Default: ab-scorecard.md next to --b")
+    args = ap.parse_args()
+
+    for d in (args.a, args.b):
+        for name in ("scores.csv", "manifest.csv"):
+            if not (d / name).exists():
+                print(f"error: {d / name} not found", file=sys.stderr)
+                return 2
+
+    scores_a, scores_b = load_csv(args.a / "scores.csv"), load_csv(args.b / "scores.csv")
+    manifest_a, manifest_b = load_csv(args.a / "manifest.csv"), load_csv(args.b / "manifest.csv")
+
+    pq_a, mq_a, _, _ = aggregate_quality(scores_a)
+    pq_b, mq_b, _, _ = aggregate_quality(scores_b)
+    cost_a, _ = aggregate_cost(manifest_a)
+    cost_b, _ = aggregate_cost(manifest_b)
+
+    report = build_scorecard(args.a, args.b, args.label_a, args.label_b,
+                              pq_a, pq_b, mq_a, mq_b, cost_a, cost_b,
+                              manifest_a, manifest_b, scores_a, scores_b)
+
+    out = args.out or (args.b / "ab-scorecard.md")
+    out.write_text(report)
+    print(report)
+    print(f"\nwrote {out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/scoring/compare-ab.py
+++ b/scripts/scoring/compare-ab.py
@@ -67,7 +67,7 @@ _T95 = {1: 12.706, 2: 4.303, 3: 3.182, 4: 2.776, 5: 2.571, 6: 2.447, 7: 2.365,
 def t95(df):
     if df < 1:
         return None
-    if df >= 120:
+    if df > 120:
         return 1.960
     best = max((k for k in _T95 if k <= df), default=min(_T95))
     return _T95[best]
@@ -251,9 +251,12 @@ def build_scorecard(dir_a, dir_b, label_a, label_b,
 
     L.append("## Lift per model (B - A)\n")
     eps = 1e-9
-    def nz(key):
-        return any(abs((mq_b.get(m, {}).get(key) or 0) - (mq_a.get(m, {}).get(key) or 0)) > eps
-                   for m in models)
+  def nz(key):
+      def val(d, m):
+          v = d.get(m, {}).get(key)
+          return 0.0 if v is None else v
+      return any(abs(val(mq_b, m) - val(mq_a, m)) > eps for m in models)
+
     show_bonus, show_avoid = nz("bonus_rate"), nz("avoid_violations")
     headers = ["model", "must_coverage A -> B", "delta +/- SE", "95% CI != 0?"]
     if show_bonus:

--- a/scripts/scoring/match-changed-prompts.sh
+++ b/scripts/scoring/match-changed-prompts.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Given a set of changed files under skills/ (one per line on stdin), find every
+# scored (non-discord-) test-prompt whose skill_url family is among the changed
+# families, and copy those prompt JSONs into an output directory.
+#
+# Used by the A/B test workflow to scope a PR-triggered run to only the
+# prompt(s) that exercise the skill(s) the PR touches, so it does not re-score
+# the whole 26-prompt matrix for a one-skill change.
+#
+# Usage:
+#   git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- skills/ \
+#     | scripts/scoring/match-changed-prompts.sh --out-dir /tmp/ab-prompts
+#
+# Prints the matched family names (one per line) to stdout for logging, and the
+# count of matched prompts to stderr as "MATCHED=<n>".
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=resolve-skill.sh
+source "$SCRIPT_DIR/resolve-skill.sh"
+
+PROMPTS_DIR="${PROMPTS_DIR:-$REPO_ROOT/evals/test-prompts}"
+OUT_DIR=""
+
+usage() {
+  cat <<'USAGE'
+Usage: git diff --name-only BASE HEAD -- skills/ | match-changed-prompts.sh --out-dir DIR
+
+Options:
+  --out-dir DIR       Where to copy matched prompt JSONs. Required.
+  --prompts-dir DIR   Test-prompt JSONs to search. Default: ../evals/test-prompts
+  -h, --help          Show this help.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out-dir) OUT_DIR="${2:?}"; shift 2 ;;
+    --prompts-dir) PROMPTS_DIR="${2:?}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 64 ;;
+  esac
+done
+
+[[ -n "$OUT_DIR" ]] || { echo "--out-dir is required" >&2; usage >&2; exit 64; }
+[[ -d "$PROMPTS_DIR" ]] || { echo "Prompts dir not found: $PROMPTS_DIR" >&2; exit 66; }
+command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 64; }
+
+mkdir -p "$OUT_DIR"
+
+# Changed families: first path segment after "skills/" for every changed file.
+# Portable to bash 3.2 (macOS default) — no associative arrays, per the same
+# convention as run-eval-matrix.sh.
+FAMILIES_FILE="$(mktemp)"
+trap 'rm -f "$FAMILIES_FILE"' EXIT
+while IFS= read -r path; do
+  [[ -n "$path" ]] || continue
+  rest="${path#skills/}"
+  [[ "$rest" == "$path" ]] && continue # not under skills/
+  family="${rest%%/*}"
+  [[ -n "$family" ]] && echo "$family"
+done | sort -u > "$FAMILIES_FILE"
+
+if [[ ! -s "$FAMILIES_FILE" ]]; then
+  echo "No changed files under skills/ — nothing to match." >&2
+  echo "MATCHED=0" >&2
+  exit 0
+fi
+
+matched=0
+for f in "$PROMPTS_DIR"/*.json; do
+  base="$(basename "$f")"
+  [[ "$base" == discord-* ]] && continue
+
+  url="$(jq -r 'if (.skill_url | type) == "string" then .skill_url else empty end' "$f")"
+  [[ -n "$url" ]] || continue
+
+  resolved="$(resolve_skill "$url")" || continue
+  family="${resolved%%$'\t'*}"
+
+  if grep -qxF "$family" "$FAMILIES_FILE"; then
+    cp "$f" "$OUT_DIR/"
+    matched=$((matched + 1))
+  fi
+done
+
+cat "$FAMILIES_FILE"
+echo "MATCHED=$matched" >&2

--- a/scripts/scoring/match-changed-prompts.sh
+++ b/scripts/scoring/match-changed-prompts.sh
@@ -1,18 +1,25 @@
 #!/usr/bin/env bash
 # Given a set of changed files under skills/ (one per line on stdin), find every
-# scored (non-discord-) test-prompt whose skill_url family is among the changed
-# families, and copy those prompt JSONs into an output directory.
+# scored (non-discord-) test-prompt whose skill_url LEAF (not just its family)
+# was touched, and copy those prompt JSONs into an output directory.
 #
 # Used by the A/B test workflow to scope a PR-triggered run to only the
-# prompt(s) that exercise the skill(s) the PR touches, so it does not re-score
-# the whole 26-prompt matrix for a one-skill change.
+# prompt(s) that exercise the exact skill the PR touches. Matching at the leaf
+# level rather than the family level matters for cost: run-eval-matrix.sh's
+# with-skill install stages the whole top-level family (unavoidable — a leaf's
+# relative links need its siblings on disk), but a family can have many leaves
+# and many scored prompts (e.g. qdrant-scaling has 8). A one-leaf change should
+# score the one prompt that targets it, not the whole family's prompt set.
+#
+# A prompt matches if the changed-files list contains its leaf's SKILL.md, or
+# any file under the leaf's directory (a resource file, not just SKILL.md).
 #
 # Usage:
 #   git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- skills/ \
 #     | scripts/scoring/match-changed-prompts.sh --out-dir /tmp/ab-prompts
 #
-# Prints the matched family names (one per line) to stdout for logging, and the
-# count of matched prompts to stderr as "MATCHED=<n>".
+# Prints the matched leaf directories (one per line) to stdout for logging, and
+# the count of matched prompts to stderr as "MATCHED=<n>".
 set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
@@ -50,20 +57,14 @@ command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 64; }
 
 mkdir -p "$OUT_DIR"
 
-# Changed families: first path segment after "skills/" for every changed file.
 # Portable to bash 3.2 (macOS default) — no associative arrays, per the same
 # convention as run-eval-matrix.sh.
-FAMILIES_FILE="$(mktemp)"
-trap 'rm -f "$FAMILIES_FILE"' EXIT
-while IFS= read -r path; do
-  [[ -n "$path" ]] || continue
-  rest="${path#skills/}"
-  [[ "$rest" == "$path" ]] && continue # not under skills/
-  family="${rest%%/*}"
-  [[ -n "$family" ]] && echo "$family"
-done | sort -u > "$FAMILIES_FILE"
+CHANGED_FILE="$(mktemp)"
+LEAVES_FILE="$(mktemp)"
+trap 'rm -f "$CHANGED_FILE" "$LEAVES_FILE"' EXIT
+grep -v '^[[:space:]]*$' > "$CHANGED_FILE" || true
 
-if [[ ! -s "$FAMILIES_FILE" ]]; then
+if [[ ! -s "$CHANGED_FILE" ]]; then
   echo "No changed files under skills/ — nothing to match." >&2
   echo "MATCHED=0" >&2
   exit 0
@@ -78,13 +79,15 @@ for f in "$PROMPTS_DIR"/*.json; do
   [[ -n "$url" ]] || continue
 
   resolved="$(resolve_skill "$url")" || continue
-  family="${resolved%%$'\t'*}"
+  leaf="${resolved#*$'\t'}"       # e.g. qdrant-scaling/minimize-latency/SKILL.md
+  leaf_dir="${leaf%/*}"           # e.g. qdrant-scaling/minimize-latency
 
-  if grep -qxF "$family" "$FAMILIES_FILE"; then
+  if grep -qxF "skills/$leaf" "$CHANGED_FILE" || grep -q "^skills/${leaf_dir}/" "$CHANGED_FILE"; then
     cp "$f" "$OUT_DIR/"
     matched=$((matched + 1))
+    echo "$leaf_dir" >> "$LEAVES_FILE"
   fi
 done
 
-cat "$FAMILIES_FILE"
+sort -u "$LEAVES_FILE"
 echo "MATCHED=$matched" >&2

--- a/scripts/scoring/post-pr-comment.sh
+++ b/scripts/scoring/post-pr-comment.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Post a PR comment, or update the existing one if a comment starting with the
+# given marker already exists — so a re-triggered A/B test (label removed and
+# re-added) edits its own prior scorecard instead of piling up duplicates.
+#
+# Requires `gh` authenticated (GH_TOKEN/GITHUB_TOKEN in env, as in Actions).
+set -Eeuo pipefail
+
+PR=""
+MARKER=""
+BODY_FILE=""
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/scoring/post-pr-comment.sh --pr N --marker STR --body-file FILE
+
+The body file's first line must be the marker (an HTML comment, e.g.
+"<!-- skill-ab-test:scorecard -->") so a prior comment can be found and
+edited in place. Any existing PR comment whose body starts with MARKER is
+updated; otherwise a new comment is created.
+
+Options:
+  --pr N            Pull request number.
+  --marker STR      Marker string identifying this comment across runs.
+  --body-file FILE  File with the full comment body (marker on line 1).
+  -h, --help        Show this help.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr) PR="${2:?}"; shift 2 ;;
+    --marker) MARKER="${2:?}"; shift 2 ;;
+    --body-file) BODY_FILE="${2:?}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 64 ;;
+  esac
+done
+
+[[ -n "$PR" && -n "$MARKER" && -n "$BODY_FILE" ]] || { usage >&2; exit 64; }
+[[ -f "$BODY_FILE" ]] || { echo "Body file not found: $BODY_FILE" >&2; exit 66; }
+command -v gh >/dev/null 2>&1 || { echo "gh CLI is required" >&2; exit 64; }
+
+existing_id="$(gh api "repos/{owner}/{repo}/issues/${PR}/comments" --paginate \
+  --jq "[.[] | select(.body | startswith(\"${MARKER}\"))][0].id" 2>/dev/null || true)"
+
+if [[ -n "$existing_id" && "$existing_id" != "null" ]]; then
+  gh api --method PATCH "repos/{owner}/{repo}/issues/comments/${existing_id}" \
+    -f body="@${BODY_FILE}" >/dev/null
+  echo "Updated PR comment $existing_id"
+else
+  gh pr comment "$PR" --body-file "$BODY_FILE"
+  echo "Created new PR comment"
+fi

--- a/scripts/scoring/post-pr-comment.sh
+++ b/scripts/scoring/post-pr-comment.sh
@@ -46,7 +46,7 @@ existing_id="$(gh api "repos/{owner}/{repo}/issues/${PR}/comments" --paginate \
 
 if [[ -n "$existing_id" && "$existing_id" != "null" ]]; then
   gh api --method PATCH "repos/{owner}/{repo}/issues/comments/${existing_id}" \
-    -f body="@${BODY_FILE}" >/dev/null
+    -F body="@${BODY_FILE}" >/dev/null
   echo "Updated PR comment $existing_id"
 else
   gh pr comment "$PR" --body-file "$BODY_FILE"


### PR DESCRIPTION
## What this PR does

This PR adds a GitHub Action that compares a skill's current (`main`) version against a PR's amended version, triggered by adding the `A/B test` label.

The GH action:

- diffs the PR against its base to find which skills changed, and matches them to the relevant scored test prompts (skips ones the PR doesn't touch).
- runs both versions through the existing scoring harness.
- compares results with a new script and posts/updates a single scorecard comment on the PR.
- uploads full transcripts as a workflow artifact.

No changes to the existing scoring framework logic, only reuses it via existing flags.