### PR TITLE
Adds test prompts and rubrics for multitenancy and sizing skills

### DIFF
--- a/evals/test-prompts/qdrant-multitenancy.json
+++ b/evals/test-prompts/qdrant-multitenancy.json
@@ -1,0 +1,56 @@
+{
+  "name": "qdrant-multitenancy",
+  "product_area": "multitenancy",
+  "skill_url": "https://skills.qdrant.tech/qdrant-multitenancy/SKILL.md",
+  "prompt": "We run a B2B SaaS product with Qdrant multi-tenant search — about 5,000 customers, most under 10k documents each, but our three largest enterprise accounts each have 20M+ documents and get indexed continuously throughout the day. Everything currently lives in one collection with a tenant ID on each point. Over the last month, p95 query latency for our small customers has crept up during business hours, and we suspect the big accounts' write volume is the cause. Should we stay on a single collection, move to one collection per tenant, or do something else? Walk me through the tradeoffs and what you'd actually recommend for our situation.",
+  "rubric": [
+    {
+      "type": "must",
+      "text": "Rejects collection-per-tenant for ~5,000 tenants, citing per-collection resource overhead and/or the practical collection-count ceiling on a cluster, rather than presenting it as a viable option"
+    },
+    {
+      "type": "must",
+      "text": "Recommends tiered/hybrid multitenancy: promote the three large, continuously-indexed accounts to their own dedicated shard(s) via custom sharding, while the small tenants share a fallback shard"
+    },
+    {
+      "type": "must",
+      "text": "Diagnoses the small-tenant latency creep as resource contention from the large accounts' continuous write/indexing load sharing the same index and shard, not as a symptom of read/query traffic or total tenant count growing"
+    },
+    {
+      "type": "must",
+      "text": "Recommends isolating tenant vector indexes (e.g. disabling the global HNSW graph and building per-tenant graphs) so the large accounts' indexing does not degrade search for tenants sharing the same collection"
+    },
+    {
+      "type": "must",
+      "text": "Notes that switching to custom/tiered sharding requires the collection to be created with that sharding method, so this is a migration (new collection + data move), not an in-place config change"
+    },
+    {
+      "type": "bonus",
+      "text": "Gives a concrete signal or threshold for deciding when a growing tenant should be promoted from the shared fallback shard to its own dedicated shard"
+    },
+    {
+      "type": "bonus",
+      "text": "Recommends a tenant-id payload index for isolation/filtering performance in addition to the sharding change"
+    },
+    {
+      "type": "bonus",
+      "text": "Notes the ~1000 dedicated-shard ceiling per cluster and that the fallback shard must fit on a single node"
+    },
+    {
+      "type": "bonus",
+      "text": "Flags that per-tenant HNSW trades away fast cross-tenant search, and checks whether that's rare enough here to accept"
+    },
+    {
+      "type": "avoid",
+      "text": "Recommends collection-per-tenant as the actual fix for this scale"
+    },
+    {
+      "type": "avoid",
+      "text": "Attributes the p95 latency creep mainly to overall data/tenant growth or read volume, missing the continuous write volume from the three large accounts"
+    },
+    {
+      "type": "avoid",
+      "text": "Recommends keeping the current single-collection, single shared-index design unchanged as adequate for this situation"
+    }
+  ]
+}

--- a/evals/test-prompts/qdrant-sizing.json
+++ b/evals/test-prompts/qdrant-sizing.json
@@ -1,0 +1,60 @@
+{
+  "name": "qdrant-sizing",
+  "product_area": "sizing",
+  "skill_url": "https://skills.qdrant.tech/qdrant-sizing/SKILL.md",
+  "prompt": "I'm planning a Qdrant deployment for 50 million points. Each point has one 768-dimensional FP32 dense vector and about 2 KB of payload.\nI expect 500 QPS at peak with a p99 latency target of 100 ms. I need replication factor 2 and want the cluster to tolerate one node failure. I'm considering scalar quantization to reduce RAM usage, but I don't want to sacrifice more than a small amount of recall. The dataset is expected to grow by about 50% over the next 12 months.\nHow much RAM and disk should I provision, how many CPU cores and nodes would you recommend, and should I use quantization? Please show your assumptions and calculations and tell me what I should benchmark before committing to the hardware.",
+  "rubric": [
+    {
+      "type": "must",
+      "text": "Sizes hardware for the 12-month-projected point count (~75M, from 50M growing by 50%) rather than only today's 50M points"
+    },
+    {
+      "type": "must",
+      "text": "Breaks the estimate into separate components (dense vectors, HNSW graph, ID tracker, payload) scaled by replication_factor=2, instead of a single blended points × dims × bytes figure"
+    },
+    {
+      "type": "must",
+      "text": "Distinguishes total disk footprint from the RAM footprint of what actually needs to be resident/cached for the 100 ms p99 target, and reserves extra headroom (roughly 15-20%) on top of the raw component totals"
+    },
+    {
+      "type": "must",
+      "text": "Conditions the quantization recommendation on measuring recall against the user's 'small amount' tolerance rather than assuming it's safe, and notes that original FP32 vectors are typically retained (usually on disk) for rescoring rather than discarded"
+    },
+    {
+      "type": "must",
+      "text": "Recommends a topology of at least 3 nodes to satisfy replication_factor=2 while still tolerating one node failure"
+    },
+    {
+      "type": "must",
+      "text": "States that CPU core count for hitting 500 QPS at p99 ≤ 100 ms cannot be derived from a fixed formula and must be validated by load-testing representative data and queries"
+    },
+    {
+      "type": "bonus",
+      "text": "Proposes a concrete benchmark plan beyond recall/latency alone — e.g. failover/one-node-down behavior, resident memory under sustained load, or disk growth checked against the 12-month horizon"
+    },
+    {
+      "type": "bonus",
+      "text": "Discusses shard count/topology with room to scale into additional nodes later, not just a single target node count"
+    },
+    {
+      "type": "bonus",
+      "text": "Points to the Qdrant Sizing Calculator (or an equivalent tool-assisted check) to sanity-check the manual estimate before committing"
+    },
+    {
+      "type": "avoid",
+      "text": "Sizes only against the current 50M points and ignores the stated 12-month growth"
+    },
+    {
+      "type": "avoid",
+      "text": "Uses points × dims × 4 bytes as the entire RAM/disk estimate, ignoring the HNSW index, ID tracker, payload, or replication factor"
+    },
+    {
+      "type": "avoid",
+      "text": "States a specific CPU core count as a firm recommendation instead of noting that QPS-per-core is workload-dependent and must be measured"
+    },
+    {
+      "type": "avoid",
+      "text": "States a specific quantization recall-loss percentage without evidence or benchmarking to back it"
+    }
+  ]
+}


### PR DESCRIPTION
## What this PR does

This PR adds test prompts and rubrics for two Qdrant skills: `qdrant-multitenancy` and `qdrant-sizing`.

### Method

Rubrics were created independently by two agents for each skill. One agent only had access to the public documentation, while the other worked directly from the skill. This was done to reduce the risk of the rubric overfitting to the wording and structure of the skill itself.

The agents cross-reviewed each other's output, after which the two rubric sets were manually compared and merged. General, behavior-based wording was preferred over skill-specific terminology, bundled `avoid` criteria were split to make binary grading clearer, and non-overlapping `bonus` criteria from both sets were retained.

Test prompts were reviewed in the same way and reworded where they overlapped too closely with the skill's trigger description.
