### PR TITLE
Strengthen guardrails in skills

### DIFF
--- a/skills/qdrant-deployment-options/SKILL.md
+++ b/skills/qdrant-deployment-options/SKILL.md
@@ -17,21 +17,22 @@ Use when: building a prototype, running tests, CI/CD pipelines, or learning Qdra
 - For a real server locally, use Docker [Quick start](https://skills.qdrant.tech/md/documentation/quickstart/?s=download-and-run)
 
 
-## Going to Production (Self-Hosted)
+## Going to Production (Self-Hosted, You Own Ops)
 
-Use when: you need full control over infrastructure, data residency, or custom configuration.
+Use when: you need full control over infrastructure or custom configuration, and are prepared to own operations (upgrades, backups, scaling, monitoring) yourself.
 
-- Docker is the default deployment. Full Qdrant Open Source feature set, minimal setup. [Quick start](https://skills.qdrant.tech/md/documentation/quickstart/?s=download-and-run)
+- Docker is the standard self-hosted deployment. Full Qdrant Open Source feature set, minimal setup. [Quick start](https://skills.qdrant.tech/md/documentation/quickstart/?s=download-and-run)
 - You own operations: upgrades, backups, scaling, monitoring
 - Must set up distributed mode manually for multi-node clusters [Distributed deployment](https://skills.qdrant.tech/md/documentation/scaling/distributed_deployment/)
-- Consider Hybrid Cloud if you want Qdrant Cloud management on your infrastructure [Hybrid Cloud](https://skills.qdrant.tech/md/documentation/hybrid-cloud/)
+- Have a data-residency or compliance requirement but don't want to own that ops burden? That combination is Hybrid Cloud (next section), not self-hosted Docker.
 
 
 ## Going to Production (Zero-Ops)
 
-Use when: you want managed infrastructure with zero-downtime updates, automatic backups, and resharding without operating clusters yourself.
+Use when: you want managed infrastructure with zero-downtime updates, automatic backups, and resharding without operating clusters yourself — including when data-residency or compliance rules mean the data can't sit on Qdrant-operated infrastructure.
 
 - Qdrant Cloud handles upgrades, scaling, backups, and monitoring [Qdrant Cloud](https://skills.qdrant.tech/md/documentation/cloud-quickstart/)
+- Hybrid Cloud: the same managed control plane, deployed on your own infrastructure/VPC. Use this when data residency or compliance requirements rule out Qdrant Cloud but you still don't want to operate clusters yourself [Hybrid Cloud](https://skills.qdrant.tech/md/documentation/hybrid-cloud/)
 - Supports multi-version upgrades automatically
 - Provides features not available in self-hosted: `/sys_metrics`, managed resharding, pre-configured alerts
 
@@ -50,5 +51,6 @@ Use when: network round-trip to a server is unacceptable. Edge devices, in-proce
 
 - Use local mode for production or benchmarking (not optimized, incompatible data format)
 - Self-host without monitoring and backup strategy (you will lose data or miss outages)
+- Recommend self-managed Docker as the production target when the user says they don't want to operate clusters — that combination needs Hybrid Cloud or Qdrant Cloud, not self-hosted
 - Choose EDGE when you need distributed search (single-node only)
 - Pick Hybrid Cloud unless you have data residency requirements (unnecessary Kubernetes complexity when Qdrant Cloud works)

--- a/skills/qdrant-deployment-options/SKILL.md
+++ b/skills/qdrant-deployment-options/SKILL.md
@@ -51,6 +51,6 @@ Use when: network round-trip to a server is unacceptable. Edge devices, in-proce
 
 - Use local mode for production or benchmarking (not optimized, incompatible data format)
 - Self-host without monitoring and backup strategy (you will lose data or miss outages)
-- Recommend self-managed Docker as the production target when the user says they don't want to operate clusters — that combination needs Hybrid Cloud or Qdrant Cloud, not self-hosted
+- Recommend self-managed Docker as the production target when the user says they don't want to operate clusters — that combination needs Qdrant Hybrid Cloud or Qdrant Managed Cloud, not self-hosted
 - Choose EDGE when you need distributed search (single-node only)
 - Pick Hybrid Cloud unless you have data residency requirements (unnecessary Kubernetes complexity when Qdrant Cloud works)

--- a/skills/qdrant-scaling/scaling-data-volume/tenant-scaling/SKILL.md
+++ b/skills/qdrant-scaling/scaling-data-volume/tenant-scaling/SKILL.md
@@ -7,6 +7,8 @@ description: "Guides Qdrant multi-tenant scaling. Use when someone asks 'how to 
 
 Do not create one collection per tenant. Does not scale past a few hundred and wastes resources. One company hit the 1000 collection limit after a year of collection-per-repo and had to migrate to payload partitioning. Use a shared collection with a tenant key.
 
+"Isolated" tenant queries — each tenant only ever sees its own data, with good performance — is the default outcome of payload filtering (`is_tenant=true`) in a single shared collection. It does not require separate collections. Separate collections only apply to the legal/compliance case below, not as a way to get isolation.
+
 - Understand multitenancy patterns [Multitenancy](https://skills.qdrant.tech/md/documentation/manage-data/multitenancy/)
 
 Here is a short summary of the patterns:
@@ -28,9 +30,9 @@ This will localize tenant requests to specific nodes instead of broadcasting the
 
 If some tenants are much larger than others, use [tiered multitenancy](https://skills.qdrant.tech/md/documentation/manage-data/multitenancy/?s=tiered-multitenancy) to promote large tenants to dedicated shards while keeping small tenants on shared shards. This optimizes resource allocation and performance for tenants of varying sizes.
 
-## Need Strict Tenant Isolation
+## Need Per-Tenant Encryption or Legal/Compliance Isolation (Exception, Not the Default)
 
-Use when: legal/compliance requirements demand per-tenant encryption or strict isolation beyond what payload filtering provides.
+Use when: legal/compliance requirements demand per-tenant encryption keys or physical data separation — not merely "tenants shouldn't see each other's data," which payload filtering already guarantees on its own.
 
 - Multiple collections may be necessary for per-tenant encryption keys
 - Limit collection count and use payload filtering within each collection
@@ -40,5 +42,6 @@ Use when: legal/compliance requirements demand per-tenant encryption or strict i
 ## What NOT to Do
 
 - Do not create one collection per tenant without compliance justification (does not scale past hundreds)
+- Do not treat "isolated" or "isolation" in a request as a reason to use separate collections — default query isolation comes from payload filtering (`is_tenant=true`) in a shared collection, not from separate collections
 - Do not skip `is_tenant=true` on the tenant index (kills sequential read performance)
 - Do not build global HNSW for multi-tenant collections (wasteful, use `payload_m` instead)

--- a/skills/qdrant-scaling/scaling-data-volume/tenant-scaling/SKILL.md
+++ b/skills/qdrant-scaling/scaling-data-volume/tenant-scaling/SKILL.md
@@ -7,7 +7,7 @@ description: "Guides Qdrant multi-tenant scaling. Use when someone asks 'how to 
 
 Do not create one collection per tenant. Does not scale past a few hundred and wastes resources. One company hit the 1000 collection limit after a year of collection-per-repo and had to migrate to payload partitioning. Use a shared collection with a tenant key.
 
-"Isolated" tenant queries — each tenant only ever sees its own data, with good performance — is the default outcome of payload filtering (`is_tenant=true`) in a single shared collection. It does not require separate collections. Separate collections only apply to the legal/compliance case below, not as a way to get isolation.
+"Isolated" tenant queries — each tenant only ever sees its own data, with good performance — is the default outcome of payload filtering (`is_tenant=true`) in a single shared collection. It does not require separate collections. Separate collections only apply to the legal/compliance case, not as a way to get isolation.
 
 - Understand multitenancy patterns [Multitenancy](https://skills.qdrant.tech/md/documentation/manage-data/multitenancy/)
 

--- a/skills/qdrant-search-quality/search-strategies/SKILL.md
+++ b/skills/qdrant-search-quality/search-strategies/SKILL.md
@@ -12,6 +12,17 @@ allowed-tools:
 These strategies complement basic vector search. Use them after confirming the embedding model is fitting the task and HNSW config is correct. If exact search returns bad results, verify the selection of the embedding model (retriever) first.
 If the user wants to use a weaker embedding model because it is small, fast, and cheap, use reranking or relevance feedback to improve search quality.
 
+Each symptom below needs its own strategy — diagnose and treat them independently. A single project can have more than one symptom at once, and fixing one (e.g. adding hybrid search for keyword misses) does not also fix the others (e.g. redundant results still need MMR; poor precision still needs reranking).
+
+| Symptom | Strategy |
+| --- | --- |
+| Missing exact/keyword matches | Hybrid search |
+| Right documents exist but rank low (good recall, poor precision) | Multistage queries / reranking |
+| Dense retriever misses relevant items entirely, or reranking too costly | Relevance feedback |
+| Results are redundant / near-duplicate | MMR |
+| Need to steer with example points | Recommendation / Discovery API |
+| Need business-logic-based ranking | Score boosting |
+
 ## Missing Keyword Matches or Need to Combine Multiple Search Signals
 
 Use when: pure vector search misses keyword/domain term matches, or the use case benefits from combining searches on multiple representations (including languages and modalities) of the same item.
@@ -56,4 +67,5 @@ Check how to set up in [Score Boosting docs](https://skills.qdrant.tech/md/docum
 ## What NOT to Do
 
 - Use hybrid search before verifying pure vector search quality (adds complexity, may mask model issues)
+- Apply one strategy (e.g. hybrid search) as a blanket fix for multiple distinct symptoms — diagnose and treat each symptom separately (see table above)
 - Skip evaluation when adding relevance feedback — score the end-to-end pipeline to confirm it actually helps [Pipeline Output Quality](https://skills.qdrant.tech/md/documentation/improve-search/pipeline-output-quality/)

--- a/skills/qdrant-search-quality/search-strategies/SKILL.md
+++ b/skills/qdrant-search-quality/search-strategies/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools:
 These strategies complement basic vector search. Use them after confirming the embedding model is fitting the task and HNSW config is correct. If exact search returns bad results, verify the selection of the embedding model (retriever) first.
 If the user wants to use a weaker embedding model because it is small, fast, and cheap, use reranking or relevance feedback to improve search quality.
 
-Each symptom below needs its own strategy — diagnose and treat them independently. A single project can have more than one symptom at once, and fixing one (e.g. adding hybrid search for keyword misses) does not also fix the others (e.g. redundant results still need MMR; poor precision still needs reranking).
+Each symptom needs its own strategy — diagnose and treat them independently. A single project can have more than one symptom at once, and fixing one (e.g. adding hybrid search for keyword misses) does not also fix the others (e.g. redundant results still need MMR; poor precision still needs reranking).
 
 | Symptom | Strategy |
 | --- | --- |


### PR DESCRIPTION
## What this PR does

Weekly eval runs showed Haiku violating three "avoid" rules despite existing guardrail content. Each fix targets the root cause behind the specific failure rather than patching the literal eval wording, to avoid overfitting to this one test run.


## Type

<!-- check one -->
- [ ] new skill
- [x] skill improvement
- [ ] bug fix
- [ ] repo hygiene