### PR TITLE
fix clients sdk warning for validate skills

### DIFF
--- a/skills/qdrant-clients-sdk/SKILL.md
+++ b/skills/qdrant-clients-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qdrant-clients-sdk
-description: "Qdrant provides client SDKs for various programming languages, allowing easy integration with Qdrant deployments."
+description: "Points to Qdrant's official client SDKs, the REST and gRPC API references, and the curated code-snippet search endpoint. Use when someone asks which Qdrant client to use for their language, how to install a Qdrant client, where the REST or gRPC API reference is, how to get a code example (such as uploading points), how to search Qdrant's snippet library, or whether to use REST or gRPC."
 allowed-tools:
   - Read
   - Grep
@@ -10,60 +10,59 @@ allowed-tools:
 
 # Qdrant Clients SDK
 
-Qdrant has the following officially supported client SDKs:
+Qdrant ships official client SDKs, a REST and gRPC API, and a curated library of code snippets. Reach for an official client before writing raw HTTP calls, and prefer the REST API when starting out. [Qdrant clients](https://skills.qdrant.tech/md/documentation/interfaces/)
 
-- Python — [qdrant-client](https://github.com/qdrant/qdrant-client) · Installation: `pip install qdrant-client[fastembed]`
-- JavaScript / TypeScript — [qdrant-js](https://github.com/qdrant/qdrant-js) · Installation: `npm install @qdrant/js-client-rest`
-- Rust — [rust-client](https://github.com/qdrant/rust-client) · Installation: `cargo add qdrant-client`
-- Go — [go-client](https://github.com/qdrant/go-client) · Installation: `go get github.com/qdrant/go-client`
-- .NET — [qdrant-dotnet](https://github.com/qdrant/qdrant-dotnet) · Installation: `dotnet add package Qdrant.Client`
-- Java — [java-client](https://github.com/qdrant/java-client) · Available on Maven Central: https://central.sonatype.com/artifact/io.qdrant/client
+## Choosing and Installing a Client
 
+Use when: picking the client for your language or setting up a new project.
+
+- Python - [qdrant-client](https://github.com/qdrant/qdrant-client), install with `pip install qdrant-client[fastembed]`
+- JavaScript / TypeScript - [qdrant-js](https://github.com/qdrant/qdrant-js), install with `npm install @qdrant/js-client-rest`
+- Rust - [rust-client](https://github.com/qdrant/rust-client), install with `cargo add qdrant-client`
+- Go - [go-client](https://github.com/qdrant/go-client), install with `go get github.com/qdrant/go-client`
+- .NET - [qdrant-dotnet](https://github.com/qdrant/qdrant-dotnet), install with `dotnet add package Qdrant.Client`
+- Java - [java-client](https://github.com/qdrant/java-client), available on [Maven Central](https://central.sonatype.com/artifact/io.qdrant/client)
 
 ## API Reference
 
-All interaction with Qdrant can happen through the REST API or gRPC API. We recommend using the REST API if you are using Qdrant for the first time or working on a prototype.
+Use when: no client exists for your language, or you need the exact request/response schema.
 
-* REST API - [OpenAPI Reference](https://skills.qdrant.tech/api-reference.md) - [GitHub](https://github.com/qdrant/qdrant/blob/master/docs/redoc/master/openapi.json)
-* gRPC API - [gRPC protobuf definitions](https://github.com/qdrant/qdrant/tree/master/lib/api/src/grpc/proto)
+All interaction with Qdrant happens through the REST API or the gRPC API. Prefer REST if you are using Qdrant for the first time or working on a prototype; reach for gRPC when you need lower latency at high throughput.
 
-## Code examples
+- REST API - [OpenAPI reference](https://skills.qdrant.tech/api-reference.md), [source on GitHub](https://github.com/qdrant/qdrant/blob/master/docs/redoc/master/openapi.json)
+- gRPC API - [protobuf definitions](https://github.com/qdrant/qdrant/tree/master/lib/api/src/grpc/proto)
 
-To obtain code examples for a specific client and use case, you can send a search request to the library of curated code snippets for the Qdrant client.
+## Code Examples
+
+Use when: you want a working snippet for a specific client and task.
+
+Query the curated snippet library instead of guessing at client APIs from memory. Send a search request scoped to a language and use case:
 
 ```bash
 curl -X GET "https://skills.qdrant.tech/snippets/search?language=python&query=how+to+upload+points"
 ```
 
-Available languages: `python`, `typescript`, `rust`, `java`, `go`, `csharp`
+Available languages: `python`, `typescript`, `rust`, `java`, `go`, `csharp` (use `csharp` for .NET). Passing any other language returns no results.
 
-
-Response example:
+The default response format is markdown; append `&format=json` to the query string for JSON. A markdown response looks like:
 
 ```markdown
-
 ## Snippet 1
 
-*qdrant-client* (vlatest) — https://skills.qdrant.tech/md/documentation/manage-data/points/
+*qdrant-client* (vlatest) - https://skills.qdrant.tech/md/documentation/manage-data/points/
 
-Uploads multiple vector-embedded points to a Qdrant collection using the Python qdrant_client (PointStruct) with id, payload (e.g., color), and a 3D-like vector for similarity search. It supports parallel uploads (parallel=4) and a retry policy (max_retries=3) for robust indexing. The operation is idempotent: re-uploading with the same id overwrites existing points; if ids aren’t provided, Qdrant auto-generates UUIDs.
+Uploads multiple vector-embedded points to a Qdrant collection using the Python
+qdrant_client (PointStruct) with id, payload, and vector. Supports parallel
+uploads (parallel=4) and a retry policy (max_retries=3). The operation is
+idempotent: re-uploading with the same id overwrites existing points.
 
 client.upload_points(
     collection_name="{collection_name}",
     points=[
         models.PointStruct(
             id=1,
-            payload={
-                "color": "red",
-            },
+            payload={"color": "red"},
             vector=[0.9, 0.1, 0.1],
-        ),
-        models.PointStruct(
-            id=2,
-            payload={
-                "color": "green",
-            },
-            vector=[0.1, 0.9, 0.1],
         ),
     ],
     parallel=4,
@@ -71,4 +70,9 @@ client.upload_points(
 )
 ```
 
-Default response format is markdown, if snippet output is required in JSON format, you can add `&format=json` to the query string.
+## What NOT to Do
+
+- Hand-roll raw HTTP requests when an official client exists for your language.
+- Reach for gRPC on a first prototype; start with REST and switch to gRPC only when you need the throughput.
+- Guess client method names from memory instead of querying the snippet search endpoint.
+- Assume a community client is officially supported; only the clients listed above are maintained by Qdrant.

--- a/skills/qdrant-clients-sdk/SKILL.md
+++ b/skills/qdrant-clients-sdk/SKILL.md
@@ -34,35 +34,41 @@ All interaction with Qdrant happens through the REST API or the gRPC API. Prefer
 
 ## Code Examples
 
-Use when: you want a working snippet for a specific client and task.
-
-Query the curated snippet library instead of guessing at client APIs from memory. Send a search request scoped to a language and use case:
+To obtain code examples for a specific client and use case, you can send a search request to the library of curated code snippets for the Qdrant client.
 
 ```bash
 curl -X GET "https://skills.qdrant.tech/snippets/search?language=python&query=how+to+upload+points"
 ```
 
-Available languages: `python`, `typescript`, `rust`, `java`, `go`, `csharp` (use `csharp` for .NET). Passing any other language returns no results.
+Available languages: `python`, `typescript`, `rust`, `java`, `go`, `csharp`
 
-The default response format is markdown; append `&format=json` to the query string for JSON. A markdown response looks like:
+
+Response Example:
 
 ```markdown
+
 ## Snippet 1
 
-*qdrant-client* (vlatest) - https://skills.qdrant.tech/md/documentation/manage-data/points/
+*qdrant-client* (vlatest) — https://skills.qdrant.tech/md/documentation/manage-data/points/
 
-Uploads multiple vector-embedded points to a Qdrant collection using the Python
-qdrant_client (PointStruct) with id, payload, and vector. Supports parallel
-uploads (parallel=4) and a retry policy (max_retries=3). The operation is
-idempotent: re-uploading with the same id overwrites existing points.
+Uploads multiple vector-embedded points to a Qdrant collection using the Python qdrant_client (PointStruct) with id, payload (e.g., color), and a 3D-like vector for similarity search. It supports parallel uploads (parallel=4) and a retry policy (max_retries=3) for robust indexing. The operation is idempotent: re-uploading with the same id overwrites existing points; if ids aren’t provided, Qdrant auto-generates UUIDs.
 
 client.upload_points(
     collection_name="{collection_name}",
     points=[
         models.PointStruct(
             id=1,
-            payload={"color": "red"},
+            payload={
+                "color": "red",
+            },
             vector=[0.9, 0.1, 0.1],
+        ),
+        models.PointStruct(
+            id=2,
+            payload={
+                "color": "green",
+            },
+            vector=[0.1, 0.9, 0.1],
         ),
     ],
     parallel=4,


### PR DESCRIPTION
## What this PR does

Adds Use when (in description metadata): triggers, a trigger-phrase-rich description, and a What NOT to Do section, clearing the leaf-skill validation warnings. 

Before: 

```
WARN  skills/qdrant-clients-sdk/SKILL.md: description missing 'Use when' trigger phrases
WARN  skills/qdrant-clients-sdk/SKILL.md: missing 'What NOT to Do' section
WARN  skills/qdrant-clients-sdk/SKILL.md: line 20: raw URL not wrapped in markdown link
WARN  skills/qdrant-clients-sdk/SKILL.md: line 35: raw URL not wrapped in markdown link
WARN  skills/qdrant-clients-sdk/SKILL.md: line 47: raw URL not wrapped in markdown link
WARN  skills/qdrant-clients-sdk/SKILL.md: contains em-dash character
```

After (Now):  

```
WARN  skills/qdrant-clients-sdk/SKILL.md: line 42: raw URL not wrapped in markdown link
WARN  skills/qdrant-clients-sdk/SKILL.md: line 52: raw URL not wrapped in markdown link
```

## Type

<!-- check one -->
- [ ] new skill
- [x] skill improvement
- [ ] bug fix
- [ ] repo hygiene

## Checklist

<!-- for new/improved skills, check all that apply -->
- [x] `python3 scripts/validate_skills.py` passes
- [x] skill answers "when?" or "why?", not "how?"
- [x] skill navigates to docs, does not duplicate or replace them
- [x] description has `Use when` with 5+ trigger phrases
- [x] leaf skills omit `allowed-tools`, hub skills declare them
- [x] ends with `## What NOT to Do` section
- [ ] no code blocks except minimal snippets when absolutely required (reference the docs instead)
- [x] all doc links go to `skills.qdrant.tech/md/documentation/`

@szabosteve regarding the code blocks, this skills originally had a code snippet but it was just the upload_points, and no other REST API, so should we remove the code block?

Here is my suggestion:
- We should include the docs link of the major endpoints in the collection like: upload_points, set_payload, overwrite_payload, update_vectors, batch update and update_collection_aliases. 
- This PR can also contribute and is part of this issue: #80  