### PR TITLE
Redirect bare skill directory URLs to SKILL.md

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -37,6 +37,11 @@
   status = 200
   force = true
 
+[[redirects]]
+  from = "/*"
+  to = "/:splat/SKILL.md"
+  status = 200
+
 [[headers]]
   for = "/*.md"
   [headers.values]


### PR DESCRIPTION
## What this PR does

Agents that fetch a bare skill URL (for example, `/qdrant-clients-sdk` instead of `/qdrant-clients-sdk/SKILL.md`), for example when an intermediate summarizer strips the `/SKILL.md` suffix from a link before the model sees it, previously hit a 404. This PR adds a rewrite in netlify.toml that serves `SKILL.md` for any directory path without the `/SKILL.md` suffix.

So, after merge: `skills.qdrant.tech/qdrant-clients-sdk` will resolve to `skills.qdrant.tech/qdrant-clients-sdk/SKILL.md` instead of resulting in 404.